### PR TITLE
Italian: secondary stress, Roman numbers and last updates

### DIFF
--- a/dictsource/it_list
+++ b/dictsource/it_list
@@ -1,6 +1,6 @@
 ﻿
 // This file is UTF-8 encoded
-// Updated 2017 January 5 by Christian Leo M, <llajta2012@gmail.com>
+// Updated 2017 feb 2 by Christian Leo M, <llajta2012@gmail.com>
 
 //  $alt   change [e] or [o] in the stressed syllable to [E] or [O]
 //  $alt2  change [E] or [O] in the stressed syllable to [e] or [o]
@@ -68,7 +68,7 @@ _stk	baR*'a:ta
 _tld	kon||t'ilde
 _smc	m,ajuskol'e:t:o
 _rev	inv'E:@-*sa
-_tur	@-*oveS'a:ta
+_tur	@-*oveS'ata
 _bar	baR*'a:ta
 _rfx	@-*et@-*ofl'E:ssa
 _crl	k'u@-*lI
@@ -103,13 +103,13 @@ _>	madZ:'oRe||d'I
 *	aste@-*'isko $max3
 $	d'Ol:aRI
 %	pe@-*tS'ENto $max3
-=	ugwale	$max3
-+	pju	$max3
+=	ugw'ale	$max3
++	pj'u	$max3
 /	b'aR*a	$max3
 \	kont@-*ob'a:R*a	$max3
 _|	b'aR*a||ve@-*tik'ale
 &	'a/nd
-©       k'O:pI||raIt
+©       k'O:pi||raIt
 #	kantSellet:o
 @	ki'otS:ola
 ~	tilde
@@ -266,8 +266,8 @@ _zh	tSIn'ezE
 η	'e:ta||g@-*'eka
 ή	'e:ta||g@-*'eka_
 θ	t'e:ta||g@-*'eka_
-ι	I'ota_
-ί	I'ota_
+ι	j'ota_
+ί	j'ota_
 κ	k'ap:a||g@-*'eka_
 λ	l'ambda_
 μ	m'ju:_
@@ -388,7 +388,6 @@ _1M4	unbili'one
 _dpt	v'i@-*gola
 // _0Z2	tSent'ezimi     // 100ths
 _0Z3	mill'ezimi      // 1000ths
-_roman	@-*om'ano
 
 // ordinal numbers
 _#º	o         // ordinal suffix
@@ -454,6 +453,7 @@ dna	$abbrev
 dr	dot:'o@-*	$hasdot	$dot
 fiat	f'iat[	$only
 gnu	$abbrev	$allcaps
+hd	'ak:a_d'i
 hiv	ak:a||i:||v'u
 html	ak:ati||em:e||'El:e
 l'html	lak:at,i||em:e'El:e
@@ -505,9 +505,9 @@ io	$u+ $only
 tu	$u+ $verbf $only
 lui	$u+ $only
 lei	$u+ $only
-noi	$u+ $only
-voi	v'o|I	$only
-loro	$u+ $only
+noi	$u+	$only
+voi	v'oi	$only
+loro	$u+
 egli	$u+
 ella	$u+
 essa	$u+ 
@@ -582,7 +582,7 @@ ma	$u+ $brk
 mai	$u+ $verbf
 mentre	$u+
 neanche	$u+	$brk
-// né	$u+	$brk  $only
+né	$brk  $only
 no	nO $strend
 non	$u	$verbf $only
 o	$u+ $brk
@@ -596,7 +596,7 @@ più	$u+
 se	$u+ $verbf
 senza	s,Ents2a
 senza	s'Entsa $atend
-si	si: $atend
+sì	si:
 sopra	   $alt2
 sotto	$alt2
 tuttavia	tut:av'ia
@@ -631,7 +631,6 @@ delle	$u+
 de      $u+ $only
 in	$u 	$only $nounf
 in	'i:n	$atend
-(in arrivo)	_inaR*'ivo
 nel	 $u+	$only
 nello	$u+
 nella	$u+
@@ -677,7 +676,7 @@ eravamo	$3
 eravate	$3
 erano	$1
 sarò	$u+ 
-sarai	sa*'aI
+sarai	sa*'a|I
 sarà	$u+
 saremo	$u2+
 sarete	$u2+
