### PR TITLE
Move definitions from tr_languages.c to language files

### DIFF
--- a/docs/voices.md
+++ b/docs/voices.md
@@ -25,6 +25,7 @@
   - [dictionary](#dictionary)
   - [dictrules](#dictrules)
   - [replace](#replace)
+  - [stressRule](#stressrule)
   - [stressLength](#stresslength)
   - [stressAdd](#stressadd)
   - [stressAmp](#stressamp)
@@ -371,6 +372,20 @@ e.g.
 
 The phoneme mnemonics can be defined for each language, but some are
 listed in [Phonemes](phonemes.md).
+
+### stressRule
+
+	stressRule <4 integer values>
+
+Four integer parameters. These correspond to:
+
+1. langopts->stress_rule (values in translate.h)
+2. langopts->stress_flags
+3. langopts->unstressed_wd1 (stress for $u word of 1 syllable)
+4. langopts->unstressed_wd2 (stress for $u word of >1 syllable) 
+
+If a value is not given, it defaults to zero. For example:
+"stressRule 2" is equal to "stressRule 2 0 0 0"
 
 ### stressLength
 

--- a/docs/voices.md
+++ b/docs/voices.md
@@ -384,8 +384,7 @@ Four integer parameters. These correspond to:
 3. langopts->unstressed_wd1 (stress for $u word of 1 syllable)
 4. langopts->unstressed_wd2 (stress for $u word of >1 syllable) 
 
-If a value is not given, it defaults to zero. For example:
-"stressRule 2" is equal to "stressRule 2 0 0 0"
+All parameters are not required. For example, "stressRule 2 1" is valid.
 
 ### stressLength
 

--- a/docs/voices.md
+++ b/docs/voices.md
@@ -30,7 +30,7 @@
   - [stressAmp](#stressamp)
   - [intonation](#intonation)
   - [dictmin](#dictmin)
-
+  - [letterVowel](#letterVowel)
 ----------
 
 A Voice file specifies a language (and possibly a language variant or
@@ -425,3 +425,9 @@ Used for some languages to detect if additional language data is
 installed. If the size of the compiled dictionary data for the language
 (the file `espeak-ng-data/*_dict`) is less than this size then a
 warning is given.
+
+### letterVowel
+
+	letterVowel <letter>
+
+Used for some languages to handle a certain letter as a vowel instead of consonant.

--- a/espeak-ng-data/lang/aav/vi
+++ b/espeak-ng-data/lang/aav/vi
@@ -3,3 +3,4 @@ language vi
 
 words 1
 pitch 80 118
+stressRule 0

--- a/espeak-ng-data/lang/art/eo
+++ b/espeak-ng-data/lang/art/eo
@@ -2,3 +2,4 @@ name Esperanto
 language eo
 
 apostrophe 2
+stressRule 2

--- a/espeak-ng-data/lang/art/ia
+++ b/espeak-ng-data/lang/art/ia
@@ -1,2 +1,3 @@
 name Interlingua
 language ia
+stressRule 2

--- a/espeak-ng-data/lang/art/jbo
+++ b/espeak-ng-data/lang/art/jbo
@@ -3,3 +3,4 @@ language jbo
 
 speed 80   // speed adjustment, percentage
 letterVowel y
+stressRule 2

--- a/espeak-ng-data/lang/art/jbo
+++ b/espeak-ng-data/lang/art/jbo
@@ -2,3 +2,4 @@ name Lojban
 language jbo
 
 speed 80   // speed adjustment, percentage
+letterVowel y

--- a/espeak-ng-data/lang/azc/nci
+++ b/espeak-ng-data/lang/azc/nci
@@ -2,5 +2,5 @@ name Nahuatl (Classical)
 language nci
 
 intonation 3
-stressrule 2
+stressRule 2
 stressLength  190  190  200  200  0  0  220  240

--- a/espeak-ng-data/lang/bat/lt
+++ b/espeak-ng-data/lang/bat/lt
@@ -1,2 +1,3 @@
 name Lithuanian
 language lt
+stressRule 2

--- a/espeak-ng-data/lang/bat/lv
+++ b/espeak-ng-data/lang/bat/lv
@@ -11,3 +11,4 @@ formant 0 95 100 100 -5
 tone 150 220 450 255 750 20 3500 255
 stressAmp 12 10 8 8 0 0 18 15
 stressLength 160 140 200 140 0 0 240 180
+stressRule 0

--- a/espeak-ng-data/lang/bnt/sw
+++ b/espeak-ng-data/lang/bnt/sw
@@ -2,3 +2,4 @@ name Swahili
 language sw
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/bnt/tn
+++ b/espeak-ng-data/lang/bnt/tn
@@ -2,3 +2,4 @@ name Setswana
 language tn
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/ccs/ka
+++ b/espeak-ng-data/lang/ccs/ka
@@ -1,2 +1,3 @@
 name Georgian
 language ka
+stressRule 0

--- a/espeak-ng-data/lang/cel/cy
+++ b/espeak-ng-data/lang/cel/cy
@@ -2,3 +2,5 @@ name Welsh
 language cy
 
 intonation 4
+letterVowel w
+letterVowel y

--- a/espeak-ng-data/lang/cel/cy
+++ b/espeak-ng-data/lang/cel/cy
@@ -4,3 +4,4 @@ language cy
 intonation 4
 letterVowel w
 letterVowel y
+stressRule 2

--- a/espeak-ng-data/lang/cel/ga
+++ b/espeak-ng-data/lang/cel/ga
@@ -2,3 +2,4 @@ name Gaelic (Irish)
 language ga
 
 dictrules 1  // fix for eclipsis
+stressRule 0

--- a/espeak-ng-data/lang/cel/gd
+++ b/espeak-ng-data/lang/cel/gd
@@ -2,3 +2,4 @@ name Gaelic (Scottish)
 language gd
 
 status testing
+stressRule 0

--- a/espeak-ng-data/lang/cus/om
+++ b/espeak-ng-data/lang/cus/om
@@ -2,3 +2,4 @@ name Oromo
 language om
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/dra/kn
+++ b/espeak-ng-data/lang/dra/kn
@@ -3,3 +3,4 @@ language kn
 
 intonation 2
 //consonants 80
+stressRule 0

--- a/espeak-ng-data/lang/dra/ml
+++ b/espeak-ng-data/lang/dra/ml
@@ -3,3 +3,4 @@ language ml
 
 intonation 2
 //consonants 80
+stressRule 13

--- a/espeak-ng-data/lang/dra/ta
+++ b/espeak-ng-data/lang/dra/ta
@@ -3,3 +3,4 @@ language ta
 
 intonation 2
 consonants 80
+stressRule 0

--- a/espeak-ng-data/lang/dra/te
+++ b/espeak-ng-data/lang/dra/te
@@ -5,3 +5,4 @@ status testing
 
 intonation 2
 //consonants 80
+stressRule 0

--- a/espeak-ng-data/lang/esx/kl
+++ b/espeak-ng-data/lang/esx/kl
@@ -1,3 +1,4 @@
 name Greenlandic
 language kl
 
+stressRule 12

--- a/espeak-ng-data/lang/eu
+++ b/espeak-ng-data/lang/eu
@@ -2,3 +2,4 @@ name Basque
 language eu
 
 status testing
+stressRule 1

--- a/espeak-ng-data/lang/gmq/da
+++ b/espeak-ng-data/lang/gmq/da
@@ -3,3 +3,4 @@ language da
 
 tunes s2 c2 q2 e2
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmq/da
+++ b/espeak-ng-data/lang/gmq/da
@@ -2,3 +2,4 @@ name Danish
 language da
 
 tunes s2 c2 q2 e2
+letterVowel y

--- a/espeak-ng-data/lang/gmq/is
+++ b/espeak-ng-data/lang/gmq/is
@@ -1,3 +1,4 @@
 name Icelandic
 language is
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmq/is
+++ b/espeak-ng-data/lang/gmq/is
@@ -1,2 +1,3 @@
 name Icelandic
 language is
+letterVowel y

--- a/espeak-ng-data/lang/gmq/nb
+++ b/espeak-ng-data/lang/gmq/nb
@@ -5,3 +5,4 @@ phonemes no
 dictionary no
 
 intonation 4
+letterVowel y

--- a/espeak-ng-data/lang/gmq/nb
+++ b/espeak-ng-data/lang/gmq/nb
@@ -6,3 +6,4 @@ dictionary no
 
 intonation 4
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmq/sv
+++ b/espeak-ng-data/lang/gmq/sv
@@ -1,2 +1,3 @@
 name Swedish
 language sv
+letterVowel y

--- a/espeak-ng-data/lang/gmq/sv
+++ b/espeak-ng-data/lang/gmq/sv
@@ -1,3 +1,4 @@
 name Swedish
 language sv
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmw/af
+++ b/espeak-ng-data/lang/gmw/af
@@ -7,3 +7,4 @@ status mature
 roughness 0
 pitch 63 120
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmw/af
+++ b/espeak-ng-data/lang/gmw/af
@@ -6,3 +6,4 @@ status mature
 
 roughness 0
 pitch 63 120
+letterVowel y

--- a/espeak-ng-data/lang/gmw/de
+++ b/espeak-ng-data/lang/gmw/de
@@ -2,3 +2,4 @@ name German
 language de
 
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/gmw/de
+++ b/espeak-ng-data/lang/gmw/de
@@ -1,2 +1,4 @@
 name German
 language de
+
+letterVowel y

--- a/espeak-ng-data/lang/gmw/en
+++ b/espeak-ng-data/lang/gmw/en
@@ -6,3 +6,4 @@ maintainer Reece H. Dunn <msclrhd@gmail.com>
 status mature
 
 tunes s1 c1 q1 e1
+stressRule 0

--- a/espeak-ng-data/lang/gmw/nl
+++ b/espeak-ng-data/lang/gmw/nl
@@ -1,2 +1,3 @@
 name Dutch
 language nl
+letterVowel y

--- a/espeak-ng-data/lang/gmw/nl
+++ b/espeak-ng-data/lang/gmw/nl
@@ -1,3 +1,4 @@
 name Dutch
 language nl
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/grk/el
+++ b/espeak-ng-data/lang/grk/el
@@ -1,2 +1,3 @@
 name Greek
 language el
+stressRule 2

--- a/espeak-ng-data/lang/grk/grc
+++ b/espeak-ng-data/lang/grk/grc
@@ -2,5 +2,6 @@ name Greek (Ancient)
 language grc
 
 stressLength 170 170  190 190  0 0  230 240
+stressRule 2
 dictrules 1
 words 3

--- a/espeak-ng-data/lang/inc/as
+++ b/espeak-ng-data/lang/inc/as
@@ -2,3 +2,5 @@ name Assamese
 language as
 
 status testing
+
+stressRule 0

--- a/espeak-ng-data/lang/inc/bn
+++ b/espeak-ng-data/lang/inc/bn
@@ -1,2 +1,3 @@
 name Bengali
 language bn
+stressRule 0

--- a/espeak-ng-data/lang/inc/bpy
+++ b/espeak-ng-data/lang/inc/bpy
@@ -1,2 +1,3 @@
 name Bishnupriya Manipuri
 language bpy
+stressRule 0

--- a/espeak-ng-data/lang/inc/gu
+++ b/espeak-ng-data/lang/inc/gu
@@ -2,3 +2,4 @@ name Gujarati
 language gu
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/inc/hi
+++ b/espeak-ng-data/lang/inc/hi
@@ -1,2 +1,3 @@
 name Hindi
 language hi
+stressRule 6

--- a/espeak-ng-data/lang/inc/mr
+++ b/espeak-ng-data/lang/inc/mr
@@ -2,3 +2,4 @@ name Marathi
 language mr
 
 status testing
+stressRule 6 

--- a/espeak-ng-data/lang/inc/ne
+++ b/espeak-ng-data/lang/inc/ne
@@ -2,3 +2,4 @@ name Nepali
 language ne
 
 dictrules 1
+stressRule 6

--- a/espeak-ng-data/lang/inc/or
+++ b/espeak-ng-data/lang/inc/or
@@ -2,3 +2,4 @@ name Oriya
 language or
 
 status testing
+stressRule 6

--- a/espeak-ng-data/lang/inc/pa
+++ b/espeak-ng-data/lang/inc/pa
@@ -1,2 +1,3 @@
 name Punjabi
 language pa
+stressRule 6

--- a/espeak-ng-data/lang/inc/si
+++ b/espeak-ng-data/lang/inc/si
@@ -4,3 +4,4 @@ language si
 status testing
 
 intonation 2
+stressRule 0

--- a/espeak-ng-data/lang/inc/ur
+++ b/espeak-ng-data/lang/inc/ur
@@ -3,5 +3,5 @@ language ur
 maintainer Ejaz Shah <eashah67@gmail.com>
 status testing
 
-stressrule 6
+stressRule 6
 

--- a/espeak-ng-data/lang/ine/hy
+++ b/espeak-ng-data/lang/ine/hy
@@ -1,3 +1,4 @@
 name Armenian (East Armenia)
 language hy
 language hy-arevela
+stressRule 3

--- a/espeak-ng-data/lang/ine/sq
+++ b/espeak-ng-data/lang/ine/sq
@@ -1,6 +1,6 @@
 name Albanian
 language sq
 letterVowel y
-
+stressRule 3
 // add this line to remove 'ë' at the end of words
 // replace 00  @/  NULL

--- a/espeak-ng-data/lang/ine/sq
+++ b/espeak-ng-data/lang/ine/sq
@@ -1,5 +1,6 @@
 name Albanian
 language sq
+letterVowel y
 
 // add this line to remove 'ë' at the end of words
 // replace 00  @/  NULL

--- a/espeak-ng-data/lang/ira/ku
+++ b/espeak-ng-data/lang/ira/ku
@@ -2,4 +2,4 @@ name Kurdish
 language ku
 
 //words 1 48
-
+stressRule 7

--- a/espeak-ng-data/lang/itc/la
+++ b/espeak-ng-data/lang/itc/la
@@ -1,6 +1,6 @@
 name Latin
 language la
-stressrule 2 33 0 2
+stressRule 2 33 0 2
 // rule=penultimate
 // flags=0100001 (no automatic secondary stress + don't stres monosyllables)
 // unstressed_wd1=0

--- a/espeak-ng-data/lang/ko
+++ b/espeak-ng-data/lang/ko
@@ -3,3 +3,4 @@ language ko
 pitch 80 118
 intonation 2
 
+stressRule 8

--- a/espeak-ng-data/lang/poz/id
+++ b/espeak-ng-data/lang/poz/id
@@ -3,5 +3,5 @@ language id
 
 stressLength 160 200  180 180  0 0  220 240
 stressAmp    16  18   18  18   0 0  22  21
-
+stressRule 2
 consonants 80 80

--- a/espeak-ng-data/lang/poz/ms
+++ b/espeak-ng-data/lang/poz/ms
@@ -7,6 +7,7 @@ translator id
 
 stressLength 160 200  180 180  0 0  220 240
 stressAmp    16  18   18  18   0 0  22  21
+stressRule 2
 intonation	3	// Less intonation, and comma does not raise the pitch.
 
 // Nuance - Peninsula Malaysia
@@ -14,3 +15,4 @@ intonation	3	// Less intonation, and comma does not raise the pitch.
 				// (only the last phoneme of a word, only in unstressed syllables)
 				
 consonants 80 80
+

--- a/espeak-ng-data/lang/roa/an
+++ b/espeak-ng-data/lang/roa/an
@@ -1,2 +1,3 @@
 name Aragonese
 language an
+stressRule 2

--- a/espeak-ng-data/lang/roa/ca
+++ b/espeak-ng-data/lang/roa/ca
@@ -1,2 +1,3 @@
 name Catalan
 language ca
+stressRule 2

--- a/espeak-ng-data/lang/roa/es
+++ b/espeak-ng-data/lang/roa/es
@@ -2,3 +2,4 @@ name Spanish (Spain)
 language es
 dictrules 1
 tunes s6 c6 q6 e6
+stressRule 2

--- a/espeak-ng-data/lang/roa/fr
+++ b/espeak-ng-data/lang/roa/fr
@@ -4,3 +4,4 @@ language fr
 
 dictrules 1
 tunes s3 c3 q3 e3
+letterVowel y

--- a/espeak-ng-data/lang/roa/fr
+++ b/espeak-ng-data/lang/roa/fr
@@ -5,3 +5,4 @@ language fr
 dictrules 1
 tunes s3 c3 q3 e3
 letterVowel y
+stressRule 3

--- a/espeak-ng-data/lang/roa/fr-BE
+++ b/espeak-ng-data/lang/roa/fr-BE
@@ -4,5 +4,5 @@ language fr 8
 
 dictrules 2
 tunes s3 c3 q3 e3
-
+letterVowel y
 

--- a/espeak-ng-data/lang/roa/fr-CH
+++ b/espeak-ng-data/lang/roa/fr-CH
@@ -4,3 +4,4 @@ language fr 8
 
 dictrules 3
 tunes s3 c3 q3 e3
+letterVowel y

--- a/espeak-ng-data/lang/roa/it
+++ b/espeak-ng-data/lang/roa/it
@@ -6,3 +6,4 @@ status mature
 
 tunes s4 c4 q4 e4
 letterVowel y
+stressRule 2

--- a/espeak-ng-data/lang/roa/it
+++ b/espeak-ng-data/lang/roa/it
@@ -5,3 +5,4 @@ maintainer Christian Leo M <llajta2012@gmail.com>
 status mature
 
 tunes s4 c4 q4 e4
+letterVowel y

--- a/espeak-ng-data/lang/roa/pap
+++ b/espeak-ng-data/lang/roa/pap
@@ -4,4 +4,4 @@ language pap
 status testing
 
 phonemes base2
-
+stressRule 3

--- a/espeak-ng-data/lang/roa/pt
+++ b/espeak-ng-data/lang/roa/pt
@@ -6,3 +6,4 @@ phonemes pt-pt
 dictrules 1
 intonation 2
 letterVowel y
+stressRule 3

--- a/espeak-ng-data/lang/roa/pt
+++ b/espeak-ng-data/lang/roa/pt
@@ -5,3 +5,4 @@ phonemes pt-pt
 
 dictrules 1
 intonation 2
+letterVowel y

--- a/espeak-ng-data/lang/roa/pt-BR
+++ b/espeak-ng-data/lang/roa/pt-BR
@@ -4,4 +4,4 @@ language pt 6
 
 dictrules 2
 stressLength 200 115 230 230 0 0 250 270
-
+stressRule 3

--- a/espeak-ng-data/lang/sai/gn
+++ b/espeak-ng-data/lang/sai/gn
@@ -2,3 +2,4 @@ name Guarani
 language gn
 dictrules 1
 words 0 1
+stressRule 3

--- a/espeak-ng-data/lang/sem/am
+++ b/espeak-ng-data/lang/sem/am
@@ -2,3 +2,4 @@ name Amharic
 language am
 
 status testing
+stressRule 0

--- a/espeak-ng-data/lang/sem/mt
+++ b/espeak-ng-data/lang/sem/mt
@@ -2,3 +2,4 @@ name Maltese
 language mt
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/trk/az
+++ b/espeak-ng-data/lang/trk/az
@@ -2,3 +2,4 @@ name Azerbaijani
 language az
 
 status testing
+stressRule 7

--- a/espeak-ng-data/lang/trk/tr
+++ b/espeak-ng-data/lang/trk/tr
@@ -1,2 +1,3 @@
 name Turkish
 language tr
+stressRule 7

--- a/espeak-ng-data/lang/trk/tt
+++ b/espeak-ng-data/lang/trk/tt
@@ -1,2 +1,3 @@
 name Tatar
 language tt
+stressRule 3

--- a/espeak-ng-data/lang/urj/fi
+++ b/espeak-ng-data/lang/urj/fi
@@ -1,2 +1,3 @@
 name Finnish
 language fi
+letterVowel y

--- a/espeak-ng-data/lang/urj/fi
+++ b/espeak-ng-data/lang/urj/fi
@@ -1,3 +1,4 @@
 name Finnish
 language fi
 letterVowel y
+stressRule 0

--- a/espeak-ng-data/lang/urj/hu
+++ b/espeak-ng-data/lang/urj/hu
@@ -2,5 +2,5 @@ name Hungarian
 language hu
 option bracket 0 0
 pitch 81 117
-
+letterVowel y
 

--- a/espeak-ng-data/lang/urj/hu
+++ b/espeak-ng-data/lang/urj/hu
@@ -3,4 +3,4 @@ language hu
 option bracket 0 0
 pitch 81 117
 letterVowel y
-
+stressRule 0

--- a/espeak-ng-data/lang/zle/ru
+++ b/espeak-ng-data/lang/zle/ru
@@ -4,3 +4,4 @@ language ru
 replace 03 a a#
 
 dict_min  20000
+stressRule 5

--- a/espeak-ng-data/lang/zls/bg
+++ b/espeak-ng-data/lang/zls/bg
@@ -3,3 +3,5 @@ language bg
 
 stressAmp 13 12 17 17 20 22 22 21 
 stressLength 180 170  200 200  200 200  210 220
+letterVowel 0x2a
+

--- a/espeak-ng-data/lang/zls/bg
+++ b/espeak-ng-data/lang/zls/bg
@@ -3,5 +3,6 @@ language bg
 
 stressAmp 13 12 17 17 20 22 22 21 
 stressLength 180 170  200 200  200 200  210 220
+stressRule 2
 letterVowel 0x2a
 

--- a/espeak-ng-data/lang/zls/bs
+++ b/espeak-ng-data/lang/zls/bs
@@ -12,3 +12,5 @@ formant 5  97 102 100
 
 stressAdd 10 10 0 0 0 0 -30 -30
 dictrules 3 4
+letterVowel y
+letterVowel r

--- a/espeak-ng-data/lang/zls/bs
+++ b/espeak-ng-data/lang/zls/bs
@@ -14,3 +14,4 @@ stressAdd 10 10 0 0 0 0 -30 -30
 dictrules 3 4
 letterVowel y
 letterVowel r
+stressRule 0

--- a/espeak-ng-data/lang/zls/hr
+++ b/espeak-ng-data/lang/zls/hr
@@ -15,3 +15,4 @@ stressAdd 10 10 0 0 0 0 -30 -30
 dictrules 1
 letterVowel y
 letterVowel r
+stressRule 0

--- a/espeak-ng-data/lang/zls/hr
+++ b/espeak-ng-data/lang/zls/hr
@@ -13,3 +13,5 @@ formant 5  97 102 100
 
 stressAdd 10 10 0 0 0 0 -30 -30
 dictrules 1
+letterVowel y
+letterVowel r

--- a/espeak-ng-data/lang/zls/mk
+++ b/espeak-ng-data/lang/zls/mk
@@ -1,2 +1,3 @@
 name Macedonian
 language mk
+stressRule 4

--- a/espeak-ng-data/lang/zls/sl
+++ b/espeak-ng-data/lang/zls/sl
@@ -2,3 +2,4 @@ name Slovenian
 language sl
 
 status testing
+stressRule 2

--- a/espeak-ng-data/lang/zls/sr
+++ b/espeak-ng-data/lang/zls/sr
@@ -14,3 +14,4 @@ dictrules 2 4
 
 letterVowel y
 letterVowel r
+stressRule 0

--- a/espeak-ng-data/lang/zls/sr
+++ b/espeak-ng-data/lang/zls/sr
@@ -11,3 +11,6 @@ formant 5  97 102 100
 
 stressAdd 10 10 0 0 0 0 -30 -30
 dictrules 2 4
+
+letterVowel y
+letterVowel r

--- a/espeak-ng-data/lang/zlw/cs
+++ b/espeak-ng-data/lang/zlw/cs
@@ -2,3 +2,4 @@ name Czech
 language cs
 letterVowel y
 letterVowel r
+stressRule 0

--- a/espeak-ng-data/lang/zlw/cs
+++ b/espeak-ng-data/lang/zlw/cs
@@ -1,2 +1,4 @@
 name Czech
 language cs
+letterVowel y
+letterVowel r

--- a/espeak-ng-data/lang/zlw/pl
+++ b/espeak-ng-data/lang/zlw/pl
@@ -3,3 +3,4 @@ language pl
 
 intonation 2
 letterVowel y
+stressRule 2

--- a/espeak-ng-data/lang/zlw/pl
+++ b/espeak-ng-data/lang/zlw/pl
@@ -2,3 +2,4 @@ name Polish
 language pl
 
 intonation 2
+letterVowel y

--- a/espeak-ng-data/lang/zlw/sk
+++ b/espeak-ng-data/lang/zlw/sk
@@ -2,3 +2,4 @@ name Slovak
 language sk
 letterVowel y
 letterVowel r
+stressRule 0

--- a/espeak-ng-data/lang/zlw/sk
+++ b/espeak-ng-data/lang/zlw/sk
@@ -1,2 +1,4 @@
 name Slovak
 language sk
+letterVowel y
+letterVowel r

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -121,11 +121,6 @@ ALPHABET *AlphabetFromChar(int c)
 
 static void Translator_Russian(Translator *tr);
 
-static void SetLetterVowel(Translator *tr, int c)
-{
-	tr->letter_bits[c] = (tr->letter_bits[c] & 0x40) | 0x81; // keep value for group 6 (front vowels e,i,y)
-}
-
 static void ResetLetterBits(Translator *tr, int groups)
 {
 	// Clear all the specified groups
@@ -483,7 +478,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.vowel_pause = 0x30;
 		tr->langopts.param[LOPT_DIERESES] = 1;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
-		SetLetterVowel(tr, 'y'); // add 'y' to vowels
 
 		tr->langopts.numbers = NUM_SWAP_TENS | NUM_HUNDRED_AND | NUM_SINGLE_AND | NUM_ROMAN | NUM_1900;
 		tr->langopts.accents = 1;
@@ -512,7 +506,6 @@ Translator *SelectTranslator(const char *name)
 	case L('b', 'g'): // Bulgarian
 	{
 		SetCyrillicLetters(tr);
-		SetLetterVowel(tr, 0x2a);
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_5;
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 0x432; // [v]  don't count this character at start of word
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x107; // devoice at end of word, and change voicing to match a following consonant (except v)
@@ -581,8 +574,6 @@ Translator *SelectTranslator(const char *name)
 
 		tr->langopts.numbers = NUM_OMIT_1_HUNDRED;
 
-		SetLetterVowel(tr, 'w'); // add letter to vowels and remove from consonants
-		SetLetterVowel(tr, 'y');
 	}
 		break;
 	case L('d', 'a'): // Danish
@@ -592,7 +583,6 @@ Translator *SelectTranslator(const char *name)
 
 		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SWAP_TENS | NUM_HUNDRED_AND | NUM_OMIT_1_HUNDRED | NUM_ORDINAL_DOT | NUM_1900 | NUM_ROMAN | NUM_ROMAN_CAPITALS | NUM_ROMAN_ORDINAL;
 	}
 		break;
@@ -609,7 +599,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_LONG_VOWEL_THRESHOLD] = 175/2;
 
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SWAP_TENS | NUM_ALLOW_SPACE | NUM_ORDINAL_DOT | NUM_ROMAN;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 2; // use de_rules for unpronouncable rules
 	}
 		break;
@@ -801,7 +790,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.long_stop = 130;
 
 		tr->langopts.numbers = NUM_DECIMAL_COMMA + NUM_ALLOW_SPACE;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.spelling_stress = 1;
 		tr->langopts.intonation_group = 3; // less intonation, don't raise pitch at comma
 	}
@@ -816,7 +804,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.accents = 2; // Say "Capital" after the letter.
 
 		tr->langopts.numbers = NUM_SINGLE_STRESS | NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_OMIT_1_HUNDRED | NUM_NOPAUSE | NUM_ROMAN | NUM_ROMAN_CAPITALS | NUM_ROMAN_AFTER | NUM_VIGESIMAL | NUM_DFRACTION_4;
-		SetLetterVowel(tr, 'y');
 	}
 		break;
 	case L('g', 'a'): // irish
@@ -900,8 +887,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.replace_chars = replace_cyrillic_latin;
 		tr->langopts.our_alphabet = OFFSET_CYRILLIC; // don't say "cyrillic" before letter names
 
-		SetLetterVowel(tr, 'y');
-		SetLetterVowel(tr, 'r');
 	}
 		break;
 	case L('h', 't'): // Haitian Creole
@@ -929,7 +914,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.decimal_sep = ',';
 		tr->langopts.max_roman = 899;
 		tr->langopts.min_roman = 1;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.spelling_stress = 1;
 		SetLengthMods(tr, 3); // all equal
 	}
@@ -986,7 +970,6 @@ Translator *SelectTranslator(const char *name)
 		SetLetterBits(tr, 4, "kpst"); // Letter group F
 		SetLetterBits(tr, 3, "jvr"); // Letter group H
 		tr->letter_groups[1] = is_lettergroup_B;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SINGLE_AND | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_1900;
 		tr->langopts.numbers2 = 0x2;
 	}
@@ -1011,7 +994,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.numbers2 = NUM2_NO_TEEN_ORDINALS;
 		tr->langopts.roman_suffix = utf8_ordinal;
 		tr->langopts.accents = 2; // Say "Capital" after the letter.
-		SetLetterVowel(tr, 'y');
 	}
 		break;
 	case L_jbo: // Lojban
@@ -1024,7 +1006,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.vowel_pause = 0x20c; // pause before a word which starts with a vowel, or after a word which ends in a consonant
 		tr->punct_within_word = jbo_punct_within_word;
 		tr->langopts.param[LOPT_CAPS_IN_WORD] = 2; // capitals indicate stressed syllables
-		SetLetterVowel(tr, 'y');
 		tr->langopts.max_lengthmod = 368;
 	}
 		break;
@@ -1195,7 +1176,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_DIERESES] = 1;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x100; // devoice at end of word
-		SetLetterVowel(tr, 'y');
 
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SWAP_TENS | NUM_OMIT_1_HUNDRED | NUM_OMIT_1_THOUSAND | NUM_ALLOW_SPACE | NUM_1900 | NUM_ORDINAL_DOT;
 		tr->langopts.ordinal_indicator = "e";
@@ -1209,7 +1189,6 @@ Translator *SelectTranslator(const char *name)
 
 		SetupTranslator(tr, stress_lengths_no, NULL);
 		tr->langopts.stress_rule = STRESSPOSN_1L;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_HUNDRED_AND | NUM_ALLOW_SPACE | NUM_1900 | NUM_ORDINAL_DOT;
 	}
 		break;
@@ -1240,7 +1219,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_DFRACTION_2;
 		tr->langopts.numbers2 = NUM2_THOUSANDS_VAR3;
 		tr->langopts.param[LOPT_COMBINE_WORDS] = 4 + 0x100; // combine 'nie' (marked with $alt2) with some 1-syllable (and 2-syllable) words (marked with $alt)
-		SetLetterVowel(tr, 'y');
 	}
 		break;
 	case L('p', 't'): // Portuguese
