### PR TITLE
Fix compiler warning

### DIFF
--- a/src/libespeak-ng/event.h
+++ b/src/libespeak-ng/event.h
@@ -62,6 +62,7 @@ espeak_ng_STATUS event_declare(espeak_EVENT *event);
 void event_terminate(void);
 
 // general functions
+struct timespec;
 void clock_gettime2(struct timespec *ts);
 void add_time_in_ms(struct timespec *ts, int time_in_ms);
 


### PR DESCRIPTION
Before this change, the clang compiler produced the following warning:

```
In file included from src/libespeak-ng/espeak_api.c:35:
src/libespeak-ng/event.h:65:28: warning: declaration of 'struct timespec' will
      not be visible outside of this function [-Wvisibility]
void clock_gettime2(struct timespec *ts);
                           ^
src/libespeak-ng/event.h:66:28: warning: declaration of 'struct timespec' will
      not be visible outside of this function [-Wvisibility]
void add_time_in_ms(struct timespec *ts, int time_in_ms);
                           ^
2 warnings generated.
```

The forward declaration of `struct timespec` makes the warning go away.