@@ -808,7 +807,7 @@ bunker	$1
 business	_^_EN
 by	b'aI $only
 bye	_^_EN
-bypass	b'aIpas
+bypass	b'aI||p'as
 byte	_^_EN
 cabaret	$3 $only
 camper	$1
@@ -855,7 +854,7 @@ condor	$1
 container	kont'eInE@-*	$onlys
 controller	$2
 converter	$2	$onlys
-copyright	k'O:pI@-*,aIt[
+copyright	k'O:pi@-*,aIt[
 corner	$1
 corporation	ko@-*poR'ESon
 couscous	k,us||k'us
@@ -894,6 +893,7 @@ editor	'Edito@-*	$onlys
 l'editor	l'Edito@-* $only
 eloquence		_^_EN
 emergency	em'e@-*dZensi
+emoji	em'o:dZi
 emule	,i||_mj'ul
 (e mule)	,i||_mj'ul
 english		_^_EN
@@ -1244,7 +1244,7 @@ zoom	dz'u:m
 zoster	$1
 élysées	eliz''e
 
-rock'n'roll	@-*,Oken@-*'o:l
+rock'n'roll	@-*,Oken@-*'O:l
 (call center)	k'ol||s'entE@-*
 (e speak)		isp'ik:
 (i phone)		'aI||fon
@@ -1350,18 +1350,8 @@ cuor	kU'OR
 cucchiain	kuk:ia'in
 cupidigia	$3
 curriculum	$2
-debol	$1
-decim	$1
-decimonono	$4
-decine	$2
-decrepit	$2
 dei	d'E:i	$noun
-deleghe	$1
-dentifrici	$3
-deroghe	$1
 desideri	d,Ezid'E:RI	$only
-desossicortisol	$6
-detraibil	det@-*a'ibil
 diamin	di'a:min
 discepol	$2	$alt
 disguid	dizgw2'id
@@ -1415,21 +1405,10 @@ gazzetta	ga|dz:'Et:a
 genesi	$1
 gentil	$2
 geroglifici	dZeRogl'ifitSi
-ghiacciol	gIatS:'ol
+ghiacciol	giatS:'ol
 giovani	dZ'ovani
 giovanil	$3
 gladiol	$2
-glicemia	glitSem'ia
-glicemici	glitS'emitSi
-glicerofosforici	glitSeRofosf'oRitSi
-glicerol	glitSeR'Ol
-glicolici	glik'olitSi
-glutine	$1
-gomitoli	$2
-gonartria	$3
-grandin	$1
-grigia	$1
-grumoli	$1
 guaiscono	gua'iskono
 hinterland	$1
 icono	$2
@@ -1453,7 +1432,6 @@ intraspecifici	$4
 introversi	$3
 intuito	int'u:jto
 ipercheratosi	$5
-iperglicemici	ipe@-*glitS'EmitSi
 ipertono	$3
 ipogastrici	$3
 ipopotam	$3
@@ -1493,7 +1471,7 @@ mezzosoprano	medz:osop@-*'ano
 microb	$1
 microfoni	$2	$alt2
 microtono	$3
-miglior	mil^'O@-*
+miglior	$2 $alt2
 milliampere	mil:i||amp'e@-*
 miop	m'i;op
 monopattin	$3
@@ -1542,7 +1520,7 @@ patrie	$1
 patrono	$2
 pedine	$2
 pedonal	$3
-peggior	$2 $alt
+peggior	$2 $alt2
 perigastrici	$3
 peripezia	$4
 peripezie	pe@-*ipets'ie
@@ -1596,7 +1574,7 @@ repubblicano	$4
 restio	@-*est'io
 revoche	$1
 riavvia	@-*iav:'i#a
-riavvio	@-*iav:'IO
+riavvio	@-*iav:'iO
 ricordino	$3 $noun
 rigoli	$1
 rossonere	$3 $alt2
@@ -1696,7 +1674,7 @@ veterano	$3
 vicere	$3 $alt2
 videocamera	$4
 vinacciol	$3
-visualizzazion	vizw2ali|dz:atsj'on
+visualizzazion	vizw2ali|dz:atsi'on
 vittime	$1
 vocaboli	$2
 voragini	$2