@@ -1256,7 +1234,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_DFRACTION_2 | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_ROMAN_CAPITALS;
 		tr->langopts.numbers2 = NUM2_MULTIPLE_ORDINAL | NUM2_NO_TEEN_ORDINALS | NUM2_ORDINAL_NO_AND;
 		tr->langopts.max_roman = 5000;
-		SetLetterVowel(tr, 'y');
 		ResetLetterBits(tr, 0x2);
 		SetLetterBits(tr, 1, "bcdfgjkmnpqstvxz"); // B  hard consonants, excluding h,l,r,w,y
 		tr->langopts.param[LOPT_ALT] = 2; // call ApplySpecialAttributes2() if a word has $alt or $alt2
@@ -1314,8 +1291,6 @@ Translator *SelectTranslator(const char *name)
 		if (name2 == L('c', 's'))
 			tr->langopts.numbers2 = 0x108; // variant numbers before milliards
 
-		SetLetterVowel(tr, 'y');
-		SetLetterVowel(tr, 'r');
 		ResetLetterBits(tr, 0x20);
 		SetLetterBits(tr, 5, sk_voiced);
 	}
@@ -1368,7 +1343,6 @@ Translator *SelectTranslator(const char *name)
 
 		tr->langopts.stress_rule = STRESSPOSN_1R;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_FINAL_VOWEL_UNSTRESSED;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_DFRACTION_4;
 		tr->langopts.accents = 2; // "capital" after letter name
 	}
