### PR TITLE
Guarani Language

### DIFF
--- a/dictsource/gn_list
+++ b/dictsource/gn_list
@@ -1,0 +1,168 @@
+﻿
+// This file is UTF-8 encoded
+// Updated 2016 april 20 by Chris, Christian Leo M, <llajta2012@gmail.com>
+
+// letter names
+
+a	a
+ch	Se
+e	e:
+g	ge:
+ĝ	n.e~
+h	he
+i	i:
+j	dZe
+k	ke
+l	le
+m	me
+mb	mbe:
+n	ne
+nd	Nde
+ng	Nge:
+nt	Nte
+ñ	n^e
+o	o:
+p	pe:
+r	r'e:
+rr	R2e:
+s	se
+t	te:
+u	u:
+v	ve:
+y	y:
+_'	pus'o
+ʻ	pus'o
+
+b	be
+c	Te
+d	de
+f	'efe
+q	ku
+w	v'e||_k'o~i
+x	'ekis
+z	T'eta
+
+_á	$accent
+_é	$accent
+_í	$accent
+_ó	$accent
+_ú	$accent
+_ý	$accent
+_ã	$accent
+_ẽ	e~
+_ê	e~:
+_ĩ	$accent
+_õ	$accent
+_ũ	$accent
+_ỹ	y~
+_ĝ	$accent
+
+
+// Accent names
+_acu	muanduh'e~
+// _cir	muanduh,e~||tigu'a~
+_cir	Tirkumfl'exo
+_tld	muanduh,e~||tigu'a~
+_brv	br'eBe
+
+// numbers
+?1  _0lang   _^_es   // speak numbers in Spanish
+
+// character names
+
+_.	kyt'a	$max3
+_:	kytak'o~i
+_,	kygu'ai
+_?	kyporandu||pah'a
+_¿	kyporandu||n^epyr'y~
+_¡	kyNd'yi||n^epyr'y~
+_!	kyNd'yi||pah'a
+_(	rok'ai||dZepe_!'a
+_)	rok'ai||n^embot'y
+_-	taik'y $max3
+__	taiky||karap'e	$max3
+
+// foreign words
+
+(e speak) 'isp'ik
+android	'andr,oid
+audácity	awd'asiti
+english	_^_en
+espeak	i||sp'ik
+facebook	f'eisbuk
+firefox	f'airfoks
+gmail	dZi||m'eil
+google	g'u:g@l
+hardware	h'ardwer
+linux	$1
+microsoft	m'aikrosoft
+mozilla	_^_es
+office	_^_en
+periscope	p'erisk,op
+skype	sk'aip
+software	s'oftwer
+spanish	sp'a:niS
+twitter	tw'iter
+windows	w'i:ndows
+youtube	_^_en
+
+// abbreviations
+nvda	,ene||B,e||D,e_'a
+txt	$abbrev
+gn	$abbrev
+
+//  Proper names
+felipe	_^_es
+chris	kr'is
+
+// countries
+
+américa	_^_es
+argentina	_^_es
+asunción	_^_es
+barcelona	_^_es
+berlín	_^_es
+bolivia	_^_es
+brasilia	_^_es
+brucelas	_^_es
+cagliari	_^_it // k'al^ari
+caracas	_^_es
+chile	_^_es
+colombia	_^_es
+concepción	_^_es
+costa	_^_es
+cuba	_^_es
+dominicana	_^_es
+ecuador	_^_es
+encarnación	_^_es
+españa	_^_es
+estigarribia	_^_es
+guatemala	_^_es
+guatemala	_^_es
+honduras	_^_es
+latina	_^_es
+lima	_^_es
+lisboa	_^_es
+londres	_^_es
+méxico	_^_es
+méxico	_^_es
+madrid	_^_es
+managua	_^_es
+milán	_^_es
+misiones	_^_es
+nápoles	_^_es
+nicaragua	_^_es
+ottawa	_^_es
+parís	_^_es
+paraguay	_^_es
+república	_^_es
+rica	_^_es
+roma	_^_es
+salvador	_^_es
+santiago	_^_es
+tegucigalpa	_^_es
+uruguay	_^_es
+venezuela	_^_es
+washington	_^_en
+zúrich	_^_es
+