@@ -1708,6 +1686,7 @@ cos'hai	koz'a:i
 cos'è	koz'E
 cos'altro	koz'a:lt@-*o/
 dov'è	dov'E
+dov'erano	dov'ERano
 qual'è	kwal''E
 tant'è	taNt'E
 l'ancora	l'ankoRa
@@ -1753,7 +1732,7 @@ alessano	$3
 amsterdam	$1
 andorrano	$3
 angeles	$1
-anglican	aNglik'an
+
 angola	$2 $capital
 aostano	aost'ano
 arab $1
@@ -2135,7 +2114,7 @@ stazzano	$2
 stezzano	$2
 submontano	$3
 survoltano	$3
-svizzer	zv'its2:eR
+svizzer	zv'Its2:eR
 swahili	swah'ilI
 sydney	$1
 tagikistan	$2
@@ -2345,6 +2324,7 @@ freud	f@-*'Oid $only
 gandolfi  $alt
 garcía	_^_ES
 gargiul	$2
+gasperi	$1
 gavino	$2
 genesia	$2
 george	dZ'O@-*dZ	$onlys
@@ -2413,6 +2393,7 @@ landolf  $alt
 laurenzi  $alt
 lee	_^_en $capital
 lennon	_^_EN
+leonard	l'EonaRd	$onlys
 leopold  $alt
 lewis	l'uIs
 ligabue	$3
@@ -2638,7 +2619,7 @@ accampano	$2
 accarezzano	$3 $alt
 accecano	$2
 accechino	$2
-acceler	atS:'E:l,ER
+acceler	atS:'Ele:R
 accelerano	atS:'E:l,eRano
 accelerino	$2
 accennino	$2
@@ -2850,6 +2831,7 @@ attacchino	$2
 atteggino	$2
 attendano	$2
 attentino	$2
+attenuano	$2
 atterrano	$2
 atterrino	$2
 attestino	$2
@@ -2899,6 +2881,7 @@ barino	$1
 basano	$1
 bastino	$1
 bastono	$2
+battagliano	$2
 battezzat	bat:edz:'at
 battezzino	bat:'edz:ino
 beccano	$1
@@ -2955,6 +2938,7 @@ catturano	$2
 catturino	$2
 causano	$1
 causino	$1
+cavalcano	$2
 celebr	$1
 celebrano	$1
 celebrino	$1
@@ -3055,8 +3039,7 @@ contino	$1
 continuano	$2
 continuino	$2
 contraddicano	$3
-contraddici	$3
-contraddico	$3
+contraddic	$3
 contraddistinguano	$4
 contrattaccano	$3
 contrastino	$2
@@ -3112,6 +3095,7 @@ degradano	$2
 degradino	$2
 delegano	$1
 deleghino	$1
+deleghi	$1
 delimit	$2
 delimitano	$2
 delimitino	$2
@@ -3255,6 +3239,7 @@ entrano	$1
 entrino	$1
 enuncino	$2
 equivalere	$4
+eredit	$2
 ereditano	$2
 ereditino	$2
 erog	$1
@@ -3369,6 +3354,7 @@ germogliano	$2
 ghignano	$1
 giacere	$2
 giocano	$1
+giochino	$1 $verb
 gioimmo	dZo'i:m:o
 gioire	dZo'iRE
 gioirne	dZo'i:@-*ne
@@ -4690,6 +4676,8 @@ zuccherano	$1
 (quando desideri)	kwando||_|dez'i:deRi
 (quale desideri)	kw2ale||dez'i:deRi
 (quindi desideri)	kw,indi||_dez'i:deRi
+ch'era	k'E*a
+ch'erano	k'E*ano
 
 // pronominal verbs
 

--- a/dictsource/it_listx
+++ b/dictsource/it_listx
@@ -54,8 +54,8 @@ aculei	$2
 aculeo $2
 adamas $3
 addebit $2  $alt2
-addom	$2 $alt
 addio	ad:'io/
+addom	$2 $alt
 adenoipofisi $5
 adenomer $3
 aderbale $2
@@ -203,8 +203,6 @@ anfipoli $2
 anfor $1
 angel $1
 angiogenesi $3
-anglicanesimo	anglikan'ezimo
-anglicizzazione	anglitSidz:atsi'One
 anglosassone $3
 anglosassoni $3
 angol $1
