### PR TITLE
Italian: removed lengthen penultimate stressed vowels, last improvements for italian dict-source.

### DIFF
--- a/dictsource/it_list
+++ b/dictsource/it_list
@@ -1,6 +1,6 @@
 ﻿
 // This file is UTF-8 encoded
-// Updated 2016 march 30 by Chris, Christian Leo M, <llajta2012@gmail.com>
+// Updated 2016 june 4 by Chris, Christian Leo M, <llajta2012@gmail.com>
 
 //  $alt   change [e] or [o] in the stressed syllable to [E] or [O]
 //  $alt2  change [E] or [O] in the stressed syllable to [e] or [o]
@@ -13,17 +13,17 @@ _a	a:
 b	bi
 c	tSi
 d	d['i:
-_e	e:
+_e	E:
 f	'Effe
 g	dZi
 h	ak:a
 _i	i:
-j	'i||l'unga
+j	'i||_l'uNga/
 k	kap:a
 l	Elle
 m	Emme
 n	Enne/
-_o	o:
+_o	O:
 p	pi
 q	ku
 r	ER*e
@@ -292,8 +292,8 @@ _0	dz'E*o
 _1	'uno
 _2	d'ue
 _3	t@-*'e
-_4	kw2'at:@-*o
-_5	tS'inkw2e
+_4	kw'at:@-*o
+_5	tS'inkwe
 _6	s'Ej
 _7	s'Et:e
 _8	'Ot:o
@@ -303,7 +303,7 @@ _11     'unditSi
 _12     d'oditSi
 _13     t@-*'editSi
 _14     kw2at:'oRditSi
-_15     kw2'imditSi
+_15     kw'imditSi
 _16     s'editSi
 _17     ditSass'Et:e
 _18     ditS'Ot:o
@@ -319,7 +319,7 @@ _28     vent'Ot:o
 _29	ventin'Ove
 _3X     t@-*'enta
 _4X     kua*'a:nta
-_5X     tSinkw2'anta
+_5X     tSinkw'anta
 _6X     sess'anta
 _7X     set:'anta
 _8X     ot:'anta
@@ -345,8 +345,8 @@ _#ª	a
 _1ox	p@-*im
 _2ox	sekond
 _3ox	tE@-*ts
-_4ox	kw2a:@-*t
-_5ox	kw2int
+_4ox	kwa:@-*t
+_5ox	kwint
 _6ox	sEst
 _7ox	s'Et:im
 _8ox	ot:av
@@ -355,8 +355,8 @@ _9ox	non
 _1o	un'Ezim
 _2o	du'Ezim
 _3o	t@-*e'Ezim
-_4o	kw2at:@-*'Ezim
-_5o	tSinkw2'Ezim
+_4o	kwat:@-*'Ezim
+_5o	tSinkw'Ezim
 _6o	sEj'Ezim
 _7o	sEt:'Ezim
 _8o	Ot:'Ezim
@@ -376,7 +376,7 @@ _19o	ditSan:Ov'Ezim
 _20o	vent'Ezim
 _30o	t@-*ent'Ezim
 _40o	kua*a:nt'Ezim
-_50o	tSinkw2ant'Ezim
+_50o	tSinkwant'Ezim
 _60o	sessant'Ezim
 _70o	set:ant'Ezim
 _80o    ot:ant'Ezim
@@ -432,6 +432,7 @@ uk	$abbrev
 unicef	$1
 url	u||eR*e||'El:e $only
 usb	$abbrev
+utc	,u||ti||tS'i
 wwf	vu||vu||'Ef:e
 www	v,u||_vu||_v'u
 xml	iks||em:e||'El:e
@@ -496,11 +497,9 @@ sue	$u+
 nostre	$u+
 vostre	$u+
 
-questo	$u+
-questa	$u+
-questi  $u+	$nounf
-queste  $u+
-
+quest	$u+	$nounf
+(questa è)	kw'esta||'E
+(questo è)	kw'esto/||,E
 quel	$u+
 quella	$u+
 quei	kw2eI
@@ -533,7 +532,7 @@ mentre	$u+
 neanche	$u+	$brk
 né	$u+	$brk  $only
 no	nO $strend
-non	$u	$only
+non	$u	$verbf $only
 o	$u+ $brk
 ogni	$u+
 oltre	$u+
@@ -828,6 +827,7 @@ disney	$1
 disneyland	$1
 display	displ'ei
 device	dIv'aIs
+door	d'o:@-*	$onlys
 doppler	$1
 down	d'a/:w2n
 download	d'a/:w2nl,o:d
@@ -1192,7 +1192,7 @@ rock'n'roll	@-*,Oken@-*'o:l
 (déjà vu)	deIZa:||v'u:
 (ladies and gentlemen)	l'eIdIz||and||dZ'Ent@lm@n
 (nôtre dame)	noUt@-*'da:m
-(question time)	kw2'estiont'aIm
+(question time)	kw'estiont'aIm
 
 // Main  nouns Dictionary (see also it_listx)
 
@@ -1534,7 +1534,6 @@ retino	$2
 revoche	$1
 riavvia	@-*iav:'i#a
 riavvio	@-*iav:'IO
-riciao	@-*i_tS'ao:
 ricordino	$3 $noun
 rigoli	$1
 rossonere	$3 $alt2
@@ -1560,7 +1559,7 @@ schettin	$2
 schizzofrenia	$4
 scia	S'ia
 sciabile	Si'abile
-sciacquii	S,akw2'i:j
+sciacquii	S,akw'i:j
 sciacquio	S,akw2'i;O
 sciator	Si|at'oR
 sciatric	Siat@-*'ItS
@@ -1645,10 +1644,11 @@ com'era	kom'E:Ra
 cos'hai	koz'a:i
 cos'è	koz'E
 dov'è	dov'E
+qual'è	kwal''E
 tant'è	taNt'E
 l'ancora	l'ankoRa
 un'ancora	un'a:nkoRa
-quand'è	kw2aNd'E
+quand'è	kwaNd'E
 senz'altro	sents'a:lt@-*o
 nessun'altra	nessun'alt@-*a
 ultim'ora	ultim'ORa
@@ -1660,8 +1660,7 @@ vent'anni	vent'an:I
 (principi attivi)	p@-*intS'i:pI||at:'ivI
 (principi morali)	p@-*intS'i:pI||moR'alI
 (principi sociali)	p@-*intS'i:pI||sotS'alI
-ciao	tS'ao_
-(ciao a)	tS'ao||_|,a_|
+(ciao ciao)	tS,a/o||tSao
 (un turbine)	un||_t'u@-*bine
 (gli auguri)	l^iaw2g'u:RI
 (pro capite)	p@-*ok'a:pIte
@@ -2032,6 +2031,7 @@ sandviciano	$3
 sangano	$2
 sanlazzaro	san_l'adz:aRo
 saragozzano	$4
+sarcidano	$3
 sarezzano	$3
 sarnano	$2
 sassano	$2
@@ -2177,6 +2177,7 @@ asdrubale	$2
 asimov	'azim,ov
 asterix	$1
 augias	a'u:dZas
+avirex	$1
 bardot	ba@-*d'o
 bartali	$1
 bastian $2
@@ -2232,6 +2233,7 @@ debor $1  $alt
 deborah	$1 $alt2
 deidda	de'i:d:a
 delrio	del||@-*'io/
+dessolis	$2 $onlys
 diaz	d'iats $only
 Dickinson	$1
 diocle $1
@@ -2767,6 +2769,7 @@ attentino	$2
 atterrano	$2
 atterrino	$2
 attestino	$2
+attieniti	$2
 attirano	$2
 attirino	$2
 attonit	$2
@@ -4305,6 +4308,7 @@ spolver	$1
 spolverano	$1
 spopolano	$1
 sporchino	$1
+spostino	$1	$alt2
 sprecano	$1
 spregia	$1
 sprigionino	$2
@@ -4566,11 +4570,14 @@ zuccherano	$1
 (come desideri)	kome||dez'ideRi
 (così desideri)	koz'i||_dez'i:deRI
 (cosa desideri)	k'O:za||dez'i:deRI
+(cui desideri)	k'u:|I||dez'ide**I
+(invece desideri)	inv'etSe||dez'ide**I
 (la desideri)	ladez'i:deRi
 (lo desideri)	lodez'ideRi
 (mi desideri)	mI||dez'i:deRI
-(quando desideri)	kw2ando||_|dez'i:deRi
-(quindi desideri)	kw2,indi||_dez'i:deRi
+// (non desideri)	non||dez'ideRI
+(quando desideri)	kwando||_|dez'i:deRi
+(quindi desideri)	kw,indi||_dez'i:deRi
 
 // pronominal verbs
 
@@ -4605,6 +4612,8 @@ causatoci	$3
 cercal	$1
 cercasi	$1
 chiuditi	kj'uditI
+cliccal	$1
+cliccaci	$1
 compil	$2
 comunicacel	$2
 comunical	$2
@@ -4644,6 +4653,7 @@ evolverci	$2
 evolversi	$2
 fammel	$1
 fattel	f'at:el
+fermati	$1 $atstart
 fermatosi	$2
 formatosi	$2
 giuravi	$2
@@ -4659,6 +4669,7 @@ illuminaci	$2
 illuminami	$2
 illuminal	$2
 immergiti	$2
+immetterl	$2
 impostaci	$2
 impostomi	$2
 indirizziamoci	indiRi_tsj'amotSI // $5
@@ -4696,6 +4707,7 @@ pizzicami	$1
 portala	$1
 portalo	$1
 portatel	$2
+posizionati	$4 $atstart
 presentaci	$2
 promessomi	$2
 privaci	$1

--- a/dictsource/it_listx
+++ b/dictsource/it_listx
@@ -283,7 +283,7 @@ aporia $3
 apostat $2
 apostrof	$2
 apotem  $alt
-appen	ap:,en
+appen	ap:'en
 appendice $3
 appiomb  $alt2
 appoggi  $alt
@@ -1115,7 +1115,6 @@ costumanz	kostum'an|ts
 cot  $alt
 cottim  $alt
 coyote  $alt
-cozzoli	k'o_tsolI
 cratere $2
 cred  $alt
 credit $1  $alt2

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -1,7 +1,7 @@
 
 // Italian translation rules
 // This file is UTF-8 encoded
-// Last update: 2016 march 3 by Chris <llajta2012@gmail.com>
+// Last update: 2016 june 1 by Chris <llajta2012@gmail.com>
 // letter groups
 // A  any vowel
 // C  any consonant
@@ -67,18 +67,18 @@
 	cqui (A	k:wj
 	c (Y	tS
 	cc (Y	tS:
-		ch (Y	k
+	ch (Y	k
 		cch (Y	k:
 	s) ch (A	k
 	ch (a	tS
 	ch (o	tS
 	ch (u	tS
-		ci (A	tS
-		cci (A  tS:
-	@)	co (lA_ =ko
+	ci (A	tS
+	cci (A	tS:
+	@) co (lA_	=ko
 	cardia (_	ka@-*d'ia
 	cardie (_	ka@-*d'ie
-     _) c' (P2t     tS
+	_) c' (P2t	tS
 	@@A) ce (A_	=tSE
 	ciano (_	=tSano   // verbs
 	cciano (_	=tS:ano
@@ -90,18 +90,19 @@
 	cuocer (L04_	kU'OtSe@-*
 	compra (L07_	k'omp@-*a
 	_L04Z) capit (A_	k'a:p,it
-		_L04Z) capit (ano_	k'a:p,it
+	_L04Z) capit (ano_	k'a:p,it
 	correr (L04_	k'o:R*eR
 	ccorrer (L04_	k:'o:R*eR
 	chiama (L07_	ki'a:ma
-	a) cquista (L07_	k:w2'ista
+	a) cquista (L07_	k:w'ista
+	re) cat (AL07_	k''at
 
 .group d
-		d	d
-		dd	d:
+	d	d
+	dd	d:
 	n) dere (_	=deRe
-     _) dall' (P5t     dall
-     _) dell' (P5t     dell
+	_) dall' (P5t	dall
+	_) dell' (P5t	dell
 	_) d' (P2t	d
 	donat (Y_	don'at
 	dona (L07_	d'ona  // Pron.s verbs
@@ -116,7 +117,7 @@
 	day (_	d'eI   // foreign
 
 .group e
-		e        e
+	e	e
 	ei (d	Ej
 	ei (c	Ej
 	ei (colA_	ei
@@ -125,48 +126,48 @@
 	@t) ei (_	'eI
 	@) ey (_	=eI
 	@C)	e (_S1q  e/     // lookup it_list without suffix
-		e (C_    E
-		e (A     E
-		e (C%A_  E
+	e (C_    E
+	e (A	E
+	e (C%A_	E
 	_d) e (llA_	e
-		e (CiCA_ E
-		e (CulA_ E
-		e (llu   E
-		e (st    E
-		e (ttA_	 e
-	c)	e (ttA_  E
-		e (tti@	 E
-		e (zzA_  e
-		e (r     E
-		e (rsi_N e
+	e (CiCA_	E
+	e (CulA_	E
+	e (llu	E
+	e (st	E
+	e (ttA_	e
+	c) e (ttA_	E
+	e (tti@	E
+	e (zzA_	e
+	e (r	E
+	e (rsi_N	e
 	A) e (r_	'E
 	_r) e	E
 	@)	e (ci_	=e
-		e (l     E
-	r)	e (m     E
-		e (monA_ 'e
-		e (nA_   E
-	g)	e (ne    E
-		e (ngA_  e
-		e (nCA_  E
-	@m)	e (ntA_  e
-       %C)	e (rA_   =E
-	C)	e (re_	 =E
-	gg)	e (ro_   E
-	gg)	e (ri_	E
-	f)	e (rm    e
-	@)	e (rrimo_ 'E
+	e (l	E
+	r)	e (m	E
+	e (monA_	'e
+	e (nA_	E
+	g) e (ne	E
+	e (ngA_	e
+	e (nCA_	E
+	@m) e (ntA_	e
+	%C) e (rA_	=E
+	C) e (re_	=E
+	gg) e (ro_	E
+	gg) e (ri_	E
+	f) e (rm	e
+	@) e (rrimo_	'E
 	an) e (simA_	'e:
 	@) e (simA_	'E
-	h)	e (ss    e
-	m)	e (ss    e
-	_sC)	e (ss    e
-		e (ssa_  e
-		e (tr    E
-		e (ti    E
-		e (vi_   E
-		e (vo_   E
-	@)	e (volA_ 'e
+	h)	e (ss	e
+	m) e (ss	e
+	_sC) e (ss	e
+	e (ssa_	e
+	e (tr	E
+	e (ti	E
+	e (vi_	E
+	e (vo_	E
+	@) e (volA_	'e
 		e (zA    E
 		CC) eggia (no_	'EdZ:a
 	C) ender (L04_	'ende@-*  // Pron.s verbs
@@ -190,6 +191,7 @@
 	fobi (A_	fob'i;
 	fob (A_	=fob
 	farma (ci_	f'a@-*ma
+	ferma (L07_	f'e@-*ma/
 
 .group g
 		g	g
@@ -478,10 +480,10 @@
 
 .group q
 		q	k
-		qu (AK	kw2
+	qu (A	kw
 	qui (A	kwj
-     _) quell' (P6t     kw2Ell
-     _) quest' (P6t     kw2est
+     _) quell' (P6t     kwEll
+     _) quest' (P6t     kwest
 
 .group r
 	C)	r	@-*
@@ -559,7 +561,8 @@
 .group t
 		t	t
 		tt	t:
-		@a) tria (_	t@-*'ia
+	_) t' (P2t	 t
+	@a) tria (_	t@-*'ia
 		@a) trie (_	t@-*'ie
 		a) ttoria (_	t:oR'ia
 		a) ttorie (_	t:oR'Ie
@@ -575,6 +578,8 @@
 	_) togli (L04_	t'Ol^i
 	trova (L07_	t@-*'Ova
 	_) tutt' (P5t	tut:
+	au) tentica (L07_	t'ENtIka/
+	a) ttiva (L07_	t:'iva
 	L02) tre (_	t@-*'e
 
 .group u
@@ -598,9 +603,9 @@
 	uomini (_	w2'Omini
 
 .group v
-		v	v
-		vv	v:
-		vvi (A	v:i
+	v	v
+	vv	v:
+	vvi (A	v:i
 		C) vi (A	vI
 		C) vi (A_	=vI
 	A) vino (_	=vino  // verbs
@@ -612,6 +617,7 @@
 	_in) vader (L04_	v'a:de@-*
 	_) vota (L07_	v'Ota
 	s) veglia (L07_	v'el^ia
+	volta (L07_	v'Olta
 
 .group w
 		w	w2
@@ -737,6 +743,6 @@ _L16_)	: (_L17D_	_%%E_	// Say time
 	D) , (D	v'i@-*gola
         __)  - (_D         meno
         A_)  - (_D        _
-        C_)  - (_D        _
-		§	pa*'ag@-*afO
-
+	C_)  - (_D        _
+	§	pa*'ag@-*afO
+	's (S2t	s

--- a/phsource/ph_italian
+++ b/phsource/ph_italian
@@ -1,6 +1,6 @@
 ﻿
 //====================================================
-//  Italian, last update 2 jan 2016 by Chris <llajta2012@gmail.com>
+//  Italian, last update 4 june 2016 by Chris <llajta2012@gmail.com>
 //====================================================
 
 phoneme : //  Lengthen previous vowel by "length"
@@ -13,23 +13,31 @@ phoneme a
   vowel starttype #a endtype #a
   length 160
   ChangeIfNotStressed(a/)
+  IF thisPh(isWordEnd) AND prevPhW(t) AND thisPh(isStressed) THEN
+    FMT(vowel/a)
+    ENDIF
+  IF nextPhW(o/) THEN
+        FMT(vowel/a_2)
+  ENDIF
+  IF prevPhW(isVowel) OR prevPhW(j) THEN
+    FMT(vowel/a, 90)
+  ENDIF
   FMT(vwl_it/a)
 endphoneme
 
-
 phoneme a/
   vowel starttype #a endtype #a
-  length 140
+  length 145
   IF thisPh(isWordEnd) THEN
-    FMT(vowel/a#_4, 65)
+    FMT(vowel/a_7, 75)
   ENDIF
-  FMT(vowel/a_7)
+  FMT(vowel/a_8)
 endphoneme
 
 
 phoneme e
   vowel starttype #e endtype #e
-  length 150
+  length 155
   ChangeIfNotStressed(e/)
   FMT(vowel/e_2, 80)
 endphoneme
@@ -47,7 +55,7 @@ endphoneme
 
 phoneme E
   vowel starttype #e endtype #e
-  length 145
+  length 150
   ChangeIfUnstressed(e/)
   FMT(vwl_it/e_open)
 endphoneme
@@ -83,19 +91,19 @@ endphoneme
 
 phoneme o
   vowel starttype #o endtype #o
-  length 150
+  length 160
   ChangeIfNotStressed(o/)
   FMT(vwl_it/o)
 endphoneme
 
 phoneme o/
   vowel starttype #o endtype #o
-  length 140
+  length 145
   IF nextPhW(isNasal) OR nextPhW(isLiquid) THEN
     FMT(vwl_it/o_open, 80)
   ENDIF
   IF thisPh(isWordEnd) THEN
-    FMT(vowel/o, 65)
+    FMT(vwl_it/o, 65)
   ENDIF
     FMT(vowel/o)
 endphoneme
@@ -186,14 +194,17 @@ endphoneme
 
 phoneme ts
   vls alv afr sibilant
-  voicingswitch dz
+  voicingswitch s
   lengthmod 9
   Vowelin f1=0  f2=1700 -300 300  f3=-100 60 len=60
   Vowelout f1=0 f2=1700 -300 250  f3=-100 70  rms=14
-  IF nextPh(isPause2) THEN
+  IF nextPh(isNotVowel) THEN
     WAV(ustop/ts_, 80)
   ENDIF
-  WAV(ustop/ts_, 70)
+  IF prevPhW(isNotVowel) THEN
+    WAV(ustop/ts_, 70)
+  ENDIF
+  WAV(ustop/ts)
 endphoneme
 
 phoneme dz

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -1465,15 +1465,6 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 				if (shorten)
 					p++;
 			}
-
-			if ((v_stress >= 4) && (tr->langopts.param[LOPT_IT_LENGTHEN] == 2)) {
-				// LANG=Italian, lengthen penultimate stressed vowels, unless followed by 2 consonants
-				if ((v == (vowel_count - 2)) && (syllable_weight[v] == 0)) {
-					*output++ = phcode;
-					phcode = phonLENGTHEN;
-				}
-			}
-
 			v++;
 		}
 

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -978,9 +978,9 @@ Translator *SelectTranslator(const char *name)
 	case L('i', 't'): // Italian
 	{
 		static const short stress_lengths_it[8] =
-		{ 165, 100,  170, 150,  0, 0,  215, 303 };
+		{ 165, 130,  170, 150,  0, 0,  218, 305 };
 		static const unsigned char stress_amps_it[8] =
-		{ 16, 15, 16, 14, 20, 22, 22, 24 };
+		{ 16, 18, 17, 14, 20, 22, 22, 22 };
 
 		SetupTranslator(tr, stress_lengths_it, stress_amps_it);
 


### PR DESCRIPTION
Removed lengthen penultimate stressed vowels from dictionary.c lines 1469-1475. (See #80).

Fixed length stressed vowels in tr_language.c (see #80).

Improved phonemes, new statements for [a] and long close [o].

Added last improvements in italian dict source tested on april-may 2016.

Thanks.