### PR TITLE
Reorganise header files

### DIFF
--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -36,7 +36,6 @@
 #include <espeak-ng/encoding.h>
 
 #include "error.h"
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -323,9 +323,9 @@ int proc_addr[N_PROCS];
 char proc_names[N_ITEM_STRING+1][N_PROCS];
 
 #define MAX_PROG_BUF 2000
-USHORT *prog_out;
-USHORT *prog_out_max;
-USHORT prog_buf[MAX_PROG_BUF+20];
+unsigned short *prog_out;
+unsigned short *prog_out_max;
+unsigned short prog_buf[MAX_PROG_BUF+20];
 
 static espeak_ng_STATUS ReadPhondataManifest(espeak_ng_ERROR_CONTEXT *context)
 {
@@ -442,8 +442,8 @@ STACK stack[N_STACK];
 #define N_IF_STACK 12
 int if_level;
 typedef struct {
-	USHORT *p_then;
-	USHORT *p_else;
+	unsigned short *p_then;
+	unsigned short *p_else;
 	bool returned;
 } IF_STACK;
 IF_STACK if_stack[N_IF_STACK];
@@ -1626,7 +1626,7 @@ static int CompileIf(int elif)
 	int bitmap;
 	int brackets;
 	bool not_flag;
-	USHORT *prog_last_if = NULL;
+	unsigned short *prog_last_if = NULL;
 
 	then_count = 2;
 	after_if = true;
@@ -1727,7 +1727,7 @@ static int CompileIf(int elif)
 
 static void FillThen(int add)
 {
-	USHORT *p;
+	unsigned short *p;
 	int offset;
 
 	p = if_stack[if_level].p_then;
@@ -1755,8 +1755,8 @@ static void FillThen(int add)
 
 static int CompileElse(void)
 {
-	USHORT *ref;
-	USHORT *p;
+	unsigned short *ref;
+	unsigned short *p;
 
 	if (if_level < 1) {
 		error("ELSE not expected");
@@ -1794,7 +1794,7 @@ static int CompileElif(void)
 
 static int CompileEndif(void)
 {
-	USHORT *p;
+	unsigned short *p;
 	int chain;
 	int offset;
 
@@ -2293,7 +2293,7 @@ static int CompilePhoneme(int compile_phoneme)
 	if (prog_out > prog_buf) {
 		// write out the program for this phoneme
 		fflush(f_phindex);
-		phoneme_out->program = ftell(f_phindex) / sizeof(USHORT);
+		phoneme_out->program = ftell(f_phindex) / sizeof(unsigned short);
 
 		if (f_prog_log != NULL) {
 			phoneme_prog_log.addr = phoneme_out->program;
@@ -2302,8 +2302,8 @@ static int CompilePhoneme(int compile_phoneme)
 		}
 
 		if (compile_phoneme == 0)
-			proc_addr[n_procs++] =  ftell(f_phindex) / sizeof(USHORT);
-		fwrite(prog_buf, sizeof(USHORT), prog_out - prog_buf, f_phindex);
+			proc_addr[n_procs++] =  ftell(f_phindex) / sizeof(unsigned short);
+		fwrite(prog_buf, sizeof(unsigned short), prog_out - prog_buf, f_phindex);
 	}
 
 	return 0;

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -22,6 +22,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -37,6 +37,14 @@
 #include "synthesize.h"
 #include "translate.h"
 
+typedef struct {
+	int points;
+	const char *phonemes;
+	int end_type;
+	char *del_fwd;
+} MatchRecord;
+
+
 int dictionary_skipwords;
 char dictionary_name[40];
 

--- a/src/libespeak-ng/error.h
+++ b/src/libespeak-ng/error.h
@@ -18,6 +18,8 @@
 #ifndef ESPEAK_NG_ERROR_API
 #define ESPEAK_NG_ERROR_API
 
+#include <espeak-ng/espeak_ng.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/espeak_api.c
+++ b/src/libespeak-ng/espeak_api.c
@@ -27,7 +27,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/espeak_command.c
+++ b/src/libespeak-ng/espeak_command.c
@@ -25,7 +25,6 @@
 
 #include <espeak-ng/espeak_ng.h>
 
-#include "speech.h"
 #include "espeak_command.h"
 
 #ifdef USE_ASYNC

--- a/src/libespeak-ng/espeak_command.h
+++ b/src/libespeak-ng/espeak_command.h
@@ -16,8 +16,10 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPEAK_COMMAND_H
-#define ESPEAK_COMMAND_H
+#ifndef ESPEAK_NG_COMMAND_H
+#define ESPEAK_NG_COMMAND_H
+
+#include <espeak-ng/espeak_ng.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/src/libespeak-ng/event.c
+++ b/src/libespeak-ng/event.c
@@ -33,7 +33,6 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
-#include "speech.h"
 #include "event.h"
 
 // my_mutex: protects my_thread_is_talking,

--- a/src/libespeak-ng/event.h
+++ b/src/libespeak-ng/event.h
@@ -16,9 +16,6 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EVENT_H
-#define EVENT_H
-
 /*
    Manage events (sentence, word, mark, end,...), is responsible of calling the external
    callback as soon as the relevant audio sample is played.
@@ -38,6 +35,11 @@
    Note: the timeout is checked against the real progress of the audio stream, which depends on pauses or underruns. If the real progress is lower than the expected one, a new timeout starts.
 
  */
+
+#ifndef ESPEAK_NG_EVENT_H
+#define ESPEAK_NG_EVENT_H
+
+#include <espeak-ng/espeak_ng.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/src/libespeak-ng/fifo.h
+++ b/src/libespeak-ng/fifo.h
@@ -16,11 +16,14 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FIFO_H
-#define FIFO_H
-
 // Helps to add espeak commands in a first-in first-out queue
 // and run them asynchronously.
+
+#ifndef ESPEAK_NG_FIFO_H
+#define ESPEAK_NG_FIFO_H
+
+#include <espeak-ng/espeak_ng.h>
+#include "espeak_command.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/src/libespeak-ng/ieee80.h
+++ b/src/libespeak-ng/ieee80.h
@@ -42,6 +42,7 @@
  * conversions, and accommodated conversions involving +/- infinity,
  * NaN's, and denormalized numbers.
  */
+
 #ifndef IEEE_H
 #define IEEE_H
 

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -28,7 +28,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/klatt.c
+++ b/src/libespeak-ng/klatt.c
@@ -34,7 +34,6 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"
@@ -938,7 +937,7 @@ static int Wavegen_Klatt(int resume)
 static void SetSynth_Klatt(int length, frame_t *fr1, frame_t *fr2, voice_t *v, int control)
 {
 	int ix;
-	DOUBLEX next;
+	double next;
 	int qix;
 	int cmd;
 	frame_t *fr3;

--- a/src/libespeak-ng/klatt.h
+++ b/src/libespeak-ng/klatt.h
@@ -167,14 +167,14 @@ typedef struct {
 	int bw;   // klatt bandwidth
 	int ap;   // parallel amplitude
 	int bp;   // parallel bandwidth
-	DOUBLEX freq1; // floating point versions of the above
-	DOUBLEX bw1;
-	DOUBLEX ap1;
-	DOUBLEX bp1;
-	DOUBLEX freq_inc;    // increment by this every 64 samples
-	DOUBLEX bw_inc;
-	DOUBLEX ap_inc;
-	DOUBLEX bp_inc;
+	double freq1; // floating point versions of the above
+	double bw1;
+	double ap1;
+	double bp1;
+	double freq_inc;    // increment by this every 64 samples
+	double bw_inc;
+	double ap_inc;
+	double bp_inc;
 }  klatt_peaks_t;
 
 void KlattInit(void);

--- a/src/libespeak-ng/klatt.h
+++ b/src/libespeak-ng/klatt.h
@@ -21,6 +21,12 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_KLATT_H
+#define ESPEAK_NG_KLATT_H
+
+#include "speech.h"
+#include "synthesize.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -178,4 +184,6 @@ int Wavegen_Klatt2(int length, int resume, frame_t *fr1, frame_t *fr2);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -82,7 +82,6 @@ void unload_MBR()
 #include <unistd.h>
 
 #include <espeak-ng/espeak_ng.h>
-#include "speech.h"
 
 /*
  * mbrola instance parameters

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -31,7 +31,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/phoneme.h
+++ b/src/libespeak-ng/phoneme.h
@@ -17,6 +17,11 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_PHONEME_H
+#define ESPEAK_NG_PHONEME_H
+
+#include <espeak-ng/espeak_ng.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -290,4 +295,6 @@ extern int phoneme_tab_number;
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -29,7 +29,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -28,7 +28,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/sintab.h
+++ b/src/libespeak-ng/sintab.h
@@ -17,6 +17,9 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_SINTAB_H
+#define ESPEAK_NG_SINTAB_H
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -283,4 +286,6 @@ short int sin_tab[2048] = {
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/spect.c
+++ b/src/libespeak-ng/spect.c
@@ -30,7 +30,6 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"
@@ -193,7 +192,7 @@ static espeak_ng_STATUS LoadFrame(SpectFrame *frame, FILE *stream, int file_form
 		}
 	}
 
-	spect_data = malloc(sizeof(USHORT) * frame->nx);
+	spect_data = malloc(sizeof(unsigned short) * frame->nx);
 
 	if (spect_data == NULL)
 		return ENOMEM;

--- a/src/libespeak-ng/spect.h
+++ b/src/libespeak-ng/spect.h
@@ -105,7 +105,7 @@ typedef struct {
 	unsigned short nx;
 	short markers;
 	int max_y;
-	USHORT *spect; // sqrt of harmonic amplitudes,  1-nx at 'pitch'
+	unsigned short *spect; // sqrt of harmonic amplitudes,  1-nx at 'pitch'
 
 	short klatt_param[N_KLATTP2];
 

--- a/src/libespeak-ng/spect.h
+++ b/src/libespeak-ng/spect.h
@@ -17,6 +17,13 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_SPECT_H
+#define ESPEAK_NG_SPECT_H
+
+#include <espeak-ng/espeak_ng.h>
+#include "synthesize.h"
+#include "speech.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -132,4 +139,6 @@ espeak_ng_STATUS LoadSpectSeq(SpectSeq *spect, const char *filename);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -57,10 +57,6 @@ extern "C"
    #define PATH_ESPEAK_DATA  "/usr/share/espeak-ng-data"
 #endif
 
-typedef unsigned short USHORT;
-typedef unsigned char UCHAR;
-typedef double DOUBLEX;
-
 typedef struct {
 	const char *mnem;
 	int value;

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -17,8 +17,10 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SPEECH_H
-#define SPEECH_H
+#ifndef ESPEAK_NG_SPEECH_H
+#define ESPEAK_NG_SPEECH_H
+
+#include <espeak-ng/espeak_ng.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/src/libespeak-ng/ssml.h
+++ b/src/libespeak-ng/ssml.h
@@ -21,6 +21,11 @@
 #ifndef ESPEAK_NG_SSML_API
 #define ESPEAK_NG_SSML_API
 
+#include <stdbool.h>
+#include <wchar.h>
+
+#include <espeak-ng/speak_lib.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -47,7 +47,7 @@ int current_phoneme_table;
 PHONEME_TAB *phoneme_tab[N_PHONEME_TAB];
 unsigned char phoneme_tab_flags[N_PHONEME_TAB];   // bit 0: not inherited
 
-USHORT *phoneme_index = NULL;
+unsigned short *phoneme_index = NULL;
 char *phondata_ptr = NULL;
 unsigned char *wavefile_data = NULL;
 static unsigned char *phoneme_tab_data = NULL;
@@ -498,7 +498,7 @@ static int CountVowelPosition(PHONEME_LIST *plist)
 	return count;
 }
 
-static bool InterpretCondition(Translator *tr, int control, PHONEME_LIST *plist, USHORT *p_prog, WORD_PH_DATA *worddata)
+static bool InterpretCondition(Translator *tr, int control, PHONEME_LIST *plist, unsigned short *p_prog, WORD_PH_DATA *worddata)
 {
 	int which;
 	int ix;
@@ -693,9 +693,9 @@ static bool InterpretCondition(Translator *tr, int control, PHONEME_LIST *plist,
 	return false;
 }
 
-static void SwitchOnVowelType(PHONEME_LIST *plist, PHONEME_DATA *phdata, USHORT **p_prog, int instn_type)
+static void SwitchOnVowelType(PHONEME_LIST *plist, PHONEME_DATA *phdata, unsigned short **p_prog, int instn_type)
 {
-	USHORT *prog;
+	unsigned short *prog;
 	int voweltype;
 	signed char x;
 
@@ -716,7 +716,7 @@ static void SwitchOnVowelType(PHONEME_LIST *plist, PHONEME_DATA *phdata, USHORT 
 	*p_prog += 12;
 }
 
-int NumInstnWords(USHORT *prog)
+int NumInstnWords(unsigned short *prog)
 {
 	int instn;
 	int instn2;
@@ -769,8 +769,8 @@ void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_
 	// bit 8:  change phonemes
 
 	PHONEME_TAB *ph;
-	USHORT *prog;
-	USHORT instn;
+	unsigned short *prog;
+	unsigned short instn;
 	int instn2;
 	int or_flag;
 	bool truth;
@@ -782,7 +782,7 @@ void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_
 
 	#define N_RETURN 10
 	int n_return = 0;
-	USHORT *return_addr[N_RETURN]; // return address stack
+	unsigned short *return_addr[N_RETURN]; // return address stack
 
 	ph = plist->ph;
 

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -32,7 +32,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -17,12 +17,21 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
-#include <stdbool.h>
+#ifndef ESPEAK_NG_SYNTHESIZE_H
+#define ESPEAK_NG_SYNTHESIZE_H
+
+#include "speech.h"
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <espeak-ng/espeak_ng.h>
+#include "phoneme.h"
+#include "voice.h"
 
 #define espeakINITIALIZE_PHONEME_IPA 0x0002 // move this to speak_lib.h, after eSpeak version 1.46.02
 
@@ -558,4 +567,6 @@ void InitBreath(void);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -20,8 +20,6 @@
 #ifndef ESPEAK_NG_SYNTHESIZE_H
 #define ESPEAK_NG_SYNTHESIZE_H
 
-#include "speech.h"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -137,14 +137,14 @@ typedef struct {
 	int height;   // height<<15
 	int left;     // Hz<<16
 	int right;    // Hz<<16
-	DOUBLEX freq1; // floating point versions of the above
-	DOUBLEX height1;
-	DOUBLEX left1;
-	DOUBLEX right1;
-	DOUBLEX freq_inc; // increment by this every 64 samples
-	DOUBLEX height_inc;
-	DOUBLEX left_inc;
-	DOUBLEX right_inc;
+	double freq1; // floating point versions of the above
+	double height1;
+	double left1;
+	double right1;
+	double freq_inc; // increment by this every 64 samples
+	double height_inc;
+	double left_inc;
+	double right_inc;
 } wavegen_peaks_t;
 
 typedef struct {
@@ -561,7 +561,7 @@ int DoSpect2(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  PHONEME_L
 int PauseLength(int pause, int control);
 int LookupPhonemeTable(const char *name);
 unsigned char *GetEnvelope(int index);
-int NumInstnWords(USHORT *prog);
+int NumInstnWords(unsigned short *prog);
 
 void InitBreath(void);
 

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -30,7 +30,6 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -267,13 +267,6 @@ int clause_type_from_codepoint(uint32_t c);
 
 typedef const char *constcharptr;
 
-typedef struct {
-	int points;
-	const char *phonemes;
-	int end_type;
-	char *del_fwd;
-} MatchRecord;
-
 // used to mark words with the source[] buffer
 typedef struct {
 	unsigned int flags;

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -589,16 +589,6 @@ typedef struct {
 	int suffix_add_e;      // replace a suffix (which has the SUFX_E flag) with this character
 } LANGUAGE_OPTIONS;
 
-// a parameter of ChangePhonemes()
-typedef struct {
-	int flags;
-	unsigned char stress;          // stress level of this vowel
-	unsigned char stress_highest;  // the highest stress level of a vowel in this word
-	unsigned char n_vowels;        // number of vowels in the word
-	unsigned char vowel_this;      // syllable number of this vowel (counting from 1)
-	unsigned char vowel_stressed;  // syllable number of the highest stressed vowel
-} CHANGEPH;
-
 typedef struct {
 	LANGUAGE_OPTIONS langopts;
 	int translator_name;
@@ -769,7 +759,6 @@ void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
 char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 
 void MakePhonemeList(Translator *tr, int post_pause, bool new_sentence);
-int ChangePhonemes_ru(Translator *tr, PHONEME_LIST2 *phlist, int n_ph, int index, PHONEME_TAB *ph, CHANGEPH *ch);
 void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
 void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -17,6 +17,16 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_TRANSLATE_H
+#define ESPEAK_NG_TRANSLATE_H
+
+#include <stdbool.h>
+
+#include <espeak-ng/espeak_ng.h>
+#include <espeak-ng/encoding.h>
+
+#include "synthesize.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -783,4 +793,6 @@ extern FILE *f_trans; // for logging
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/voice.h
+++ b/src/libespeak-ng/voice.h
@@ -22,8 +22,6 @@
 
 #include <espeak-ng/espeak_ng.h>
 
-#include "speech.h"
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -80,7 +78,7 @@ typedef struct {
 } voice_t;
 
 // percentages shown to user, ix=N_PEAKS means ALL peaks
-extern USHORT voice_pcnt[N_PEAKS+1][3];
+extern unsigned short voice_pcnt[N_PEAKS+1][3];
 
 extern espeak_VOICE current_voice_selected;
 

--- a/src/libespeak-ng/voice.h
+++ b/src/libespeak-ng/voice.h
@@ -17,6 +17,13 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ESPEAK_NG_VOICE_H
+#define ESPEAK_NG_VOICE_H
+
+#include <espeak-ng/espeak_ng.h>
+
+#include "speech.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -92,4 +99,6 @@ void FreeVoiceList(void);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -32,10 +32,10 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
+#include "synthesize.h"
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"
-#include "synthesize.h"
 
 #ifdef INCLUDE_KLATT
 #include "klatt.h"

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -1151,7 +1151,7 @@ static void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *
 		return;
 
 	int ix;
-	DOUBLEX next;
+	double next;
 	int length2;
 	int length4;
 	int qix;


### PR DESCRIPTION
Currently, some header files don't have include guards, and the .c files need to include the headers in a specific order. 

The  commit makes is possible to include headers in any order. It also removes some unnecessary includes and unused declarations.This helps in all further restructuring efforts.

**TODO**
There are 30 .c files and 15 .h files. Most headers include declarations for functions defined in various .c files. For example, Translate.h declares functions used in about 10 different .c files.

Having so few header files makes the existing ones very bulky. I think it would be better to have a corresponding header for each .c file. The .c files could then include only those headers they need instead of more han 1000 lines of translate.h and synthesize.h combined. Build times would decrease.