### PR TITLE
Documentation: Fixes for intonation.md file

### DIFF
--- a/docs/add_language.md
+++ b/docs/add_language.md
@@ -1,11 +1,14 @@
 # Adding or Improving a Language
 
+# Table of contents
+
 - [Language Code](#language-code)
 - [Language Files](#language-files)
 - [Voice File](#voice-file)
 - [Phoneme Definition File](#phoneme-definition-file)
 - [Dictionary Files](#dictionary-files)
 - [Program Code](#program-code)
+- [Compiling rules file for debugging](#compiling-rules-file-for-debugging)
 - [Improving a Language](#improving-a-language)
 
 ----------
@@ -162,6 +165,35 @@ options. For a new language, you would add its language code and the
 required options in `SetTranslator()`. However, this may not be necessary
 during testing because most of the options can also be set in the voice
 file in espeak-data/voices (see [Voice Files](voices.md)).
+
+## Compiling rules file for debugging
+
+When `espeak-ng` is invoked with `-X` parameter, it shows more detailed trace of 
+chosen language rules for pronunciation. This trace can show line numbers also, 
+if language is compiled with `--compile-debug` option.
+
+To do this, go to `espeak-ng` project root folder, then:
+
+    cd dictsource/
+    ../src/espeak-ng --compile-debug=en
+
+When invoked in following way:
+
+    es -ven -X "Test."
+
+It will show:
+
+    --------------
+    Translate 'test'
+      1  5965:  t [t]
+    
+      1  2104:  e [E]
+    
+      1  5725:  s [s]
+    
+      1  5965:  t [t]
+    
+     t'Est
 
 ## Improving a Language
 

--- a/docs/intonation.md
+++ b/docs/intonation.md
@@ -108,7 +108,7 @@ are specified.
 
 `start pitch` give a pitch path for the stressed syllables of the head.
 
-steps` is the maximum number of stressed syllables for which this applies. If
+`steps` is the maximum number of stressed syllables for which this applies. If
 there are additional stressed syllables, then the `headextend` statement is used
 for them.
 
@@ -122,7 +122,7 @@ than the previous stressed syllable.
 	headextend <percentage list>
 
 If the head contains more stressed syllables than is specified by `steps` is used.
-Itmcontains up to 8 numbers which are used repeatedly for the additional stressed
+It contains up to 8 numbers which are used repeatedly for the additional stressed
 syllables. A value of 0 corresponds to the lower the `start pitch` values of the
 `head` statement. 100 corresponds to the higher value.
 


### PR DESCRIPTION
Reece, intonation.md file should also answer following questions:

### prehead

> Gives the pitch path for any series of unstressed syllables before the first
stressed syllable.

Is 'pitch' in Hz? If yes, should mention it.


### headenv

What are possible types of envelopes is unknown. There is image file `phsource/envelopes.png` but its names are different than names used in `intonation` file.

> `height` gives a pitch range for the envelope.

Is height in Hz or other units?

### head

What is allowed range of steps? (e.g. is 0 allowed, is maximum 8?)

### headextend

> "A value of 0 corresponds to the lower the `start pitch` values of the `head` statement. 100 corresponds to the higher value."

what means that range and how it is computed is unclear.

### nucleus0

> ..if there are no unstressed syllables..

Double negative should be rewritten to positive statement. Something like "..if there are stressed (with primary/secondary stress?) syllables.."