@@ -1133,6 +1131,7 @@ dataria $3
 dauphine $4
 davver $2  $alt2
 debit $1  $alt2
+debol	$1
 debole $1
 dec  $alt
 decameron	$2 $only
@@ -1140,30 +1139,38 @@ decapoli $2
 decebal $2  $alt
 decenni  $alt
 deci  $alt
+decim	$1
+decimonono	$4
+decine	$2
+decrepit	$2
 decret  $alt
 decubit $2
 dedit $1
 deficit $1  $alt
 deg  $alt
 deiotar $2
-delebi  $alt
-deleg $1
+deleg	$1
+deleghe	$1
 deleteria	$3 $alt
 deleterie	$3 $alt
 deliber $2
 demerit	$2
 democrit $2
 dentice  $alt
+dentifrici	$3
 deposit $2
 depost  $alt2
 derattizzazion	deRat:idz:atsi'on
 derid	$2
 derog $1
+deroghe	$1
 desdemon  $alt
 desi  $alt
 desman  $alt
+desossicortisol	$6
 despot $1  $alt
 desuet  $alt
+detraibil	det@-*a'ibil
 deuteronomi  $alt
 deuterostomi  $alt
 devot  $alt
@@ -1486,8 +1493,8 @@ estet  $alt
 estraibil	est@-*a'ibil
 etanol $3
 eteocle $2
-etereo	$2
 eterei	$2
+etereo	$2
 eterocefal $4  $alt
 eterotteri  $alt
 etiope $2
@@ -1684,8 +1691,8 @@ franciacort  $alt2
 francoboll  $alt2
 frassin $1
 frattemp  $alt
-freccine	$2
 freccette  $alt2
+freccine	$2
 fredd	$alt2
 fregol	$1
 fren  $alt2
@@ -1793,22 +1800,11 @@ gladiol $2
 glaucofane $3
 gleb  $alt
 glia  gl'i:a
-glif	gl'if
-glifosat	glifoz'at
-glicemic	glitS'Emik
-glicemiche	glitS'emike
-glicemie	glitSem'i;e
-gliceridi	glitS'eRidi
-glicerin	glitSe*'in
-glicerofosforic	glitSeRofosf'oRik
-glicerol $3
+glicerol	glitSeR'Ol
 glicidi	glitS'idI
 glicin	gl'itSin
-glicine	gl'itSine
-glicolic	glik'olik
-glicolisi	glikol'izI
-gliconeo	glik'O:n,Eo
-glicoprotein	glikop@-*ote'in
+glif	gl'if
+glifosat	glifoz'at
 gliptodontid	gliptod'Ontid
 glissando	gliss'ando
 glissare	gliss'aRe
@@ -1823,6 +1819,7 @@ glucidi	$2
 glucosi  $alt
 glutei	$1
 gluteo $1
+glutine	$1
 gnom  $alt
 gocciolio	$3
 goleador $4
@@ -1830,9 +1827,11 @@ golia $2
 goliardia $4
 goliardie	golia@-*d'i:e
 gomit $1  $alt2
+gomitoli	$2
 gomm  $alt2
 gommoresine	$3
 gonars $2
+gonartria	$3
 goni  $alt
 gonn  $alt2
 gonnes  $alt
@@ -1847,6 +1846,7 @@ gozz  $alt2
 gradoli $1
 grafem  $alt
 grandigia	$2
+grandin	$1
 gratteri $2
 gratuit	g@-*at'u:it
 gravimetr $2
@@ -1854,10 +1854,12 @@ gravit	$1
 grec  $alt
 grembiul	g@-*embI'ul
 greve  $alt
+grigia	$1
 grom  $alt2
 grondone	$2
 grosi  $alt
 grossomod $3  $alt
+grumoli	$1
 guarani $3
 guardamacchine	$3
 guardarob  $alt
@@ -1991,7 +1993,6 @@ iperborea	$3
 iperboree	$3
 iperborei	$3
 iperboreo	$3
-iperglicemic	iperglitS'emik
 ipernucleo	$3
 ipersonnia $4
 ipertermia $4
@@ -2001,7 +2002,6 @@ ipocentr  $alt
 ipocloridria $5
 ipocondria $4
 ipofisi	ip'O:fizI
