### PR TITLE
Stop audio output before fifo_stop is called

### DIFF
--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -236,8 +236,10 @@ static espeak_ng_STATUS close_stream()
 		return status;
 
 	int a_stop_is_required = my_stop_is_required;
-	if (!a_stop_is_required)
+	if (!a_stop_is_required) {
 		my_command_is_running = 1;
+		pthread_cond_broadcast(&my_cond_command_is_running);
+	}
 
 	status = pthread_mutex_unlock(&my_mutex);
 
@@ -307,11 +309,11 @@ static void *say_thread(void *p)
 		my_command_is_running = 1;
 
 		assert(-1 != pthread_cond_broadcast(&my_cond_command_is_running));
-		assert(-1 != pthread_mutex_unlock(&my_mutex));
+		//assert(-1 != pthread_mutex_unlock(&my_mutex));
 
 		while (my_command_is_running) {
-			int a_status = pthread_mutex_lock(&my_mutex);
-			assert(!a_status);
+			//int a_status = pthread_mutex_lock(&my_mutex);
+			//assert(!a_status);
 			t_espeak_command *a_command = (t_espeak_command *)pop();
 
 			if (a_command == NULL) {

--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -309,11 +309,8 @@ static void *say_thread(void *p)
 		my_command_is_running = 1;
 
 		assert(-1 != pthread_cond_broadcast(&my_cond_command_is_running));
-		//assert(-1 != pthread_mutex_unlock(&my_mutex));
 
 		while (my_command_is_running) {
-			//int a_status = pthread_mutex_lock(&my_mutex);
-			//assert(!a_status);
 			t_espeak_command *a_command = (t_espeak_command *)pop();
 
 			if (a_command == NULL) {

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -799,15 +799,16 @@ ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode,
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Cancel(void)
 {
+#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO)
+		audio_object_flush(my_audio);
+#endif
+
 #ifdef USE_ASYNC
 	fifo_stop();
 	event_clear_all();
 #endif
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
-	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO)
-		audio_object_flush(my_audio);
-#endif
 	embedded_value[EMBED_T] = 0; // reset echo for pronunciation announcements
 
 	for (int i = 0; i < N_SPEECH_PARAM; i++)


### PR DESCRIPTION
This allows process_espeak_command to stop as soon as possible

Using emacspeak server with espeak-ng (still not published) found that audio was only being stoped after a command is processed (i.e. using pcaudiolib).
This fixes the issue.