### PR TITLE
documenation: remove Place of articulation from table of contents in phontab.md

### DIFF
--- a/docs/phontab.md
+++ b/docs/phontab.md
@@ -5,7 +5,6 @@
 - [Phoneme Properties](#phoneme-properties)
   - [Type](#type)
   - [Properties](#properties)
-  - [Place of Articulation](#place-of-articulation)
   - [starttype](#starttype)
   - [endtype](#endtype)
   - [lengthmod](#lengthmod)


### PR DESCRIPTION
Place of articulation is already fully documented in phonemes.md
Closes #386. 