-ipoglicemic	ipoglitS'emik
 ipotalam $3
 ipotec  $alt
 ipotermia $4
@@ -2141,22 +2141,21 @@ litania $3
 litanie	litan'ie
 litigi	$2
 lob  $alt
-lod  $alt
-lodol $1
-lodz  $alt2
+lod	$alt
+lodol	$1
 log  $alt
 loggia  $alt
 logli  $alt
 logorio	$3
 lol  $alt
+lombrichi	$2
+lombrico	$2
 long  $alt
 longhi  $alt
 lonicer $2
 lord  $alt2
 loreggia  $alt
-lorsic  $alt2
 lot  $alt
-lovere  $alt2
 lucciolio	$3
 lucifug $2
 lugubre $1
@@ -2543,7 +2542,6 @@ niobe $1
 nippur $2
 niscemi  $alt
 niteroi  $alt2
-nitroglicerin	nit@-*oglitSeR'in
 nizzard	nits2:'a@-*d
 nocciol	$2	$alt
 noccioli	$1 $alt
@@ -2837,7 +2835,7 @@ peptidi  $alt
 percentil	$3
 percors  $alt2
 perdio	pe@-*||d'i:o
-perdit $1
+perdit	$1
 perdon	$2 $alt2
 pereg $1
 peretol $2
@@ -2845,7 +2843,6 @@ perez  $alt2
 perfett  $alt
 perfugas $1
 pergam $1
-perieget  $alt
 perier $1  $alt2
 perifrasi $2
 perim $2
@@ -2855,9 +2852,10 @@ peripl $1
 peristasi $2
 perizom	pe*idz'Om
 perlomen  $alt2
+permaflex	$1
 permafrost $1
 permut $1
-peronospor $3  $alt
+peronospor	$3  $alt
 perpetua  $alt
 perpetuo  $alt
 perregaux $2
@@ -3176,6 +3174,7 @@ quiete  $alt
 quindicesim  $alt
 quindicine	$3
 quot  $alt
+ra	@-*'a
 rabarbar $2
 racale $1
 racem  $alt
@@ -3203,11 +3202,8 @@ razzi	@-*'adz:I
 razzia $2
 razzie	@-*a/ts2:'ie
 razzo	@-*'a|dz:o
-ra	@-*'a
 re	@-*'E
 re	@-*'e	$capital
-ri	@-*I $only
-ro	@-*'O
 rebbi  $alt2
 recapit $2
 recared  $alt
@@ -3244,8 +3240,8 @@ resin $1
 respons  $alt
 ret	$alt2
 retin	$1
-retino	$2
 retini	$2
+retino	$2
 retinol $3
 retorbid  $alt2
 retore $1
@@ -3259,6 +3255,7 @@ revere  $alt2
 revoc $1
 revolver  $alt
 rhea  $alt2
+ri	@-*I $only
 riassett  $alt
 ribattezzare	@-*i_bat:edz:'aRe
 ribec  $alt
@@ -3309,6 +3306,7 @@ rivincit $2
 rizzare	@-*its2:'aRe
 rizzati	@-*its2:'ati
 rizziconi $2
+ro	@-*'O
 rob  $alt
 robbi  $alt
 robbia  $alt
@@ -3902,8 +3900,8 @@ tholos  $alt2
 tiberiade $3
 tiburon $3
 ticchettio	tik:et:'io
-timpan $1
 timoria	$3
+timpan $1
 tindari $1
 tinian $2
 tintoria $3
@@ -3981,8 +3979,8 @@ trascors  $alt2
 tratalias $3
 traversie	$2
 travesi  $alt
-trebaseleghe $3  $alt2
 tre	t@-*'e
+trebaseleghe $3  $alt2
 tredicesim  $alt
 tredici  $alt2
 tremil $2
@@ -4005,7 +4003,6 @@ trienni  $alt
 trifogli  $alt
 trifor $1
 trigemin $2
-trigliceridi	t@-*iglitS'ERidI
 triglif $1
 trimer $1
 trimetr $1

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -1,7 +1,7 @@
 
 // Italian translation rules
 // This file is UTF-8 encoded
-// Last update: 2017 january 5 by Chris <llajta2012@gmail.com>
+// Last update: 2017 february  4 by Chris <llajta2012@gmail.com>
 // letter groups
 // A  any vowel
 // C  any consonant