@@ -1380,7 +1354,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_sv, stress_amps_sv);
 
 		tr->langopts.stress_rule = STRESSPOSN_1L;
-		SetLetterVowel(tr, 'y');
 		tr->langopts.numbers = NUM_SINGLE_STRESS | NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_1900;
 		tr->langopts.accents = 1;
 	}

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -474,7 +474,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_af[8] = { 170, 140, 220, 220,  0, 0, 250, 270 };
 		SetupTranslator(tr, stress_lengths_af, NULL);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.vowel_pause = 0x30;
 		tr->langopts.param[LOPT_DIERESES] = 1;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
@@ -487,7 +486,6 @@ Translator *SelectTranslator(const char *name)
 	{
 		SetupTranslator(tr, stress_lengths_fr, stress_amps_fr);
 		tr->letter_bits_offset = OFFSET_ETHIOPIC;
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_NO_AUTO_2 | S_FINAL_DIM; // don't use secondary stress
 		tr->langopts.length_mods0 = tr->langopts.length_mods;  // don't lengthen vowels in the last syllable
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 1;           // disable check for unpronouncable words
@@ -510,7 +508,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 0x432; // [v]  don't count this character at start of word
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x107; // devoice at end of word, and change voicing to match a following consonant (except v)
 		tr->langopts.param[LOPT_REDUCE] = 2;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_OMIT_1_HUNDRED | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_SINGLE_AND | NUM_ROMAN | NUM_ROMAN_ORDINAL | NUM_ROMAN_CAPITALS;
 		tr->langopts.thousands_sep = ' '; // don't allow dot as thousands separator
 	}
