### PR TITLE
when end_clause_after_tag is set: end clause after the tag, not before the tag

### DIFF
--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -1711,9 +1711,6 @@ int ReadClause(Translator *tr, char *buf, short *charix, int *charix_top, int n_
 					terminator = ProcessSsmlTag(xml_buf, buf, &ix, n_buf, self_closing);
 
 					if (terminator != 0) {
-						if (end_clause_after_tag)
-							ix = end_clause_index;
-
 						buf[ix] = ' ';
 						buf[ix++] = 0;
 


### PR DESCRIPTION
Fixes #402.

Before the commit, the `ix = end_clause_index` was causing the buffer to be cut before the tag, not after it. This made it impossible to have <ssml> directives at the end of the clause because they were not processed. Notably, returning to default values after a <prosody> tag was not possible. See discussion of #402 for details.

After the commit, the clause is not cut before the tag and the possible embedded command inside is handled. 

**Possible regressions:**
There are other instances of `end_clause_after_tag` in the code that do something  but I'm unsure what  exactly.