--- a/dictsource/gn_rules
+++ b/dictsource/gn_rules
@@ -1,0 +1,171 @@
+
+// guaraní translation rules
+// This file is UTF-8 encoded
+// Last update: 22 april 2016
+
+.replace
+ʻ	' // guarani puso U+02BB
+â	ã
+î	ĩ
+ô	õ
+û	ũ
+ŷ	ỹ
+ğ	ĝ
+
+.group '
+	'	_!
+	A) ' (A	_!
+
+.group a
+	a	a
+
+.group á
+	á	''a
+
+.group ã
+	ã	''a~
+
+.group e
+	e	e
+
+.group é
+	é	''e
+
+.group ẽ // latin e with tilde
+	ẽ	''e~
+
+.group ê
+	ê	''e~
+
+.group i
+	i	i
+
+.group í
+	í	''i
+
+.group ĩ
+	ĩ	''i~
+
+.group o
+	o	o
+
+.group ó
+	ó	''o
+
+.group õ
+	õ	''o~
+
+.group u
+	u	u
+
+.group ú
+	ú	''u
+
+.group ũ
+	ũ	''u~
+
+.group y
+	y 	y
+
+.group ý
+	ý	''y
+
+.group ỹ // latin y with tilde
+	ỹ	''y~
+
+// consonants
+
+.group g
+	g	g
+
+.group ĝ
+	ĝ	n.
+
+.group h
+	h	h
+
+.group j
+	j	J^
+
+.group k
+	k	k
+
+.group l
+	l	l
+
+.group m
+	m	m
+
+.group n
+	n	n
+
+.group ñ
+	ñ	n^
+
+.group p
+	p	p
+
+.group r
+	r	r
+	A) r (A	r
+	rr	R2
+
+.group s
+	s	s
+
+.group t
+	t	t
+
+.group v
+	v	b
+	A) v (A	B
+
+.group ch
+	ch	S
+
+.group mb
+	mb	mb
+
+.group nd
+	nd	Nd
+
+.group ng
+	ng	Ng
+
+.group nt
+	nt	Nt
+
+.group rr
+	rr	R2
+
+// Characters not included in achegety
+
+.group b
+	b	b
+
+.group c
+	c	k
+	_) ch	S
+	c (Y	T // spanish words
+	ck	k:
+
+.group d
+	d	d
+
+.group f
+	f	f
+
+.group q
+	q	k
+	qu (Y	 k
+
+.group w
+	w	w
+	wh	w
+
+.group x
+	x	ks
+
+.group z
+	z	T
+	zz	ts

--- a/espeak-data/voices/sai/gn
+++ b/espeak-data/voices/sai/gn
@@ -1,0 +1,5 @@
+
+name guarani
+language gn
+dictrules 1
+words 0 1

--- a/phsource/ph_guarani
+++ b/phsource/ph_guarani
@@ -1,0 +1,140 @@
+
+//====================================================
+//  guarani: Update 14 march 2016
+//====================================================
+
+phoneme a
+  vowel starttype #a endtype #a
+  length 170
+  IF thisPh(isWordEnd) AND thisPh(isStressed) THEN
+    FMT(vowel/a, 75)
+  ENDIF
+  FMT(vowel/a_4)
+endphoneme
+
+phoneme a~
+  vowel  starttype #a  endtype #a
+  length 190
+  IF thisPh(isWordEnd) AND thisPh(isStressed) THEN
+    FMT(vnasal/a#_n2, 90)
+  ENDIF
+  FMT(vnasal/a_n, 80)
+endphoneme
+
+phoneme e
+  vowel starttype #e endtype #e
+  length 165
+  IF thisPh(isWordEnd) AND thisPh(isStressed) THEN
+    FMT(vowel/e)
+  ENDIF
+  FMT(vowel/e_mid2)
+endphoneme
+
+phoneme e~
+  vowel  starttype #e  endtype #e
+  length 200
+  FMT(vnasal/e_n)
+endphoneme
+
+phoneme i
+  vowel starttype #i endtype #i
+  length 160
+  FMT(vowel/i)
+endphoneme
+
+phoneme i~
+  vowel  starttype #i  endtype #i
+  length 190
+  FMT(vnasal/i_n)
+endphoneme
+
+phoneme o
+  vowel starttype #o endtype #o
+  length 170
+  FMT(vowel/oo)
+endphoneme
+
+phoneme o~
+  vowel  starttype #o  endtype #o
+  length 190
+  FMT(vnasal/o_n)
+endphoneme
+
+phoneme u
+  vowel starttype #u endtype #u
+  length 155
+  FMT(vowel/u_bck2)
+endphoneme
+
+phoneme u~
+  vowel  starttype #u  endtype #u
+  length 185
+  FMT(vnasal/u_n)
+endphoneme
+
+phoneme y
+  vowel starttype #i endtype #i
+  length 185
+  FMT(vowel/yy_4)
+endphoneme
+
+phoneme y~ // guarani ỹ
+  ipa ɨ̃
+  vowel starttype #i endtype #i
+  length 195
+  FMT(vowel/i#_7)
+endphoneme
+
+
+// consonants
+
+phoneme b
+  vcd blb stop
+  IF nextPh(isVowel) OR nextPh(isRhotic) OR nextPh(isLiquid) THEN
+    IF prevPh(isPause) OR prevPh(isNasal) THEN
+    ELSE
+      ChangePhoneme(B)
+    ENDIF
+  ENDIF
+
+  CALL base/b
+endphoneme
+
+phoneme r
+  vcd alv flp rhotic
+  brkafter
+  ipa ɾ
+  lengthmod 3
+
+  IF nextPhW(isVowel) THEN
+    ChangePhoneme(**)
+  ENDIF
+
+  CALL base/*
+endphoneme
+
+phoneme g
+  vcd vel stop
+  lengthmod 5
+  voicingswitch k
+  Vowelin  f1=2  f2=2300 200 300  f3=-300 80
+  Vowelout f1=2  f2=2300 250 300  f3=-300 80 brk
+
+  IF nextPh(isVowel) OR nextPh(isRhotic) OR nextPh(isLiquid) THEN
+    IF prevPh(isPause) OR prevPh(isNasal) THEN
+    ELSE
+      ChangePhoneme(Q)
+    ENDIF
+  ENDIF
+
+  IF PreVoicing THEN
+    FMT(g/xg)
+  ENDIF
+
+  IF nextPh(isPause2) THEN
+    FMT(g/g_) addWav(x/g_)
+  ENDIF
+  FMT(g/g) addWav(x/g2)        // weaker [g]
+endphoneme
+
+

--- a/phsource/phonemes
+++ b/phsource/phonemes
@@ -1974,3 +1974,6 @@ include ph_oromo
 phonemetable my base
 include ph_burmese
 
+phonemetable gn base
+include ph_guarani
+

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -814,6 +814,12 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_IT_LENGTHEN] = 1; // remove [:] phoneme from non-stressed syllables (Lang=gd)
 	}
 		break;
+	case L('g','n'):   // guarani
+		{
+			tr->langopts.stress_rule = STRESSPOSN_1R;      // stress on final syllable
+			tr->langopts.length_mods0 = tr->langopts.length_mods;  // don't lengthen vowels in the last syllable
+		}
+		break;
 	case L('h', 'i'): // Hindi
 	case L('n', 'e'): // Nepali
 	case L('o', 'r'): // Oriya


### PR DESCRIPTION
Thanks a request from a native speaker I started a work for adding and improving the Guarani language:

ISO 639-1  gn

ISO 639-5 sai (South American Indian: Tupian language ).

In the file "src\libespeak-ng\tr_languages.c" I've added the lines 817-822 to set stress vowels, please check and review.

In phsource\phonemes added two lines to include ph_guarani, please check and review.

This P.R. contains also the file needed for adding a new language.
On gn_lists is used the spanish pronunciation for numbers as is commonly used by Guarani speakers in Paraguay and countries around.

We would like to add this language in eSpeak-ng, thanks.