### PR TITLE
Fix OSX compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ The extended dictionaries are taken from
 provide better coverage for those languages, while increasing the resulting
 dictionary size.
 
+## Compiling on OSX
+
+__NOTE:__ This is currently experimental. It does not build the voice data, and
+may contain runtime errors and missing functionality.
+
+To build eSpeak NG on OSX, you will need:
+
+1. [Homebrew](http://brew.sh)
+1. Portaudio: `brew install portaudio`
+1. Disabling MBROLA during configuration: `./autogen && ./configure --with-mbrola=no`
+
 ## Compiling on Windows
 
 __NOTE:__ This is currently experimental. It does not build the voice data, and

--- a/src/libespeak-ng/spect.c
+++ b/src/libespeak-ng/spect.c
@@ -25,7 +25,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define bswap_16 OSSwapInt16
+#define bswap_32 OSSwapInt32
+#define bswap_64 OSSwapInt64
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#else
 #include <endian.h>
+#endif
 
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>


### PR DESCRIPTION
This pull request aims to fix #12. The compilation fix for OSX should be quite the same than the one for windows raised #167 

If it compiles fine, I'm not able to synthetise any sentences running: `espeak "Some text"`

There should be a way to make it work because the version on *Homebrew* works fine: https://github.com/Homebrew/homebrew-core/blob/master/Formula/espeak.rb