### PR TITLE
Fix for issue #69 Speaking '1,,2' in German only says 'eins'.

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -2451,8 +2451,13 @@ void *TranslateClause(Translator *tr, FILE *f_text, const void *vp_input, int *t
 					c = ' '; // terminate digit string with a space
 					space_inserted = 1;
 				}
-			} else {
-				if (prev_in != ',') {
+			} else { // Prev output is not digit
+				if (prev_in == ',') {
+					// Workaround for several consecutive commas —
+					// replace current character with space
+					if (c == ',')
+						c = ' ';
+				} else {
 					decimal_sep_count = 0;
 				}
 			}


### PR DESCRIPTION
I tried to make espeak-ng say with comma, but unsuccesfully. This implementation says ` _'aIns tsv'aI` without comma, similarly to consecutive dots in number.