### PR TITLE
Fixed voice default in demo.html and updated to 1.49.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ gradlew.bat
 build/
 espeak.iml
 
+# emscripten output:
+a.out
+a.out.js
+
 # autotools
 
 AUTHORS

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2014-2016 Eitan Isaacson
-# Copyright (C) 2016      Alberto Pettarin
+# Copyright (C) 2014-2017 Eitan Isaacson
+# Copyright (C) 2016-2017 Alberto Pettarin
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,7 +73,7 @@ EM_WORKER_DATA=js/espeakng.worker.data
 EM_WORKER_JS=js/espeakng.worker.js
 EM_PTHREAD_MAIN_JS=js/pthread-main.js
 
-# NOTE: intermediate objects 
+# NOTE: intermediate objects
 EM_OBJS=$(EM_GLUE_OBJ) $(EM_LIBESPEAKNG_SO)
 EM_ALL_PRE_JS=$(EM_PRE_JS) $(EM_ESPEAKNG_DATA_PACKAGE_JS)
 EM_ALL_POST_JS=$(EM_GLUE_AUTOGEN_JS) $(EM_POST_JS)
@@ -82,8 +82,8 @@ EM_ALL_POST_JS=$(EM_GLUE_AUTOGEN_JS) $(EM_POST_JS)
 #
 # ./emconfigure ./configure --prefix=/usr --without-async
 # ./emmake make
-CXXFLAGS+=-DESPEAK_DATA_PATH=\"$(EM_VIRTUAL_PATH_ESPEAKNG_DATA)\" 
-CXXFLAGS+=-I ./ -I ../ -I ../src/include/espeak-ng 
+CXXFLAGS+=-DESPEAK_DATA_PATH=\"$(EM_VIRTUAL_PATH_ESPEAKNG_DATA)\"
+CXXFLAGS+=-I ./ -I ../ -I ../src/include/espeak-ng
 
 # NOTE: so far, pthread is not supported in any browser
 #       except Firefox Nightly.
@@ -114,7 +114,7 @@ $(EM_WORKER_DATA):
 $(EM_ESPEAKNG_DATA_PACKAGE_JS): $(EM_WORKER_DATA)
 
 $(EM_GLUE_AUTOGEN_CPP): $(EM_GLUE_IDL)
-	$(EM_WEBIDL_BINDER) $(EM_GLUE_IDL) $(EM_GLUE_PREFIX) 
+	$(EM_WEBIDL_BINDER) $(EM_GLUE_IDL) $(EM_GLUE_PREFIX)
 
 $(EM_GLUE_AUTOGEN_JS): $(EM_GLUE_AUTOGEN_CPP)
 

--- a/emscripten/README.md
+++ b/emscripten/README.md
@@ -7,10 +7,10 @@ to Javascript via
 allows client-side text-to-speech synthesis in any browser
 supporting Web workers and the Web Audio API.
 
-* Version: 1.49.0
-* Date: 2016-11-01
+* Version: 1.49.1
+* Date: 2017-02-01
 * License: the GNU General Public License, Version 3 (GPLv3)
-* Size: 3.0 MB (including all the voices)
+* Size: 3.2 MB (including all the voices)
 
 
 ## Demo

--- a/emscripten/demo.html
+++ b/emscripten/demo.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2">
-    <title>espeakng.js Demo</title>
+    <title>espeakng.js 1.49.1 Demo</title>
     <style>
       h1 {
         max-width: 480px;
@@ -22,6 +22,11 @@
         display: inline-block;
         width: calc(80% - 3rem);
         margin: 0;
+      }
+      .speecharg input {
+        margin: 0;
+        padding: 0;
+        border: 0;
       }
       .speecharg button {
         width: 1.5rem;
@@ -92,14 +97,14 @@
       <div>Loading eSpeak-ng worker and data...</div>
       <progress></progress>
     </div>
-    <h1>espeakng.js Demo</h1>
+    <h1>espeakng.js 1.49.1 Demo</h1>
     <form>
       <textarea id="texttospeak">Call me Ishmael. Some years ago --- never mind how long precisely --- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation.</textarea>
       <div class="speecharg">
-        <label for="pitch">Pitch</label><input id="pitch" type="range" value="50" min="0" max="100"><button type="button" aria-label="Reset pitch" title="Reset pitch" onclick="resetPitch();">&#x21b6;</button>
+        <label for="pitch">Pitch</label><input id="pitch" type="range" value="50" min="0" max="100" /><button type="button" aria-label="Reset pitch" title="Reset pitch" onclick="resetPitch();">&#x21b6;</button>
       </div>
       <div class="speecharg">
-        <label for="rate">Rate</label><input id="rate" type="range" value="175" min="80" max="450"><button type="button" aria-label="Reset rate" title="Reset rate" onclick="resetRate();">&#x21b6;</button>
+        <label for="rate">Rate</label><input id="rate" type="range" value="175" min="80" max="450" /><button type="button" aria-label="Reset rate" title="Reset rate" onclick="resetRate();">&#x21b6;</button>
       </div>
       <div class="speecharg">
         <label for="voice">Voice</label><select id="voice"></select><button type="button" aria-label="Reset voice" title="Reset voice" onclick="resetVoice();">&#x21b6;</button>

--- a/emscripten/espeakng_glue.cpp
+++ b/emscripten/espeakng_glue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Eitan Isaacson
+ * Copyright (C) 2014-2017 Eitan Isaacson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/emscripten/espeakng_glue.idl
+++ b/emscripten/espeakng_glue.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Eitan Isaacson
+ * Copyright (C) 2014-2017 Eitan Isaacson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/emscripten/js/demo.js
+++ b/emscripten/js/demo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Eitan Isaacson
+ * Copyright (C) 2014-2017 Eitan Isaacson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -164,7 +164,7 @@ function speak() {
 
   var now = Date.now();
   chunkID = 0;
-  
+
   console.log('  Creating pusher...');
   pusher = new PushAudioNode(
     ctx,
@@ -204,7 +204,7 @@ function speak() {
     } // end of function cb
   ); // end of tts.synthesize()
   console.log('  Calling synthesize... done');
-  
+
   console.log('Leaving speak()');
 } // end of speak()
 
@@ -240,7 +240,7 @@ function initializeDemo() {
             opt.value = voice.identifier;
             console.log('Adding voice: ' + opt.text);
             sel.add(opt);
-            if (voice.name === 'en') {
+            if (voice.name === 'english') {
               opt.id = 'default-voice';
               opt.selected = true;
             }

--- a/emscripten/js/espeakng.js
+++ b/emscripten/js/espeakng.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Eitan Isaacson
+ * Copyright (C) 2014-2017 Eitan Isaacson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/emscripten/post.js
+++ b/emscripten/post.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Eitan Isaacson
+ * Copyright (C) 2014-2017 Eitan Isaacson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Also:

1. added ``a.out`` and ``a.out.js`` (generated by emscripten) to the main ``.gitignore``
2. fixed the default option in ``emscripten/demo.html``, now being ``english``
3. fixed CSS that made the slider bars look ugly in Firefox
4. updated copyright strings in emscripten files to 2017