@@ -526,7 +523,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_bn, stress_amps_bn);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags =  S_MID_DIM | S_FINAL_DIM; // use 'diminished' for unstressed final syllable
 		tr->letter_bits_offset = OFFSET_BENGALI;
 		SetIndicLetters(tr); // call this after setting OFFSET_BENGALI
@@ -564,7 +560,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_cy, stress_amps_cy);
 
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_14;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 
 		// 'diminished' is an unstressed final syllable
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2;
@@ -581,7 +576,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_da[8] = { 160, 140, 200, 200, 0, 0, 220, 230 };
 		SetupTranslator(tr, stress_lengths_da, NULL);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SWAP_TENS | NUM_HUNDRED_AND | NUM_OMIT_1_HUNDRED | NUM_ORDINAL_DOT | NUM_1900 | NUM_ROMAN | NUM_ROMAN_CAPITALS | NUM_ROMAN_ORDINAL;
 	}
@@ -591,7 +585,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_de[8] = { 150, 130, 200, 200,  0, 0, 270, 270 };
 		static const unsigned char stress_amps_de[] = { 20, 20, 20, 20, 20, 22, 22, 20 };
 		SetupTranslator(tr, stress_lengths_de, stress_amps_de);
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.word_gap = 0x8; // don't use linking phonemes
 		tr->langopts.vowel_pause = 0x30;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
