### PR TITLE
Use stdbool instead of int (Issue #8)

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -116,7 +116,7 @@ static const char *help_text =
     "-h, --help Show this help.\n";
 
 int samplerate;
-int quiet = 0;
+bool quiet = false;
 unsigned int samples_total = 0;
 unsigned int samples_split = 0;
 unsigned int samples_split_seconds = 0;
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
 			pitch = atoi(optarg2);
 			break;
 		case 'q':
-			quiet = 1;
+			quiet = true;
 			break;
 		case 'f':
 			strncpy0(filename, optarg2, sizeof(filename));
@@ -443,7 +443,7 @@ int main(int argc, char **argv)
 		case 0x102: // --compile
 			strncpy0(voicename, optarg2, sizeof(voicename));
 			flag_compile = c;
-			quiet = 1;
+			quiet = true;
 			break;
 		case 0x103: // --punct
 			option_punctuation = 1;

--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,18 +43,18 @@
 // my_mutex: protects my_thread_is_talking,
 // my_stop_is_required, and the command fifo
 static pthread_mutex_t my_mutex;
-static int my_command_is_running = 0;
+static bool my_command_is_running = false;
 static pthread_cond_t my_cond_command_is_running;
-static int my_stop_is_required = 0;
+static bool my_stop_is_required = false;
 
 // my_thread: reads commands from the fifo, and runs them.
 static pthread_t my_thread;
 
 static pthread_cond_t my_cond_start_is_required;
-static int my_start_is_required = 0;
+static bool my_start_is_required = false;
 
 static pthread_cond_t my_cond_stop_is_acknowledged;
-static int my_stop_is_acknowledged = 0;
+static bool my_stop_is_acknowledged = false;
 
 static void *say_thread(void *);
 
@@ -92,11 +93,11 @@ void fifo_init()
 
 	// leave once the thread is actually started
 	assert(-1 != pthread_mutex_lock(&my_mutex));
-	while (my_stop_is_acknowledged == 0) {
+	while (my_stop_is_acknowledged == false) {
 		while ((pthread_cond_wait(&my_cond_stop_is_acknowledged, &my_mutex) == -1) && errno == EINTR)
 			;
 	}
-	my_stop_is_acknowledged = 0;
+	my_stop_is_acknowledged = false;
 	pthread_mutex_unlock(&my_mutex);
 }
 
@@ -111,7 +112,7 @@ espeak_ng_STATUS fifo_add_command(t_espeak_command *the_command)
 		return status;
 	}
 	
