### PR TITLE
Commented out some wrong/testing phonemes for Aragonese

### DIFF
--- a/dictsource/an_rules
+++ b/dictsource/an_rules
@@ -1,4 +1,3 @@
-
 // Aragon translation rules
 // This file is UTF-8 encoded
 
@@ -38,10 +37,10 @@
 .group c
         c          k
         c (Y       T         // ce  ci
-		c' (Y      T
+        c' (Y      T
         ck         k         // Forano (Foreign)
         ch         tS
-		//c (_        =
+//      c (_       =
 
 
 
@@ -50,9 +49,9 @@
 
 .group d
         d          d
-C) d (_       =         // silent, but stress on last vowel
-A) d (_       =         // silent, but stress on last vowel
-     _) d          d         // phoneme definition may change it to [D]
+     C) d (_       =    // silent, but stress on last vowel
+     A) d (_       =    // silent, but stress on last vowel
+     _) d          d    // phoneme definition may change it to [D]
      _) d (A       d
         d (A       D
         d (cY      D
@@ -79,9 +78,9 @@ A) d (_       =         // silent, but stress on last vowel
      u) e          E
      y) e          E
 
-	 L06_) e (n_      e#        // unstressed 'e' silent at start of word after a,e,o
-  L06_) e (L07C      e#        // unstressed 'e' silent at start of word after a,e,o
- L06_h) e (L07C      e#        // unstressed 'e' silent at start of word after a,e,o
+  L06_) e (n_      e#        // unstressed 'e' silent at start of word after a,e,o
+  L06_) e (L07C    e#        // unstressed 'e' silent at start of word after a,e,o
+ L06_h) e (L07C    e#        // unstressed 'e' silent at start of word after a,e,o
 
      _) ent' (AP4  ent
      _) enta'      ,ent%a
@@ -217,12 +216,11 @@ A) d (_       =         // silent, but stress on last vowel
 
 .group t
         t          t
-t (_        t#
-     C) t (C               // Silent
-C) t (r        t
- C) t (h        t
+        t (_       t#
+     C) t (C          //Silent
+     C) t (r       t
+     C) t (h       t
         tz         T
-   
      _) t' (AP2    t
      _) ta'        t%a
      _) to'        t%o
@@ -239,11 +237,11 @@ C) t (r        t
         u (A       w
      _) u (u       u
      _) u (A       gw
-	 //Ar) u (Y    gw
+//  Ar) u (Y       gw
   _des) u (Y       gw
    _es) u (Y       gw
 
-	 // Some exception
+// Some exception
 _esquir) u (el     Qw        // esquiruelo, esquiruelos
   _cir) u (ell     Qw        // Ciruello, ciruella, ciruellos, ciruellas
 

--- a/phsource/ph_aragon
+++ b/phsource/ph_aragon
@@ -1,4 +1,3 @@
-
 // based on Spanish
 
 phoneme t#
@@ -7,7 +6,6 @@ phoneme t#
     ChangePhoneme(t)
   ENDIF
 endphoneme
-
 
 phoneme E
   vowel starttype #e endtype #e
@@ -29,37 +27,35 @@ phoneme O
 endphoneme
 
 
+//phoneme k
+//  vls vel stop
+//  lengthmod 2
+//  voicingswitch g
+//  Vowelin f1=0  f2=2300 200 400  f3=-100 80
+//  Vowelout f1=0 f2=2300 300 400  f3=-100 80  rms=20
+//
+//  IF nextPh(isPause2) THEN
+//    WAV(ustop/k_)
+//  ELIF nextPh(#i) OR nextPh(;) THEN
+//    WAV(ustop/ki_unasp2, 30)
+////  ELIF nextPh(isRhotic) THEN
+////    WAV(ustop/kr)
+////  ELIF nextPh(l) THEN
+////    WAV(ustop/kl)
+//  ENDIF
+//  WAV(ustop/k_unasp2, 25)
+//endphoneme
 
-phoneme k
-  vls vel stop
-  lengthmod 2
-  voicingswitch g
-  Vowelin f1=0  f2=2300 200 400  f3=-100 80
-  Vowelout f1=0 f2=2300 300 400  f3=-100 80  rms=20
 
-  IF nextPh(isPause2) THEN
-    WAV(ustop/k_)
-  ELIF nextPh(#i) OR nextPh(;) THEN
-    WAV(ustop/ki_unasp2, 30)
-//  ELIF nextPh(isRhotic) THEN
-//    WAV(ustop/kr)
-//  ELIF nextPh(l) THEN
-//    WAV(ustop/kl)
-  ENDIF
-  WAV(ustop/k_unasp2, 25)
-endphoneme
-
-
-phoneme t
-  vls dnt stop
-  lengthmod 2
-  voicingswitch d
-  Vowelin f1=0  f2=1600 -300 300  f3=-100 80
-  Vowelout f1=0 f2=1600 -300 250  f3=-100 80  rms=20
-  IF nextPh(isPause2) THEN
-    WAV(ustop/t_dnt, 25)
-  ENDIF
-  WAV(ustop/t_unasp3, 50)
-endphoneme
-
+//phoneme t
+//  vls dnt stop
+//  lengthmod 2
+//  voicingswitch d
+//  Vowelin f1=0  f2=1600 -300 300  f3=-100 80
+//  Vowelout f1=0 f2=1600 -300 250  f3=-100 80  rms=20
+//  IF nextPh(isPause2) THEN
+//    WAV(ustop/t_dnt, 25)
+//  ENDIF
+//  WAV(ustop/t_unasp3, 50)
+//endphoneme
 


### PR DESCRIPTION
Some time ago, we tested some "improvements" to phonemes for Aragonese at eSpeak, but them was unsuccessful, generating a noise on /k/ and /t/ phonemes, this made it so annoying for people using it daily as backend for screen readers (as NVDA, that recently upgraded from eSpeak to eSpeak NG).

In order to make it usable until we solve that, I'm commenting out the lines that override that phonemes from Spanish.