### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ new languages:
 
 These are a condensed set of releases that were maintained in step with the
 upstream eSpeak releases. The releases containing minor build fixes, or only
-incorporating upstream changes have been ommitted.
+incorporating upstream changes have been omitted.
 
 ### 1.48.11 - 2014-08-31
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ already have an espeak-ng install by running:
 ## Documentation
 
 The [main documentation](docs/index.md) for eSpeak NG provides more information
-on using and creating voices/languages for for eSpeak NG.
+on using and creating voices/languages for eSpeak NG.
 
 The [espeak-ng](src/espeak-ng.1.ronn) and [speak-ng](src/speak-ng.1.ronn)
 command-line documentation provide a reference of the different command-line

--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -214,7 +214,7 @@ rule with more syllables.
 | Symbol      | Description |
 |-------------|-------------|
 | `+`         | Force an increase in the score in this rule by 20 points (may be repeated for more effect). |
-| `<`         | Force an decrease in the score in this rule by 20 points (may be repeated for more effect). |
+| `<`         | Force a decrease in the score in this rule by 20 points (may be repeated for more effect). |
 | `S<number>` | This number of matching characters are a standard suffix, remove them and retranslate the word. |
 | `P<number>` | This number of matching characters are a standard prefix, remove them and retranslate the word. |
 | `Lnn`       | `nn` is a 2-digit decimal number in the range 01 to 20 Matches with any of the letter sequences which have been defined for letter group `nn` |
@@ -393,7 +393,7 @@ This feature cannot be used for the special entries in the `*_list` files which
 start with an underscore, such as numbers.
 
 Currently `textmode` entries are only recognized for complete words, and
-not for for stems from which a prefix or suffix has been removed (e.g.
+not for stems from which a prefix or suffix has been removed (e.g.
 the word "coughs" would not match the example above).
 
 ## Conditional Rules
@@ -447,7 +447,7 @@ each language. The number fragments are given in the `*_list` file.
 | `_0M3`        | The word for 1,000,000,000. |
 | `_1M1` `_2M1` | Special pronunciation for one thousand, two thousand, etc, if needed. |
 | `_0and`       | Word for `and` when speaking numbers (e.g. `two hundred and twenty`). |
-| `_dpt`        | Word spoken for the decimnal point/comma. |
+| `_dpt`        | Word spoken for the decimal point/comma. |
 | `_dpt2`       | Word spoken (if any) at the end of all the digits after a decimal point. |
 
 ## Character Substitution

--- a/docs/phontab.md
+++ b/docs/phontab.md
@@ -236,15 +236,15 @@ instructions.
 
 	length <length>
 
-The relative length of the phoneme in miliseconds. Typical values are about 
-140 for a short vowel and from 200 to 300 for a long vowel or diphong. 
+The relative length of the phoneme in milliseconds. Typical values are about 
+140 for a short vowel and from 200 to 300 for a long vowel or a diphthong. 
 A `length()` instruction is needed for vowels. It is optional for consonants.
 
 ### ipa
 
 	ipa <ipa string>
 
-In many cases, eSpeak NG makes IPA (International Phonetic Alpbabet) phoneme
+In many cases, eSpeak NG makes IPA (International Phonetic Alphabet) phoneme
 names automatically from eSpeak NG phoneme names. If this is not correct, then
 the phoneme definition can include an `ipa` instruction to specify the correct
 IPA name. IPA strings may include non-ascii characters. They may also include
@@ -565,7 +565,7 @@ is limited by the program.
 
 	len=<integer>
 
-Nominal length of the transition in miliseconds. If omitted a default value is used.
+Nominal length of the transition in milliseconds. If omitted a default value is used.
 
 	rms=<integer>
 

--- a/docs/voices.md
+++ b/docs/voices.md
@@ -462,7 +462,7 @@ e.g.
 
 	dictdialect en-us
 
-This means that any words or rules which are maked with `_^_EN` will be
+This means that any words or rules which are made with `_^_EN` will be
 spoken with the US English voice instead of the default UK English
 voice.
 


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).