@@ -208,10 +208,11 @@
 	g	g
 	gg	g:
 	gh	g
+	gu (A	gw
 	g (Y	dZ
 	gi (A	dZ
 	gi (a_	dZ'i#  // [i] only if stressed
-	gì (a_	dZ'i#  // [i] only if stressed
+	gì (a_	dZ'i#
 	al) gie (_	dZ'iE
 	@Ar) gie (_	dZ'iE
 	fa) gie (_	dZ'iE
@@ -222,27 +223,29 @@
 	n)	gi (a_	dZ
 	gg (Y	dZ:
 	ggi (A	dZ:
+
+	gl (i	l^
+	gl (ì	l^
+	gli (A	l^
+	_) gl	gl
+	gli (cA	gli
+	gli (chA	gli
+	gn	n^
+	A) gn (A_	n^:
+
 	@) gger (L04_	=dZ:e@-*  // Pron.s verbs
 	AC) ger (L04_	=dZe@-*
 	esi) ger (L04_	=dZe@-*
 	eri) ger (L04_	=dZe@-*
 	_) giura (L07_	dZ'URa
 	godi (L04_	g'Odi
-	gl (i	l^
-	gl (ì	l^
-	gli (A	l^
-	_)	gl	gl
 	@) glier (L04_	=l^E@-*
 	@) guer (L04_	=gUe@-*
-	gn	n^
-	@) gn (A_	n^;
-	a) gn (A_	n^:
-	gu (A	gw
 	guono (_	=gw2ono   // verbs
 	o) gnano (_	=n^ano
 	A) gnano (_	n^'ano   // exceptions
 	@) ginano(_	=dZinano   // verbs
-		gano (_	=gano
+	gano (_	=gano
 	ggano (_	=g:a/no 
 	giono (_	dZ'Ono
 	n) guere (_	=gweRe
@@ -389,8 +392,10 @@
 
 .group o
 	o	o
-	oi	O%I
+	oi	O%i
 	oi (o_	oj
+	n) oi (_	oi
+	v) oi (_	oi
 	oi (sCA_	o'i
 	o (C%A_	O
 	o (CACA_	O
@@ -588,9 +593,9 @@
 .group u
 	u	u
 	_) u (A	w2
-	@)	u (dinY_  'u
-	@)	u (colo_  'u
-	@)	u (lA_	=u
+	@)	u (dinY_	'u
+	@) u (colo_	'u
+	@) u (lA_	=u
 	_) un' (P3t	un
 	@) u (A_	=u
 	A%C) u (A_	=u
@@ -609,8 +614,8 @@
 	v	v
 	vv	v:
 	vvi (A	v:i
-	C) vi (A	vI
-	C) vi (A_	=vI
+	C) vi (A	vi
+	C) vi (A_	=vi
 	A) vino (_	=vino  // verbs
 	@) vo (cano_	=vo
 	in) via (toL04_	vI'a

--- a/phsource/intonation
+++ b/phsource/intonation
@@ -144,7 +144,7 @@ nucleus  fall  92 80 76 8
 endtune
 
 
-// Italian:
+// italian (by  llajta@gmx.us)
 
 tune s4
 prehead   46 57
@@ -153,7 +153,7 @@ head       4 80 43 -8 -5
 headextend 0 63 38 13 0
 headlast 45 4 8
 nucleus0 fall 64 8
-nucleus  fall 68 18 22 8
+nucleus  fall 68 18 22 10
 endtune
 
 tune c4

--- a/phsource/ph_italian
+++ b/phsource/ph_italian
@@ -1,6 +1,6 @@
 ﻿
 //====================================================
-//  Italian, last update DECEMBER 28 2016 by Chris <llajta2012@gmail.com>
+//  Italian, last update February 4 2017 by Chris <llajta2012@gmail.com>
 //====================================================
 
 phoneme : //  Lengthen previous vowel by "length"
@@ -68,13 +68,21 @@ phoneme i
   vwl starttype #i endtype #i
   length 155
   IfNextVowelAppend(;)
-  IF thisPh(isWordEnd) AND thisPh(isNotStressed) AND NOT prevPhW(E) THEN
+  IF thisPh(isWordEnd) AND thisPh(isNotStressed) AND prevPhW(isNotVowel) THEN
     ChangePhoneme(I)
   ENDIF
-  IF thisPh(isNotStressed) AND prevPhW(s) AND nextPhW(#o) THEN
-    ChangePhoneme(j)
+  IF thisPh(isNotStressed) AND prevPhW(isNotVowel) AND nextPhW(isVowel) THEN
+    ChangePhoneme(i/) 
   ENDIF
   FMT(vwl_it/i)
+endphoneme
+
+phoneme i/
+  vwl starttype #i endtype #i
+  unstressed
+  length 130
+  IfNextVowelAppend(;)
+  FMT(vwl_it/i, 90)
 endphoneme
 
 phoneme i#    // Used for 'gia_' where [i] is only spoken if stressed
@@ -86,9 +94,9 @@ endphoneme
 
 phoneme I
   vwl starttype #i endtype #i
-  length 140
+  length 145
   IfNextVowelAppend(;)
-  FMT(vowel/i_4)
+  FMT(vowel/i_7)
 endphoneme
 
 

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -991,8 +991,9 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_SONORANT_MIN] = 130; // limit the shortening of sonorants before short vowels
 		tr->langopts.param[LOPT_REDUCE] = 1; // reduce vowels even if phonemes are specified in it_list
 		tr->langopts.param[LOPT_ALT] = 2; // call ApplySpecialAttributes2() if a word has $alt or $alt2
-		tr->langopts.numbers = NUM_SINGLE_VOWEL | NUM_OMIT_1_HUNDRED |NUM_DECIMAL_COMMA | NUM_ROMAN | NUM_DFRACTION_1 | NUM_ROMAN_CAPITALS | NUM_ROMAN_AFTER;
+		tr->langopts.numbers = NUM_SINGLE_VOWEL | NUM_OMIT_1_HUNDRED |NUM_DECIMAL_COMMA | NUM_DFRACTION_1 | NUM_ROMAN | NUM_ROMAN_CAPITALS | NUM_ROMAN_ORDINAL;
 		tr->langopts.numbers2 = NUM2_NO_TEEN_ORDINALS;
+		tr->langopts.roman_suffix = utf8_ordinal;
 		tr->langopts.accents = 2; // Say "Capital" after the letter.
 		SetLetterVowel(tr, 'y');
 	}

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -977,18 +977,14 @@ Translator *SelectTranslator(const char *name)
 		break;
 	case L('i', 't'): // Italian
 	{
-		static const short stress_lengths_it[8] =
-		{ 165, 130,  170, 150,  0, 0,  218, 305 };
-		static const unsigned char stress_amps_it[8] =
-		{ 16, 18, 17, 14, 20, 22, 22, 22 };
-
+		static const short stress_lengths_it[8] = { 165, 140, 150, 165, 0, 0, 218, 305 };
+		static const unsigned char stress_amps_it[8] = { 17, 15, 18, 16, 20, 22, 22, 22 };
 		SetupTranslator(tr, stress_lengths_it, stress_amps_it);
-
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 		tr->langopts.stress_rule = STRESSPOSN_2R;
-		tr->langopts.stress_flags = S_FINAL_NO_2 | S_PRIORITY_STRESS;
+		tr->langopts.stress_flags = S_NO_AUTO_2 | S_FINAL_DIM_ONLY | S_PRIORITY_STRESS;
 		tr->langopts.vowel_pause = 1;
-		tr->langopts.unstressed_wd1 = 2;
+		tr->langopts.unstressed_wd1 = 0;
 		tr->langopts.unstressed_wd2 = 2;
 		tr->langopts.param[LOPT_IT_LENGTHEN] = 2; // remove lengthen indicator from unstressed or non-penultimate syllables
 		tr->langopts.param[LOPT_IT_DOUBLING] = 1; // double the first consonant if the previous word ends in a stressed vowel (changed to =1, 23.01.2014 - only use if prev.word has $double)


### PR DESCRIPTION
In this PR:
IT: Removed automatic secondari stress #214 

IT: Unstressed final syllable is diminished 

IT: Preserve unstressed monosyllable words and allow secondary stress in multisillable words indicated as unstressed in it_list #214 . 

IT: Reading roman numerals as ordinals #215 

IT: last improvements tested on january 2017.