@@ -620,7 +613,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_en[8] = { 182, 140, 220, 220, 0, 0, 248, 275 };
 		SetupTranslator(tr, stress_lengths_en, NULL);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = 0x08;
 		tr->langopts.numbers = NUM_HUNDRED_AND | NUM_ROMAN | NUM_1900;
 		tr->langopts.param[LOPT_COMBINE_WORDS] = 2; // allow "mc" to cmbine with the following word
@@ -656,7 +648,6 @@ Translator *SelectTranslator(const char *name)
 		SetLetterBits(tr, LETTERGP_Y, el_fvowels); // front vowels: ε η ι υ _
 
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY; // mark unstressed final syllables as diminished
 		tr->langopts.unstressed_wd1 = 0;
 		tr->langopts.unstressed_wd2 = 2;
@@ -683,7 +674,6 @@ Translator *SelectTranslator(const char *name)
 		tr->char_plus_apostrophe = eo_char_apostrophe;
 
 		tr->langopts.vowel_pause = 2;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2;
 		tr->langopts.unstressed_wd2 = 2;
 
@@ -703,7 +693,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_es, stress_amps_es);
 
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 
 		// stress last syllable if it doesn't end in vowel or "s" or "n"
 		// 'diminished' is an unstressed final syllable
@@ -729,7 +718,6 @@ Translator *SelectTranslator(const char *name)
 			tr->langopts.roman_suffix = utf8_ordinal;
 		} else if (name2 == L_pap) {
 			// stress last syllable unless word ends with a vowel
-			tr->langopts.stress_rule = STRESSPOSN_1R;
 			tr->langopts.stress_flags = S_FINAL_VOWEL_UNSTRESSED | S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_NO_AUTO_2;
 		} else
 			tr->langopts.param[LOPT_UNPRONOUNCABLE] = 2; // use es_rules for unpronouncable rules
