### PR TITLE
categories.c: make "Invalid" the default return

### DIFF
--- a/src/ucd-tools/src/categories.c
+++ b/src/ucd-tools/src/categories.c
@@ -3534,6 +3534,8 @@ ucd_category_group ucd_get_category_group_for_category(ucd_category c)
 	case Ii:
 		return UCD_CATEGORY_GROUP_I;
 	}
+
+	return UCD_CATEGORY_GROUP_I;
 }
 
 ucd_category_group ucd_lookup_category_group(codepoint_t c)


### PR DESCRIPTION
`ucd_get_category_group_for_category` has no default return line outside of its switch statement, which can lead to the program not returning ANY value if the category passed doesn't match.

This fixes that by just returning `UCD_CATEGORY_GROUP_I` by default.

This fixes issue https://github.com/espeak-ng/espeak-ng/issues/309