### PR TITLE
espeak_ng_Cancel(): discard the audio, don't close the device!

### DIFF
--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -810,7 +810,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Cancel(void)
 
 #ifdef HAVE_PCAUDIOLIB_AUDIO_H
 	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO)
-		audio_object_close(my_audio);
+		audio_object_flush(my_audio);
 #endif
 	embedded_value[EMBED_T] = 0; // reset echo for pronunciation announcements
 


### PR DESCRIPTION
This function should just discard the currently playing audio,
rather than close the audio device.  After all,
we will probably want to synthesize something else later.