-	my_start_is_required = 1;
+	my_start_is_required = true;
 	pthread_cond_signal(&my_cond_start_is_required);
 
 	while (my_start_is_required && !my_command_is_running) {
@@ -147,7 +148,7 @@ espeak_ng_STATUS fifo_add_commands(t_espeak_command *command1, t_espeak_command 
 		return status;
 	}
 
-	my_start_is_required = 1;
+	my_start_is_required = true;
 	pthread_cond_signal(&my_cond_start_is_required);
 	
 	while (my_start_is_required && !my_command_is_running) {
@@ -168,21 +169,21 @@ espeak_ng_STATUS fifo_stop()
 	if ((status = pthread_mutex_lock(&my_mutex)) != ENS_OK)
 		return status;
 
-	int a_command_is_running = 0;
+	bool a_command_is_running = false;
 	if (my_command_is_running) {
-		a_command_is_running = 1;
-		my_stop_is_required = 1;
-		my_stop_is_acknowledged = 0;
+		a_command_is_running = true;
+		my_stop_is_required = true;
+		my_stop_is_acknowledged = false;
 	}
 
 	if (a_command_is_running) {
-		while (my_stop_is_acknowledged == 0) {
+		while (my_stop_is_acknowledged == false) {
 			while ((pthread_cond_wait(&my_cond_stop_is_acknowledged, &my_mutex) == -1) && errno == EINTR)
 				continue; // Restart when interrupted by handler
 		}
 	}
 
-	my_stop_is_required = 0;
+	my_stop_is_required = false;
 	if ((status = pthread_mutex_unlock(&my_mutex)) != ENS_OK)
 		return status;
 
@@ -196,7 +197,7 @@ int fifo_is_busy()
 
 static int sleep_until_start_request_or_inactivity()
 {
-	int a_start_is_required = 0;
+	int a_start_is_required = false;
 
 	// Wait for the start request (my_cond_start_is_required).
 	// Besides this, if the audio stream is still busy,
@@ -224,7 +225,7 @@ static int sleep_until_start_request_or_inactivity()
 		assert(gettimeofday(&tv, NULL) != -1);
 
 		if (err == 0)
-			a_start_is_required = 1;
+			a_start_is_required = true;
 	}
 	pthread_mutex_unlock(&my_mutex);
 	return a_start_is_required;
@@ -236,9 +237,9 @@ static espeak_ng_STATUS close_stream()
 	if (status != ENS_OK)
 		return status;
 
-	int a_stop_is_required = my_stop_is_required;
+	bool a_stop_is_required = my_stop_is_required;
 	if (!a_stop_is_required)
-		my_command_is_running = 1;
+		my_command_is_running = true;
 
 	status = pthread_mutex_unlock(&my_mutex);
 
@@ -247,7 +248,7 @@ static espeak_ng_STATUS close_stream()
 		if (status == ENS_OK)
 			status = a_status;
 
-		my_command_is_running = 0;
+		my_command_is_running = false;
 		a_stop_is_required = my_stop_is_required;
 
 		a_status = pthread_mutex_unlock(&my_mutex);
@@ -263,7 +264,7 @@ static espeak_ng_STATUS close_stream()
 			if((a_status = pthread_mutex_lock(&my_mutex)) != ENS_OK)
 				return a_status;
 
-			my_stop_is_acknowledged = 1;
+			my_stop_is_acknowledged = true;
 			a_status = pthread_cond_signal(&my_cond_stop_is_acknowledged);
 			if(a_status != ENS_OK)
 				return a_status;
@@ -283,33 +284,33 @@ static void *say_thread(void *p)
 
 	// announce that thread is started
 	assert(-1 != pthread_mutex_lock(&my_mutex));
-	my_stop_is_acknowledged = 1;
+	my_stop_is_acknowledged = true;
 	assert(-1 != pthread_cond_signal(&my_cond_stop_is_acknowledged));
 	assert(-1 != pthread_mutex_unlock(&my_mutex));
 
-	int look_for_inactivity = 0;
+	bool look_for_inactivity = false;
 
 	while (1) {
-		int a_start_is_required = 0;
+		bool a_start_is_required = false;
 		if (look_for_inactivity) {
 			a_start_is_required = sleep_until_start_request_or_inactivity();
 			if (!a_start_is_required)
 				close_stream();
 		}
-		look_for_inactivity = 1;
+		look_for_inactivity = true;
 
 		int a_status = pthread_mutex_lock(&my_mutex);
 		assert(!a_status);
 
 		if (!a_start_is_required) {
-			while (my_start_is_required == 0) {
+			while (my_start_is_required == false) {
 				while ((pthread_cond_wait(&my_cond_start_is_required, &my_mutex) == -1) && errno == EINTR)
 					continue; // Restart when interrupted by handler
 			}
 		}
 
 
-		my_command_is_running = 1;
+		my_command_is_running = true;
 
 		assert(-1 != pthread_cond_broadcast(&my_cond_command_is_running));
 		assert(-1 != pthread_mutex_unlock(&my_mutex));
@@ -320,13 +321,13 @@ static void *say_thread(void *p)
 			t_espeak_command *a_command = (t_espeak_command *)pop();
 
 			if (a_command == NULL) {
-				my_command_is_running = 0;
+				my_command_is_running = false;
 				a_status = pthread_mutex_unlock(&my_mutex);
 			} else {
-				my_start_is_required = 0;
+				my_start_is_required = false;
 
 				if (my_stop_is_required)
-					my_command_is_running = 0;
+					my_command_is_running = false;
 				a_status = pthread_mutex_unlock(&my_mutex);
 
 				if (my_command_is_running)
@@ -341,10 +342,10 @@ static void *say_thread(void *p)
 			init(1);
 
 			assert(-1 != pthread_mutex_lock(&my_mutex));
-			my_start_is_required = 0;
+			my_start_is_required = false;
 
 			// acknowledge the stop request
-			my_stop_is_acknowledged = 1;
+			my_stop_is_acknowledged = true;
 			int a_status = pthread_cond_signal(&my_cond_stop_is_acknowledged);
 			assert(a_status != -1);
 			pthread_mutex_unlock(&my_mutex);

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -118,8 +119,8 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 	int alternative;
 	int delete_count;
 	int word_start;
-	int inserted;
-	int deleted;
+	bool inserted;
+	bool deleted;
 	PHONEME_DATA phdata;
 
 	int n_ph_list3;
@@ -285,8 +286,8 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 	for (j = 0; insert_ph || ((j < n_ph_list3) && (ix < N_PHONEME_LIST-3)); j++) {
 		plist3 = &ph_list3[j];
 
-		inserted = 0;
-		deleted = 0;
+		inserted = false;
+		deleted = false;
 		if (insert_ph != 0) {
 			// we have a (linking) phoneme which we need to insert here
 			next = phoneme_tab[plist3->phcode];      // this phoneme, i.e. after the insert
@@ -311,7 +312,7 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 			ph = phoneme_tab[insert_ph];
 			plist3->ph = ph;
 			insert_ph = 0;
-			inserted = 1; // don't insert the same phoneme repeatedly
+			inserted = true; // don't insert the same phoneme repeatedly
 		} else {
 			// otherwise get the next phoneme from the list
 			if (plist3->sourceix != 0)
@@ -339,7 +340,7 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 			next = phoneme_tab[alternative];
 		}
 
-		if (((alternative = phdata.pd_param[pd_INSERTPHONEME]) > 0) && (inserted == 0)) {
+		if (((alternative = phdata.pd_param[pd_INSERTPHONEME]) > 0) && (inserted == false)) {
 			// PROBLEM: if we insert a phoneme before a vowel then we loose the stress.
 			PHONEME_TAB *ph2;
 			ph2 = ph;
@@ -369,7 +370,7 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 			plist3->phcode = alternative;
 
 			if (alternative == 1)
-				deleted = 1; // NULL phoneme, discard
+				deleted = true; // NULL phoneme, discard
 			else {
 				if (ph->type == phVOWEL) {
 					plist3->synthflags |= SFLAG_SYLLABLE;
@@ -384,7 +385,7 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 			}
 		}
 
-		if ((ph->type == phVOWEL) && (deleted == 0)) {
+		if ((ph->type == phVOWEL) && (deleted == false)) {
 			PHONEME_LIST *p;
 
 			// Check for consecutive unstressed syllables, even across word boundaries.
@@ -483,7 +484,7 @@ void MakePhonemeList(Translator *tr, int post_pause, int start_sentence)
 		if ((insert_ph == 0) && (phdata.pd_param[pd_APPENDPHONEME] != 0))
 			insert_ph = phdata.pd_param[pd_APPENDPHONEME];
 
-		if (deleted == 0) {
+		if (deleted == false) {
 			phlist[ix].ph = ph;
 			phlist[ix].type = ph->type;
 			phlist[ix].env = PITCHfall; // default, can be changed in the "intonation" module

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -303,7 +304,7 @@ static char *WritePitch(int env, int pitch1, int pitch2, int split, int final)
 	return output;
 }
 
-int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, int resume, FILE *f_mbrola)
+int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, bool resume, FILE *f_mbrola)
 {
 	// Generate a mbrola pho file
 	unsigned int name;
@@ -317,7 +318,7 @@ int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, int resume, FILE *f_mbr
 	PHONEME_DATA phdata;
 	FMT_PARAMS fmtp;
 	int pause = 0;
-	int released;
+	bool released;
 	int name2;
 	int control;
 	int done;
@@ -418,11 +419,11 @@ int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, int resume, FILE *f_mbr
 			done = 1;
 			break;
 		case phSTOP:
-			released = 0;
-			if (next->type == phVOWEL) released = 1;
-			if (next->type == phLIQUID && !next->newword) released = 1;
+			released = false;
+			if (next->type == phVOWEL) released = true;
+			if (next->type == phLIQUID && !next->newword) released = true;
 
-			if (released == 0)
+			if (released == false)
 				p->synthflags |= SFLAG_NEXT_PAUSE;
 			InterpretPhoneme(NULL, 0, p, &phdata, NULL);
 			len = DoSample3(&phdata, 0, -1);
@@ -505,7 +506,7 @@ int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, int resume, FILE *f_mbr
 	return 0;
 }
 
-int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
+int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 {
 	FILE *f_mbrola = NULL;
 
@@ -517,13 +518,13 @@ int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 		f_mbrola = f_trans;
 	}
 
-	int again = MbrolaTranslate(phoneme_list, *n_ph, resume, f_mbrola);
+	int  again = MbrolaTranslate(phoneme_list, *n_ph, resume, f_mbrola);
 	if (!again)
 		*n_ph = 0;
 	return again;
 }
 
-int MbrolaFill(int length, int resume, int amplitude)
+int MbrolaFill(int length, bool resume, int amplitude)
 {
 	// Read audio data from Mbrola (length is in millisecs)
 
@@ -578,7 +579,7 @@ espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans, 
 	return ENS_NOT_SUPPORTED;
 }
 
-int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
+int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 {
 	(void)phoneme_list; // unused parameter
 	(void)n_ph; // unused parameter
@@ -586,7 +587,7 @@ int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 	return 0;
 }
 
-int MbrolaFill(int length, int resume, int amplitude)
+int MbrolaFill(int length, bool resume, int amplitude)
 {
 	(void)length; // unused parameter
 	(void)resume; // unused parameter

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -333,19 +333,19 @@ unsigned char *GetEnvelope(int index)
 	return (unsigned char *)&phondata_ptr[index];
 }
 
-static void SetUpPhonemeTable(int number, int recursing)
+static void SetUpPhonemeTable(int number, bool recursing)
 {
 	int ix;
 	int includes;
 	int ph_code;
 	PHONEME_TAB *phtab;
 
-	if (recursing == 0)
+	if (recursing == false)
 		memset(phoneme_tab_flags, 0, sizeof(phoneme_tab_flags));
 
 	if ((includes = phoneme_tab_list[number].includes) > 0) {
 		// recursively include base phoneme tables
-		SetUpPhonemeTable(includes-1, 1);
+		SetUpPhonemeTable(includes-1, true);
 	}
 
 	// now add the phonemes from this table
@@ -364,7 +364,7 @@ static void SetUpPhonemeTable(int number, int recursing)
 void SelectPhonemeTable(int number)
 {
 	n_phoneme_tab = 0;
-	SetUpPhonemeTable(number, 0); // recursively for included phoneme tables
+	SetUpPhonemeTable(number, false); // recursively for included phoneme tables
 	n_phoneme_tab++;
 	current_phoneme_table = number;
 }

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1127,7 +1128,7 @@ void DoEmbedded(int *embix, int sourceix)
 	} while ((word & 0x80) == 0);
 }
 
-int Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
+int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 {
 	static int ix;
 	static int embedded_ix;
@@ -1136,10 +1137,10 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 	PHONEME_LIST *next;
 	PHONEME_LIST *next2;
 	PHONEME_LIST *p;
-	int released;
+	bool released;
 	int stress;
 	int modulation;
-	int pre_voiced;
+	bool  pre_voiced;
 	int free_min;
 	int value;
 	unsigned char *pitch_env = NULL;
@@ -1164,7 +1165,7 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 	if (mbrola_name[0] != 0)
 		return MbrolaGenerate(phoneme_list, n_ph, resume);
 
-	if (resume == 0) {
+	if (resume == false) {
 		ix = 1;
 		embedded_ix = 0;
 		word_count = 0;
@@ -1239,14 +1240,14 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 			p->std_length = p->ph->std_length;
 			break;
 		case phSTOP:
-			released = 0;
+			released = false;
 			ph = p->ph;
 			if (next->type == phVOWEL)
-				released = 1;
+				released = true;
 			else if (!next->newword) {
-				if (next->type == phLIQUID) released = 1;
+				if (next->type == phLIQUID) released = true;
 			}
-			if (released == 0)
+			if (released == false)
 				p->synthflags |= SFLAG_NEXT_PAUSE;
 
 			if (ph->phflags & phPREVOICE) {
@@ -1280,15 +1281,15 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume)
 			memset(&fmtp, 0, sizeof(fmtp));
 			fmtp.fmt_control = pd_DONTLENGTHEN;
 
-			pre_voiced = 0;
+			pre_voiced = false;
 			if (next->type == phVOWEL) {
 				DoAmplitude(p->amp, NULL);
 				DoPitch(envelope_data[p->env], p->pitch1, p->pitch2);
-				pre_voiced = 1;
+				pre_voiced = true;
 			} else if ((next->type == phLIQUID) && !next->newword) {
 				DoAmplitude(next->amp, NULL);
 				DoPitch(envelope_data[next->env], next->pitch1, next->pitch2);
-				pre_voiced = 1;
+				pre_voiced = true;
 			} else {
 				if (last_pitch_cmd < 0) {
 					DoAmplitude(next->amp, NULL);

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -17,6 +17,8 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -492,7 +494,7 @@ unsigned char *LookupEnvelope(int ix);
 espeak_ng_STATUS LoadPhData(int *srate, espeak_ng_ERROR_CONTEXT *context);
 
 void SynthesizeInit(void);
-int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume);
+int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume);
 void MakeWave2(PHONEME_LIST *p, int n_ph);
 int  SpeakNextClause(int control);
 void SetSpeed(int control);
@@ -536,9 +538,9 @@ extern SOUND_ICON soundicon_tab[N_SOUNDICON_TAB];
 
 espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans, int *srate);
 espeak_ng_STATUS SetParameter(int parameter, int value, int relative);
-int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, int resume, FILE *f_mbrola);
-int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, int resume);
-int MbrolaFill(int length, int resume, int amplitude);
+int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, bool resume, FILE *f_mbrola);
+int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume);
+int MbrolaFill(int length, bool resume, int amplitude);
 void MbrolaReset(void);
 void DoEmbedded(int *embix, int sourceix);
 void DoMarker(int type, int char_posn, int length, int value);

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -549,7 +550,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 	char word_copy2[N_WORD_BYTES];
 	int word_copy_length;
 	char prefix_chars[0x3f + 2];
-	int found = 0;
+	bool found = false;
 	int end_flags;
 	int c_temp; // save a character byte while we temporarily replace it with space
 	int first_char;
@@ -650,7 +651,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 				strcpy(word_out, word1);
 
 			return dictionary_flags[0];
-		} else if ((found == 0) && (dictionary_flags[0] & FLAG_SKIPWORDS) && !(dictionary_flags[0] & FLAG_ABBREV)) {
+		} else if ((found == false) && (dictionary_flags[0] & FLAG_SKIPWORDS) && !(dictionary_flags[0] & FLAG_ABBREV)) {
 			// grouped words, but no translation.  Join the words with hyphens.
 			wordx = word1;
 			ix = 0;
@@ -741,7 +742,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 		if (wflags & FLAG_TRANSLATOR2)
 			return 0;
 		return dictionary_flags[0] & FLAG_SKIPWORDS; // for "b.c.d"
-	} else if (found == 0) {
+	} else if (found == false) {
 		// word's pronunciation is not given in the dictionary list, although
 		// dictionary_flags may have ben set there
 
@@ -812,7 +813,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 
 			c_temp = wordx[-1];
 
-			found = 0;
+			found = false;
 			confirm_prefix = 1;
 			for (loopcount = 0; (loopcount < 50) && (end_type & SUFX_P); loopcount++) {
 				// Found a standard prefix, remove it and retranslate
@@ -903,7 +904,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 					dictionary_flags[1] = dictionary_flags2[1];
 				} else
 					prefix_flags = 1;
-				if (found == 0) {
+				if (found == false) {
 					end_type = TranslateRules(tr, wordx, phonemes, N_WORD_PHONEMES, end_phonemes, wflags & (FLAG_HYPHEN_AFTER | FLAG_PREFIX_REMOVED), dictionary_flags);
 
 					if (phonemes[0] == phonSWITCH) {
@@ -945,10 +946,10 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 						if (found)
 							prefix_phonemes[0] = 0; // matched whole word, don't need prefix now
 
-						if ((found == 0) && (dictionary_flags2[0] != 0))
+						if ((found == false) && (dictionary_flags2[0] != 0))
 							prefix_flags = 1;
 					}
-					if (found == 0) {
+					if (found == false) {
 						found = LookupDictList(tr, &wordx, phonemes, dictionary_flags2, end_flags, wtab);  // without prefix and suffix
 						if (phonemes[0] == phonSWITCH) {
 							// change to another language in order to translate this word
@@ -962,7 +963,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 							dictionary_flags[1] = dictionary_flags2[1];
 						}
 					}
-					if (found == 0) {
+					if (found == false) {
 						if (end_type & SUFX_Q) {
 							// don't retranslate, use the original lookup result
 							strcpy(phonemes, phonemes2);

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -892,7 +893,7 @@ static int Wavegen()
 	}
 }
 
-static int PlaySilence(int length, int resume)
+static int PlaySilence(int length, bool resume)
 {
 	static int n_samples;
 	int value = 0;
@@ -904,7 +905,7 @@ static int PlaySilence(int length, int resume)
 	if (length == 0)
 		return 0;
 
-	if (resume == 0)
+	if (resume == false)
 		n_samples = length;
 
 	while (n_samples-- > 0) {
@@ -926,14 +927,14 @@ static int PlaySilence(int length, int resume)
 	return 0;
 }
 
-static int PlayWave(int length, int resume, unsigned char *data, int scale, int amp)
+static int PlayWave(int length, bool resume, unsigned char *data, int scale, int amp)
 {
 	static int n_samples;
 	static int ix = 0;
 	int value;
 	signed char c;
 
-	if (resume == 0) {
+	if (resume == false) {
 		n_samples = length;
 		ix = 0;
 	}
@@ -1231,9 +1232,9 @@ static void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *
 	}
 }
 
-static int Wavegen2(int length, int modulation, int resume, frame_t *fr1, frame_t *fr2)
+static int Wavegen2(int length, int modulation, bool resume, frame_t *fr1, frame_t *fr2)
 {
-	if (resume == 0)
+	if (resume == false)
 		SetSynth(length, modulation, fr1, fr2, wvoice);
 
 	return Wavegen();
@@ -1259,7 +1260,7 @@ static int WavegenFill2()
 	int length;
 	int result;
 	int marker_type;
-	static int resume = 0;
+	static bool resume = false;
 	static int echo_complete = 0;
 
 	while (out_ptr < out_end) {
@@ -1267,7 +1268,7 @@ static int WavegenFill2()
 			if (echo_complete > 0) {
 				// continue to play silence until echo is completed
 				resume = PlaySilence(echo_complete, resume);
-				if (resume == 1)
+				if (resume == true)
 					return 0; // not yet finished
 			}
 			return 1; // queue empty, close sound channel
@@ -1283,7 +1284,7 @@ static int WavegenFill2()
 			SetPitch(length, (unsigned char *)q[2], q[3] >> 16, q[3] & 0xffff);
 			break;
 		case WCMD_PAUSE:
-			if (resume == 0)
+			if (resume == false)
 				echo_complete -= length;
 			wdata.n_mix_wavefile = 0;
 			wdata.amplitude_fmt = 100;
@@ -1361,9 +1362,9 @@ static int WavegenFill2()
 
 		if (result == 0) {
 			WcmdqIncHead();
-			resume = 0;
+			resume = false;
 		} else
-			resume = 1;
+			resume = true;
 	}
 
 	return 0;


### PR DESCRIPTION
See issue #8, https://github.com/espeak-ng/espeak-ng/issues/8

There might still be some ints that could be changed to boolean.

Possible regressions in fifo.c:
int fifo_is_busy() and int fifo_is_command_enabled() used to return an int. Now they return a boolean. This might cause problems on systems where stdbool true/false is something else than 1/0.