@@ -740,7 +728,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_eu[8] = { 200, 200,  200, 200,  0, 0,  210, 230 }; // very weak stress
 		static const unsigned char stress_amps_eu[8] = { 16, 16, 18, 18, 18, 18, 18, 18 };
 		SetupTranslator(tr, stress_lengths_eu, stress_amps_eu);
-		tr->langopts.stress_rule = STRESSPOSN_2L; // ?? second syllable, but not on a word-final vowel
 		tr->langopts.stress_flags = S_FINAL_VOWEL_UNSTRESSED;
 		tr->langopts.param[LOPT_SUFFIX] = 1;
 		tr->langopts.numbers = NUM_SINGLE_STRESS | NUM_DECIMAL_COMMA | NUM_HUNDRED_AND | NUM_OMIT_1_HUNDRED | NUM_OMIT_1_THOUSAND | NUM_VIGESIMAL;
@@ -784,7 +771,6 @@ Translator *SelectTranslator(const char *name)
 
 		SetupTranslator(tr, stress_lengths_fi, stress_amps_fi);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_2_TO_HEAVY; // move secondary stress from light to a following heavy syllable
 		tr->langopts.param[LOPT_IT_DOUBLING] = 1;
 		tr->langopts.long_stop = 130;
@@ -797,7 +783,6 @@ Translator *SelectTranslator(const char *name)
 	case L('f', 'r'): // french
 	{
 		SetupTranslator(tr, stress_lengths_fr, stress_amps_fr);
-		tr->langopts.stress_rule = STRESSPOSN_1R; // stress on final syllable
 		tr->langopts.stress_flags = S_NO_AUTO_2 | S_FINAL_DIM; // don't use secondary stress
 		tr->langopts.param[LOPT_IT_LENGTHEN] = 1; // remove lengthen indicator from unstressed syllables
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
@@ -837,7 +822,6 @@ Translator *SelectTranslator(const char *name)
 		tr->encoding = ESPEAKNG_ENCODING_ISCII;
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = 6; // stress on last heaviest syllable, excluding final syllable
 		tr->langopts.stress_flags =  S_MID_DIM | S_FINAL_DIM; // use 'diminished' for unstressed final syllable
 		tr->langopts.numbers = NUM_SWAP_TENS;
 		tr->langopts.break_numbers = 0x14aa8; // for languages which have numbers for 100,000 and 100,00,000, eg Hindi
@@ -848,7 +832,6 @@ Translator *SelectTranslator(const char *name)
 		else if (name2 == L('g', 'u')) {
 			SetupTranslator(tr, stress_lengths_equal, stress_amps_equal);
 			tr->letter_bits_offset = OFFSET_GUJARATI;
-			tr->langopts.stress_rule = STRESSPOSN_2R;
 		} else if (name2 == L('n', 'e')) {
 			SetupTranslator(tr, stress_lengths_equal, stress_amps_equal);
 			tr->langopts.break_numbers = 0x2aaaa8;
@@ -875,7 +858,6 @@ Translator *SelectTranslator(const char *name)
 			SetupTranslator(tr, stress_lengths_hr, stress_amps_hr);
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_NO_2;
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x3;
 		tr->langopts.max_initial_consonants = 5;
@@ -903,7 +885,6 @@ Translator *SelectTranslator(const char *name)
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
 
 		tr->langopts.vowel_pause = 0x20;
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_NO_AUTO_2 | 0x8000 | S_HYPEN_UNSTRESS;
 		tr->langopts.unstressed_wd1 = 2;
 		tr->langopts.param[LOPT_IT_DOUBLING] = 1;
@@ -929,7 +910,6 @@ Translator *SelectTranslator(const char *name)
 		static const char hy_consonants2[] = { 0x45, 0 };
 
 		SetupTranslator(tr, stress_lengths_hy, NULL);
-		tr->langopts.stress_rule = STRESSPOSN_1R; // default stress on final syllable
 
 		tr->letter_bits_offset = OFFSET_ARMENIAN;
 		memset(tr->letter_bits, 0, sizeof(tr->letter_bits));
@@ -949,7 +929,6 @@ Translator *SelectTranslator(const char *name)
 		static const unsigned char stress_amps_id[8] = { 16, 18, 18, 18, 20, 22, 22, 21 };
 
 		SetupTranslator(tr, stress_lengths_id, stress_amps_id);
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_ROMAN;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2;
 		tr->langopts.accents = 2; // "capital" after letter name
@@ -961,7 +940,6 @@ Translator *SelectTranslator(const char *name)
 		static const wchar_t is_lettergroup_B[] = { 'c', 'f', 'h', 'k', 'p', 't', 'x', 0xfe, 0 }; // voiceless conants, including 'þ'  ?? 's'
 
 		SetupTranslator(tr, stress_lengths_is, NULL);
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_NO_2;
 		tr->langopts.param[LOPT_IT_LENGTHEN] = 0x11; // remove lengthen indicator from unstressed vowels
 		tr->langopts.param[LOPT_REDUCE] = 2;
@@ -980,7 +958,6 @@ Translator *SelectTranslator(const char *name)
 		static const unsigned char stress_amps_it[8] = { 17, 15, 18, 16, 20, 22, 22, 22 };
 		SetupTranslator(tr, stress_lengths_it, stress_amps_it);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags = S_NO_AUTO_2 | S_FINAL_DIM_ONLY | S_PRIORITY_STRESS;
 		tr->langopts.vowel_pause = 1;
 		tr->langopts.unstressed_wd1 = 0;
@@ -1002,7 +979,6 @@ Translator *SelectTranslator(const char *name)
 		static const wchar_t jbo_punct_within_word[] = { '.', ',', '\'', 0x2c8, 0 }; // allow period and comma within a word, also stress marker (from LOPT_CAPS_IN_WORD)
 
 		SetupTranslator(tr, stress_lengths_jbo, NULL);
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.vowel_pause = 0x20c; // pause before a word which starts with a vowel, or after a word which ends in a consonant
 		tr->punct_within_word = jbo_punct_within_word;
 		tr->langopts.param[LOPT_CAPS_IN_WORD] = 2; // capitals indicate stressed syllables
@@ -1022,7 +998,6 @@ Translator *SelectTranslator(const char *name)
 		SetLetterBits(tr, LETTERGP_C, ka_consonants);
 		SetLetterBits(tr, LETTERGP_VOWEL2, ka_vowels);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_NO_2;
 		tr->letter_bits_offset = OFFSET_GEORGIAN;
 		tr->langopts.max_initial_consonants = 7;
@@ -1058,7 +1033,6 @@ Translator *SelectTranslator(const char *name)
 	case L('k', 'l'): // Greenlandic
 	{
 		SetupTranslator(tr, stress_lengths_equal, stress_amps_equal);
-		tr->langopts.stress_rule = 12;
 		tr->langopts.stress_flags = S_NO_AUTO_2;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_SWAP_TENS | NUM_HUNDRED_AND | NUM_OMIT_1_HUNDRED | NUM_ORDINAL_DOT | NUM_1900 | NUM_ROMAN | NUM_ROMAN_CAPITALS | NUM_ROMAN_ORDINAL;
 	}
@@ -1075,7 +1049,6 @@ Translator *SelectTranslator(const char *name)
 		SetLetterBits(tr, LETTERGP_Y, ko_ivowels);
 		SetLetterBits(tr, LETTERGP_G, (const char *)ko_voiced);
 
-		tr->langopts.stress_rule = 8; // ?? 1st syllable if it is heavy, else 2nd syllable
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 1; // disable check for unpronouncable words
 		tr->langopts.numbers = NUM_OMIT_1_HUNDRED;
 		tr->langopts.numbers2 = NUM2_MYRIADS;
@@ -1091,8 +1064,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_ku, stress_amps_ku);
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_9;
 
-		tr->langopts.stress_rule = 7; // stress on the last syllable, before any explicitly unstressed syllable
-
 		tr->langopts.numbers = NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_OMIT_1_HUNDRED | NUM_AND_HUNDRED;
 		tr->langopts.max_initial_consonants = 2;
 	}
