### PR TITLE
Spanish intonation.

### DIFF
--- a/espeak-data/voices/roa/es
+++ b/espeak-data/voices/roa/es
@@ -1,7 +1,8 @@
+
 name spanish
 language es
 gender male
-
 dictrules 1
-//intonation 3
+tunes s6 c6 q6 e6
+
 

--- a/phsource/intonation
+++ b/phsource/intonation
@@ -227,3 +227,41 @@ nucleus0 rise-fall  92 8
 nucleus  rise-fall  88 77 75 10
 endtune
 
+// spanish
+tune s6
+prehead   46 57
+headenv   fall 16
+head       5 79 50 -7 -4
+headextend 0 63 38 13 0
+nucleus0 fall 66 7
+nucleus fall 72 25 16 9
+endtune
+
+tune c6
+prehead   45 55
+headenv   fall 16
+head       4 80 49 -8 -3
+headextend 0 63 38 13 0
+nucleus0 fall-rise 70 15
+nucleus fall-rise 74 26 23 45
+endtune
+
+tune q6
+prehead   48 60
+headenv   fall 16
+head       3 78 40 -7 -3
+headextend 10 47 23 9 0
+onset 58 45 48
+headlast 35 22 17
+nucleus0 fall-rise 90 24
+nucleus fall-rise 78 25 90 68
+endtune
+
+tune e6
+prehead   46 57
+headenv   fall 16
+head       3 90 50 -9 0
+headextend 16 82 50 32 16
+nucleus0 fall  92 8
+nucleus fall  90 77 76 8
+endtune

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -691,8 +691,8 @@ Translator *SelectTranslator(const char *name)
 	case L('i', 'a'): // Interlingua
 	case L_pap: // Papiamento
 	{
-		static const short stress_lengths_es[8] = { 156, 170,  170, 156,  0, 0,  163, 200 }; // change for Leandro Benitez, 02.Aug.2014
-		static const unsigned char stress_amps_es[8] = { 16, 12, 18, 18, 20, 20, 20, 20 }; // 'diminished' is used to mark a quieter, final unstressed syllable
+		static const short stress_lengths_es[8] = { 160, 140,  145, 140,  0, 0,  200, 245 };
+		static const unsigned char stress_amps_es[8] = { 16, 13, 15, 16, 20, 20, 22, 22 }; // 'diminished' is used to mark a quieter, final unstressed syllable
 		static const wchar_t ca_punct_within_word[] = { '\'', 0xb7, 0 }; // ca: allow middle-dot within word
 
 		SetupTranslator(tr, stress_lengths_es, stress_amps_es);


### PR DESCRIPTION
This is a new intonation for Spanish language, mostly for Castilian spanish, we need more feedback for Latin American Spanish.

Also we changed in src/libespeak-ng/tr_language.c the values for lengthen and amplitude for a convenient impact of stressed sillable and nucleus in clauses, (see lines 694-695).