@@ -1103,10 +1074,6 @@ Translator *SelectTranslator(const char *name)
 	case L('l', 'a'): // Latin
 	{
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4; // includes a,e,i,o,u-macron
-		tr->langopts.stress_rule = STRESSPOSN_2R;
-		tr->langopts.stress_flags = S_NO_AUTO_2;
-		tr->langopts.unstressed_wd1 = 0;
-		tr->langopts.unstressed_wd2 = 2;
 		tr->langopts.param[LOPT_DIERESES] = 1;
 		tr->langopts.numbers = NUM_ROMAN;
 		tr->langopts.max_roman = 5000;
@@ -1115,7 +1082,6 @@ Translator *SelectTranslator(const char *name)
 	case L('l', 't'): // Lithuanian
 	{
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags = S_NO_AUTO_2;
 		tr->langopts.unstressed_wd1 = 0;
 		tr->langopts.unstressed_wd2 = 2;
@@ -1132,7 +1098,6 @@ Translator *SelectTranslator(const char *name)
 
 		SetupTranslator(tr, stress_lengths_lv, stress_amps_lv);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.spelling_stress = 1;
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_OMIT_1_HUNDRED | NUM_DFRACTION_4 | NUM_ORDINAL_DOT;
@@ -1154,7 +1119,6 @@ Translator *SelectTranslator(const char *name)
 		tr->letter_groups[0] = tr->letter_groups[7] = vowels_cyrillic;
 		tr->letter_bits_offset = OFFSET_CYRILLIC;
 
-		tr->langopts.stress_rule = STRESSPOSN_3R; // antipenultimate
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_AND_UNITS | NUM_OMIT_1_HUNDRED | NUM_OMIT_1_THOUSAND | NUM_DFRACTION_2;
 		tr->langopts.numbers2 = 0x8a; // variant numbers before thousands,milliards
 	}
@@ -1163,7 +1127,6 @@ Translator *SelectTranslator(const char *name)
 	{
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_3;
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x100; // devoice at end of word
-		tr->langopts.stress_rule = STRESSPOSN_2R; // penultimate
 		tr->langopts.numbers = 1;
 	}
 		break;
@@ -1171,7 +1134,6 @@ Translator *SelectTranslator(const char *name)
 	{
 		static const short stress_lengths_nl[8] = { 160, 135, 210, 210,  0, 0, 260, 280 };
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.vowel_pause = 0x30; // ??
 		tr->langopts.param[LOPT_DIERESES] = 1;
 		tr->langopts.param[LOPT_PREFIXES] = 1;
@@ -1188,7 +1150,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_no[8] = { 160, 140, 200, 200, 0, 0, 220, 230 };
 
 		SetupTranslator(tr, stress_lengths_no, NULL);
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_HUNDRED_AND | NUM_ALLOW_SPACE | NUM_1900 | NUM_ORDINAL_DOT;
 	}
 		break;
@@ -1198,7 +1159,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_om[8] = { 200, 200, 200, 200, 0, 0, 200, 200 };
 
 		SetupTranslator(tr, stress_lengths_om, stress_amps_om);
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY | S_FINAL_NO_2 | 0x80000;
 		tr->langopts.numbers = NUM_OMIT_1_HUNDRED | NUM_HUNDRED_AND;
 		tr->langopts.numbers2 = 0x200; // say "thousands" before its number
@@ -1212,7 +1172,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_pl, stress_amps_pl);
 
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY; // mark unstressed final syllables as diminished
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x9;
 		tr->langopts.max_initial_consonants = 7; // for example: wchrzczony :)
@@ -1229,7 +1188,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_pt, stress_amps_pt);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = STRESSPOSN_1R; // stress on final syllable
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_INITIAL_2 | S_PRIORITY_STRESS;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_DFRACTION_2 | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_ROMAN_CAPITALS;
 		tr->langopts.numbers2 = NUM2_MULTIPLE_ORDINAL | NUM2_NO_TEEN_ORDINALS | NUM2_ORDINAL_NO_AND;
@@ -1247,7 +1205,6 @@ Translator *SelectTranslator(const char *name)
 
 		SetupTranslator(tr, stress_lengths_ro, stress_amps_ro);
 
-		tr->langopts.stress_rule = STRESSPOSN_1R;
 		tr->langopts.stress_flags = S_FINAL_VOWEL_UNSTRESSED | S_FINAL_DIM_ONLY;
 
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
@@ -1276,7 +1233,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_sk, stress_amps_sk);
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags = S_FINAL_DIM_ONLY | S_FINAL_NO_2;
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x3;
 		tr->langopts.max_initial_consonants = 5;
@@ -1300,7 +1256,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_ta, stress_amps_ta);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2;
 		tr->langopts.spelling_stress = 1;
 
@@ -1322,7 +1277,6 @@ Translator *SelectTranslator(const char *name)
 		break;
 	case L('s', 'l'): // Slovenian
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_2;
-		tr->langopts.stress_rule = STRESSPOSN_2R; // Temporary
 		tr->langopts.stress_flags = S_NO_AUTO_2;
 		tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 0x103;
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 0x76; // [v]  don't count this character at start of word
@@ -1341,7 +1295,6 @@ Translator *SelectTranslator(const char *name)
 
 		SetupTranslator(tr, stress_lengths_sq, stress_amps_sq);
 
-		tr->langopts.stress_rule = STRESSPOSN_1R;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2 | S_FINAL_VOWEL_UNSTRESSED;
 		tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_HUNDRED_AND | NUM_AND_UNITS | NUM_DFRACTION_4;
 		tr->langopts.accents = 2; // "capital" after letter name
@@ -1353,7 +1306,6 @@ Translator *SelectTranslator(const char *name)
 		static const short stress_lengths_sv[8] = { 160, 135, 220, 220, 0, 0, 250, 280 };
 		SetupTranslator(tr, stress_lengths_sv, stress_amps_sv);
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.numbers = NUM_SINGLE_STRESS | NUM_DECIMAL_COMMA | NUM_ALLOW_SPACE | NUM_1900;
 		tr->langopts.accents = 1;
 	}
@@ -1368,7 +1320,6 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
 		tr->langopts.vowel_pause = 1;
-		tr->langopts.stress_rule = STRESSPOSN_2R;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2;
 		tr->langopts.max_initial_consonants = 4; // for example: mwngi
 
@@ -1385,7 +1336,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_ta2, stress_amps_ta);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.stress_flags =  S_FINAL_DIM_ONLY | S_FINAL_NO_2; // use 'diminished' for unstressed final syllable
 		tr->langopts.spelling_stress = 1;
 		tr->langopts.break_numbers = 0x14a8; // 1000, 100,000  10,000,000
@@ -1402,7 +1352,6 @@ Translator *SelectTranslator(const char *name)
 			tr->letter_bits_offset = OFFSET_MALAYALAM;
 			tr->langopts.numbers = NUM_OMIT_1_THOUSAND | NUM_OMIT_1_HUNDRED;
 			tr->langopts.numbers2 = NUM2_OMIT_1_HUNDRED_ONLY;
-			tr->langopts.stress_rule = 13; // 1st syllable, unless 1st vowel is short and 2nd is long
 		} else if (name2 == L('k', 'n')) {
 			tr->letter_bits_offset = OFFSET_KANNADA;
 			tr->langopts.numbers = 0x1;
@@ -1424,7 +1373,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_tr, stress_amps_tr);
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_9;
 
-		tr->langopts.stress_rule = 7; // stress on the last syllable, before any explicitly unstressed syllable
 		tr->langopts.stress_flags = S_NO_AUTO_2; // no automatic secondary stress
 		tr->langopts.dotless_i = 1;
 		tr->langopts.param[LOPT_SUFFIX] = 1;
@@ -1440,7 +1388,6 @@ Translator *SelectTranslator(const char *name)
 	{
 		SetCyrillicLetters(tr);
 		SetupTranslator(tr, stress_lengths_fr, stress_amps_fr);
-		tr->langopts.stress_rule = STRESSPOSN_1R; // stress on final syllable
 		tr->langopts.stress_flags = S_NO_AUTO_2; // no automatic secondary stress
 		tr->langopts.numbers = NUM_SINGLE_STRESS | NUM_DECIMAL_COMMA | NUM_OMIT_1_HUNDRED | NUM_OMIT_1_THOUSAND | NUM_DFRACTION_4;
 	}
@@ -1483,7 +1430,6 @@ Translator *SelectTranslator(const char *name)
 		SetupTranslator(tr, stress_lengths_vi, stress_amps_vi);
 		tr->langopts.length_mods0 = tr->langopts.length_mods; // don't lengthen vowels in the last syllable
 
-		tr->langopts.stress_rule = STRESSPOSN_1L;
 		tr->langopts.word_gap = 0x21; // length of a final vowel is less dependent on the next consonant, don't merge consonant with next word
 		tr->letter_groups[0] = tr->letter_groups[7] = vowels_vi;
 		tr->langopts.tone_language = 1; // Tone language, use  CalcPitches_Tone() rather than CalcPitches()
@@ -1558,7 +1504,6 @@ static void Translator_Russian(Translator *tr)
 	tr->langopts.param[LOPT_UNPRONOUNCABLE] = 0x432; // [v]  don't count this character at start of word
 	tr->langopts.param[LOPT_REGRESSIVE_VOICING] = 1;
 	tr->langopts.param[LOPT_REDUCE] = 2;
-	tr->langopts.stress_rule = 5;
 	tr->langopts.stress_flags = S_NO_AUTO_2;
 
 	tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_OMIT_1_HUNDRED;

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -109,7 +109,11 @@ enum {
 
 	// these need a phoneme table to have been specified
 	V_REPLACE,
-	V_CONSONANTS
+	V_CONSONANTS,
+
+	// these are alpha features that need to be tested and categorized
+	V_LETTER_VOWEL
+
 };
 
 static MNEM_TAB options_tab[] = {
@@ -168,6 +172,8 @@ static MNEM_TAB keyword_tab[] = {
 	{ "l_length_mods",    0x100+LOPT_LENGTH_MODS },
 	{ "apostrophe",       0x100+LOPT_APOSTROPHE },
 
+	// these are alpha features that need to be tested and categorized
+	{ "letterVowel", V_LETTER_VOWEL },
 	{ NULL, 0 }
 };
 
@@ -858,6 +864,27 @@ voice_t *LoadVoice(const char *vname, int control)
 		case V_MAINTAINER:
 		case V_STATUS:
 			break;
+
+		case V_LETTER_VOWEL: {
+			char str[5] = "";
+			char c = '0';
+			char *endptr = NULL;
+			sscanf(p, "%s", str);
+			// assume a hex value if string starts with "0x"
+			if (str[0] == '0' && str[1] == 'x') {
+				c = strtoul(str, &endptr, 16);
+				if (errno == ERANGE)
+					fprintf(stderr, "letterVowel out of range.\n");
+			}
+			else  {// otherwise, assume a single letter
+				c = str[0];
+				if (c < 97 || c > 122) // valid values are a-z, ascii 97-122
+					fprintf(stderr, "letterVowel out of range.\n");
+			}
+ 			new_translator->letter_bits[c] = (new_translator->letter_bits[c] & 0x40) | 0x81; // keep value for group 6 (front vowels e,i,y)
+			break;
+			}
+
 		default:
 			if ((key & 0xff00) == 0x100) {
 				if (langopts)

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -142,7 +142,7 @@ static MNEM_TAB keyword_tab[] = {
 	{ "intonation",   V_INTONATION },
 	{ "tunes",        V_TUNES },
 	{ "dictrules",    V_DICTRULES },
-	{ "stressrule",   V_STRESSRULE },
+	{ "stressRule",   V_STRESSRULE },
 	{ "stressopt",    V_STRESSOPT },
 	{ "replace",      V_REPLACE },
 	{ "words",        V_WORDGAP },


### PR DESCRIPTION
Contributions to #218.

Next up is stress_flags. Using the defines for flags make the code in tr_languages.c easily readable. Changing them to ints in language files makes them less human readable. A long term solution would be nice.