### PR TITLE
Restructuring headers

### DIFF
--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -35,7 +35,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "readclause.h" 
+#include "readclause.h"
+#include "synthdata.h"
 
 #include "error.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -37,6 +37,7 @@
 
 #include "readclause.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "error.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -35,6 +35,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h" 
+
 #include "error.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -33,6 +33,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "compiledict.h"
 #include "dictionary.h"
 #include "readclause.h"
 
@@ -42,8 +43,6 @@
 #include "voice.h"
 #include "synthesize.h"
 #include "translate.h"
-
-extern void Write4Bytes(FILE *f, int value);
 
 static FILE *f_log = NULL;
 extern char *dir_dictionary;

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -33,6 +33,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "error.h"
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -33,6 +33,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
 #include "readclause.h"
 
 #include "error.h"

--- a/src/libespeak-ng/compiledict.h
+++ b/src/libespeak-ng/compiledict.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_COMPILEDICT_H
+#define ESPEAK_NG_COMPILEDICT_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+char *DecodeRule(const char *group_chars, 
+		int group_length,
+		char *rule,
+		int control);
+
+ESPEAK_NG_API espeak_ng_STATUS espeak_ng_CompileDictionary(const char *dsource,
+		const char *dict_name,
+		FILE *log,
+		int flags,
+		espeak_ng_ERROR_CONTEXT *context);
+
+
+void print_dictionary_flags(unsigned int *flags,
+		char *buf,
+		int buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/compilembrola.c
+++ b/src/libespeak-ng/compilembrola.c
@@ -28,6 +28,8 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
+#include "mbrola.h"
+
 #include "error.h"
 #include "phoneme.h"
 #include "speech.h"

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -32,6 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -33,6 +33,7 @@
 
 #include "readclause.h"
 #include "synthdata.h"
+#include "numbers.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -31,6 +31,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -31,9 +31,10 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
+#include "numbers.h"
 #include "readclause.h"
 #include "synthdata.h"
-#include "numbers.h"
 
 #include "speech.h"
 #include "phoneme.h"
@@ -98,7 +99,7 @@ void strncpy0(char *to, const char *from, int size)
 }
 #pragma GCC visibility pop
 
-int Reverse4Bytes(int word)
+static int Reverse4Bytes(int word)
 {
 	// reverse the order of bytes from little-endian to big-endian
 #ifdef ARCH_BIG

--- a/src/libespeak-ng/dictionary.h
+++ b/src/libespeak-ng/dictionary.h
@@ -21,6 +21,7 @@
 #ifndef ESPEAK_NG_DICTIONARY_H
 #define ESPEAK_NG_DICTIONARY_H
 
+#include "compiledict.h"
 #include "synthesize.h"
 #include "translate.h"
 

--- a/src/libespeak-ng/dictionary.h
+++ b/src/libespeak-ng/dictionary.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_DICTIONARY_H
+#define ESPEAK_NG_DICTIONARY_H
+
+#include "synthesize.h"
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void strncpy0(char *to, const char *from, int size);
+int LoadDictionary(Translator *tr, const char *name, int no_error);
+int HashDictionary(const char *string);
+const char *EncodePhonemes(const char *p, char *outptr, int *bad_phoneme);
+void DecodePhonemes(const char *inptr, char *outptr);
+char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int use_ipa, int *flags);
+const char *GetTranslatedPhonemeString(int phoneme_mode);
+int IsVowel(Translator *tr, int letter);
+int Unpronouncable(Translator *tr, char *word, int posn);
+void ChangeWordStress(Translator *tr, char *word, int new_stress);
+void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags, int tonic, int control);
+void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
+int TranslateRules(Translator *tr, char *p_start, char *phonemes, int ph_size, char *end_phonemes, int word_flags, unsigned int *dict_flags);
+int TransposeAlphabet(Translator *tr, char *text);
+int Lookup(Translator *tr, const char *word, char *ph_out);
+int LookupDictList(Translator *tr, char **wordptr, char *ph_out, unsigned int *flags, int end_flags, WORD_TAB *wtab);
+int LookupFlags(Translator *tr, const char *word, unsigned int **flags_out);
+int RemoveEnding(Translator *tr, char *word, int end_type, char *word_copy);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/espeak_api.c
+++ b/src/libespeak-ng/espeak_api.c
@@ -27,6 +27,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "compiledict.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -28,6 +28,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "intonation.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -29,6 +29,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "intonation.h"
+#include "synthdata.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/intonation.h
+++ b/src/libespeak-ng/intonation.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_INTONATION_H
+#define ESPEAK_NG_INTONATION_H
+
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void CalcPitches(Translator *tr, int clause_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/mbrola.h
+++ b/src/libespeak-ng/mbrola.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+// declarations for compilembrola.c and synth_mbrola.c
+
+#ifndef ESPEAK_NG_MBROLA_H
+#define ESPEAK_NG_MBROLA_H
+
+#include <stdbool.h>
+
+#include "synthesize.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct {
+        int name;
+        unsigned int next_phoneme;
+        int mbr_name;
+        int mbr_name2;
+        int percent; // percentage length of first component
+        int control;
+} MBROLA_TAB;
+
+extern int mbrola_delay;
+extern char mbrola_name[20];
+
+espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice,
+		const char *phtrans, 
+		int *srate);
+
+int MbrolaGenerate(PHONEME_LIST *phoneme_list,
+		int *n_ph, bool resume);
+
+int MbrolaFill(int length,
+		bool resume,
+		int amplitude);
+
+void MbrolaReset(void);
+int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, bool resume, FILE *f_mbrola);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -31,6 +31,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -34,6 +34,7 @@
 #include "dictionary.h"
 #include "numbers.h"
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -32,6 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "numbers.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -31,8 +31,9 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "readclause.h"
+#include "dictionary.h"
 #include "numbers.h"
+#include "readclause.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/numbers.h
+++ b/src/libespeak-ng/numbers.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_NUMBERS_H
+#define ESPEAK_NG_NUMBERS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void LookupAccentedLetter(Translator *tr, unsigned int letter, char *ph_buf);
+void LookupLetter(Translator *tr, unsigned int letter, int next_byte, char *ph_buf1, int control);
+int IsSuperscript(int letter);
+void SetSpellingStress(Translator *tr, char *phonemes, int control, int n_chars);
+int TranslateRoman(Translator *tr, char *word, char *ph_out, WORD_TAB *wtab);
+int TranslateNumber(Translator *tr, char *word1, char *ph_out, unsigned int *flags, WORD_TAB *wtab, int control);
+int TranslateLetter(Translator *tr, char *word, char *phonemes, int control);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/phoneme.h
+++ b/src/libespeak-ng/phoneme.h
@@ -285,9 +285,6 @@ typedef struct {
 int LookupPhonemeString(const char *string);
 int PhonemeCode(unsigned int mnem);
 
-const char *EncodePhonemes(const char *p, char *outptr, int *bad_phoneme);
-void DecodePhonemes(const char *inptr, char *outptr);
-
 extern const char *WordToString(unsigned int word);
 
 extern PHONEME_TAB_LIST phoneme_tab_list[N_PHONEME_TABS];

--- a/src/libespeak-ng/phoneme.h
+++ b/src/libespeak-ng/phoneme.h
@@ -282,8 +282,6 @@ typedef struct {
 #define PH(c1, c2) (c2<<8)+c1          // combine two characters into an integer for phoneme name
 #define PH3(c1, c2, c3) (c3<<16)+(c2<<8)+c1
 #define PhonemeCode2(c1, c2) PhonemeCode((c2<<8)+c1)
-int LookupPhonemeString(const char *string);
-int PhonemeCode(unsigned int mnem);
 
 extern const char *WordToString(unsigned int word);
 

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -29,6 +29,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "phonemelist.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -30,6 +30,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "phonemelist.h"
+#include "synthdata.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/phonemelist.h
+++ b/src/libespeak-ng/phonemelist.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_PHONEMELIST_H
+#define ESPEAK_NG_PHONEMELIST_H
+
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+void MakePhonemeList(Translator *tr, int post_pause, bool start_sentence);
+
+#endif
+

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -36,6 +36,7 @@
 #include <espeak-ng/encoding.h>
 #include <ucd/ucd.h>
 
+#include "dictionary.h"
 #include "readclause.h"
 
 #include "error.h"

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -38,6 +38,7 @@
 
 #include "dictionary.h"
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "error.h"
 #include "speech.h"

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -36,6 +36,8 @@
 #include <espeak-ng/encoding.h>
 #include <ucd/ucd.h>
 
+#include "readclause.h"
+
 #include "error.h"
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/readclause.h
+++ b/src/libespeak-ng/readclause.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+#ifndef ESPEAK_NG_READCLAUSE_H
+#define ESPEAK_NG_READCLAUSE_H
+
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct {
+	int type;
+	int parameter[N_SPEECH_PARAM];
+} PARAM_STACK;
+
+extern PARAM_STACK param_stack[];
+extern const int param_defaults[N_SPEECH_PARAM];
+
+ int clause_type_from_codepoint(uint32_t c);
+int towlower2(unsigned int c); // Supports Turkish I
+int Eof(void);
+const char *WordToString2(unsigned int word);
+int Read4Bytes(FILE *f);
+int LoadSoundFile2(const char *fname);
+int AddNameData(const char *name,
+                int wide);
+int ReadClause(Translator *tr,
+		char *buf,
+		short *charix,
+		int *charix_top,
+		int n_buf,
+		int *tone_type,
+		char *voice_change);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -31,6 +31,7 @@
 #include "readclause.h"
 #include "setlengths.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -28,6 +28,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -29,6 +29,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "setlengths.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -30,6 +30,7 @@
 
 #include "readclause.h"
 #include "setlengths.h"
+#include "synthdata.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/setlengths.h
+++ b/src/libespeak-ng/setlengths.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_SETLENGTHS_H
+#define ESPEAK_NG_SETLENGTHS_H
+
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void CalcLengths(Translator *tr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/spect.h
+++ b/src/libespeak-ng/spect.h
@@ -21,6 +21,9 @@
 #define ESPEAK_NG_SPECT_H
 
 #include <espeak-ng/espeak_ng.h>
+
+#include "wavegen.h"
+
 #include "synthesize.h"
 #include "speech.h"
 

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -48,6 +48,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -49,6 +49,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "dictionary.h"
+#include "mbrola.h"
 #include "readclause.h"
 #include "synthdata.h"
 #include "wavegen.h"

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -48,6 +48,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
 #include "readclause.h"
 
 #include "speech.h"

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -51,6 +51,7 @@
 #include "dictionary.h"
 #include "readclause.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -50,6 +50,7 @@
 
 #include "dictionary.h"
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -22,6 +22,8 @@
 
 #include <espeak-ng/espeak_ng.h>
 
+#include "mbrola.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/ssml.c
+++ b/src/libespeak-ng/ssml.c
@@ -39,6 +39,8 @@
 #include <espeak-ng/encoding.h>
 #include <ucd/ucd.h>
 
+#include "readclause.h"
+
 #include "error.h"
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/ssml.h
+++ b/src/libespeak-ng/ssml.h
@@ -62,11 +62,6 @@ typedef struct {
 #define HTML_NOSPACE     16   // don't insert a space for this element, so it doesn't break a word
 #define SSML_CLOSE       0x20 // for a closing tag, OR this with the tag type
 
-int LoadSoundFile2(const char *fname);
-
-int AddNameData(const char *name,
-                int wide);
-
 int ProcessSsmlTag(wchar_t *xml_buf,
                    char *outbuf,
                    int *outix,

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -33,6 +33,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -32,6 +32,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -35,6 +35,7 @@
 #include "dictionary.h"
 #include "readclause.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -32,6 +32,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
 #include "readclause.h"
 #include "synthdata.h"
 

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -33,9 +33,11 @@
 #include <espeak-ng/encoding.h>
 
 #include "dictionary.h"
+#include "mbrola.h"
 #include "readclause.h"
 #include "synthdata.h"
 #include "wavegen.h"
+
 
 #include "speech.h"
 #include "phoneme.h"
@@ -43,9 +45,12 @@
 #include "synthesize.h"
 #include "translate.h"
 
+// included here so tests can find these even without OPT_MBROLA set
+int mbrola_delay;
+char mbrola_name[20];
+
 #ifdef INCLUDE_MBROLA
 
-extern int Read4Bytes(FILE *f);
 extern unsigned char *outbuf;
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -31,6 +31,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "error.h"
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -32,6 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "error.h"
 #include "speech.h"

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -29,8 +29,31 @@ extern "C"
 {
 #endif
 
-void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_DATA *phdata, WORD_PH_DATA *worddata);
-void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata);
+void InterpretPhoneme(Translator *tr,
+		int control,
+		PHONEME_LIST *plist,
+		PHONEME_DATA *phdata,
+		WORD_PH_DATA *worddata);
+
+void InterpretPhoneme2(int phcode,
+		PHONEME_DATA *phdata);
+
+void FreePhData(void);
+unsigned char *GetEnvelope(int index);
+espeak_ng_STATUS LoadPhData(int *srate, espeak_ng_ERROR_CONTEXT *context);
+void LoadConfig(void);
+int LookupPhonemeString(const char *string);
+int LookupPhonemeTable(const char *name);
+frameref_t *LookupSpect(PHONEME_TAB *this_ph,
+		int which,
+		FMT_PARAMS *fmt_params,
+		int *n_frames,
+		PHONEME_LIST *plist);
+
+int NumInstnWords(unsigned short *prog);
+int PhonemeCode(unsigned int mnem);
+void SelectPhonemeTable(int number);
+int  SelectPhonemeTableName(const char *name);
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -21,17 +21,13 @@
 #ifndef ESPEAK_NG_SYNTHDATA_H
 #define ESPEAK_NG_SYNTHDATA_H
 
+#include "synthesize.h"
 #include "translate.h"
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-// forward declare these to avoid including the whole synthesize.h
-struct PHONEME_LIST;
-struct PHONEME_DATA;
-struct WORD_PH_DATA;
 
 void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_DATA *phdata, WORD_PH_DATA *worddata);
 void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata);

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_SYNTHDATA_H
+#define ESPEAK_NG_SYNTHDATA_H
+
+#include "translate.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// forward declare these to avoid including the whole synthesize.h
+struct PHONEME_LIST;
+struct PHONEME_DATA;
+struct WORD_PH_DATA;
+
+void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_DATA *phdata, WORD_PH_DATA *worddata);
+void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -32,6 +32,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
 #include "intonation.h"
 #include "setlengths.h"
 #include "synthdata.h"

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -34,6 +34,7 @@
 
 #include "intonation.h"
 #include "setlengths.h"
+#include "synthdata.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -32,6 +32,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "intonation.h"
+
 #include "phoneme.h"
 #include "voice.h"
 #include "synthesize.h"

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -34,6 +34,7 @@
 
 #include "dictionary.h"
 #include "intonation.h"
+#include "mbrola.h"
 #include "setlengths.h"
 #include "synthdata.h"
 #include "wavegen.h"
@@ -49,9 +50,6 @@ static void SmoothSpect(void);
 // list of phonemes in a clause
 int n_phoneme_list = 0;
 PHONEME_LIST phoneme_list[N_PHONEME_LIST+1];
-
-int mbrola_delay;
-char mbrola_name[20];
 
 SPEED_FACTORS speed;
 

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -33,6 +33,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "intonation.h"
+#include "setlengths.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -36,6 +36,7 @@
 #include "intonation.h"
 #include "setlengths.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -513,7 +513,6 @@ int  SelectPhonemeTableName(const char *name);
 int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
 
 void Write4Bytes(FILE *f, int value);
-int Read4Bytes(FILE *f);
 int Reverse4Bytes(int word);
 
 #if HAVE_SONIC_H

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -513,7 +513,6 @@ int  SelectPhonemeTableName(const char *name);
 int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
 
 void Write4Bytes(FILE *f, int value);
-int Reverse4Bytes(int word);
 
 #if HAVE_SONIC_H
 void DoSonicSpeed(int value);

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -339,15 +339,6 @@ typedef struct {
 } SOUND_ICON;
 
 typedef struct {
-	int name;
-	unsigned int next_phoneme;
-	int mbr_name;
-	int mbr_name2;
-	int percent; // percentage length of first component
-	int control;
-} MBROLA_TAB;
-
-typedef struct {
 	int pause_factor;
 	int clause_pause_factor;
 	unsigned int min_pause;
@@ -464,9 +455,6 @@ extern int echo_tail;
 extern int echo_amp;
 extern short echo_buf[N_ECHO_BUF];
 
-extern int mbrola_delay;
-extern char mbrola_name[20];
-
 void SynthesizeInit(void);
 int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume);
 void MakeWave2(PHONEME_LIST *p, int n_ph);
@@ -506,12 +494,7 @@ extern double sonicSpeed;
 extern int n_soundicon_tab;
 extern SOUND_ICON soundicon_tab[N_SOUNDICON_TAB];
 
-espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans, int *srate);
 espeak_ng_STATUS SetParameter(int parameter, int value, int relative);
-int MbrolaTranslate(PHONEME_LIST *plist, int n_phonemes, bool resume, FILE *f_mbrola);
-int MbrolaGenerate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume);
-int MbrolaFill(int length, bool resume, int amplitude);
-void MbrolaReset(void);
 void DoEmbedded(int *embix, int sourceix);
 void DoMarker(int type, int char_posn, int length, int value);
 void DoPhonemeMarker(int type, int char_posn, int length, char *name);

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -35,7 +35,6 @@ extern "C"
 
 #define N_PHONEME_LIST 1000 // enough for source[N_TR_SOURCE] full of text, else it will truncate
 
-#define MAX_HARMONIC 400 // 400 * 50Hz = 20 kHz, more than enough
 #define N_SEQ_FRAMES  25 // max frames in a spectrum sequence (real max is ablut 8)
 #define STEPSIZE      64 // 2.9mS at 22 kHz sample rate
 
@@ -128,22 +127,6 @@ typedef struct { // 44 bytes
 	unsigned char bw[4];      // Klatt bandwidth BNZ /2, f1,f2,f3
 	unsigned char klattp[5];  // AV, FNZ, Tilt, Aspr, Skew
 } frame_t2; // without the extra Klatt parameters
-
-// formant data used by wavegen
-typedef struct {
-	int freq;     // Hz<<16
-	int height;   // height<<15
-	int left;     // Hz<<16
-	int right;    // Hz<<16
-	double freq1; // floating point versions of the above
-	double height1;
-	double left1;
-	double right1;
-	double freq_inc; // increment by this every 64 samples
-	double height_inc;
-	double left_inc;
-	double right_inc;
-} wavegen_peaks_t;
 
 typedef struct {
 	unsigned char *pitch_env;
@@ -462,17 +445,7 @@ extern intptr_t wcmdq[N_WCMDQ][4];
 extern int wcmdq_head;
 extern int wcmdq_tail;
 
-// from Wavegen file
-int  WcmdqFree(void);
-void WcmdqStop(void);
-int  WcmdqUsed(void);
-void WcmdqInc(void);
-void WavegenInit(int rate, int wavemult_fact);
-int WavegenFill(void);
 void MarkerEvent(int type, unsigned int char_position, int value, int value2, unsigned char *out_ptr);
-int GetAmplitude(void);
-void SetPitch2(voice_t *voice, int pitch1, int pitch2, int *pitch_base, int *pitch_range);
-int PeaksToHarmspect(wavegen_peaks_t *peaks, int pitch, int *htab, int control);
 
 extern unsigned char *wavefile_data;
 extern int samplerate;
@@ -545,8 +518,6 @@ void DoPhonemeMarker(int type, int char_posn, int length, char *name);
 int DoSample3(PHONEME_DATA *phdata, int length_mod, int amp);
 int DoSpect2(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  PHONEME_LIST *plist, int modulation);
 int PauseLength(int pause, int control);
-
-void InitBreath(void);
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -494,22 +494,12 @@ extern short echo_buf[N_ECHO_BUF];
 extern int mbrola_delay;
 extern char mbrola_name[20];
 
-// from synthdata file
-unsigned int LookupSound(PHONEME_TAB *ph1, PHONEME_TAB *ph2, int which, int *match_level, int control);
-frameref_t *LookupSpect(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  int *n_frames, PHONEME_LIST *plist);
-void FreePhData(void);
-
-unsigned char *LookupEnvelope(int ix);
-espeak_ng_STATUS LoadPhData(int *srate, espeak_ng_ERROR_CONTEXT *context);
-
 void SynthesizeInit(void);
 int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume);
 void MakeWave2(PHONEME_LIST *p, int n_ph);
 int  SpeakNextClause(int control);
 void SetSpeed(int control);
 void SetEmbedded(int control, int value);
-void SelectPhonemeTable(int number);
-int  SelectPhonemeTableName(const char *name);
 int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
 
 void Write4Bytes(FILE *f, int value);
@@ -555,9 +545,6 @@ void DoPhonemeMarker(int type, int char_posn, int length, char *name);
 int DoSample3(PHONEME_DATA *phdata, int length_mod, int amp);
 int DoSpect2(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  PHONEME_LIST *plist, int modulation);
 int PauseLength(int pause, int control);
-int LookupPhonemeTable(const char *name);
-unsigned char *GetEnvelope(int index);
-int NumInstnWords(unsigned short *prog);
 
 void InitBreath(void);
 

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -33,6 +33,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "readclause.h"
+#include "phonemelist.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -32,9 +32,10 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
-#include "readclause.h"
-#include "phonemelist.h"
+#include "dictionary.h"
 #include "numbers.h"
+#include "phonemelist.h"
+#include "readclause.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -32,6 +32,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -34,6 +34,7 @@
 
 #include "readclause.h"
 #include "phonemelist.h"
+#include "numbers.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -36,6 +36,7 @@
 #include "numbers.h"
 #include "phonemelist.h"
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -25,8 +25,6 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/encoding.h>
 
-#include "synthesize.h"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -738,7 +738,6 @@ int HashDictionary(const char *string);
 void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
 char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 
-void MakePhonemeList(Translator *tr, int post_pause, bool new_sentence);
 void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
 void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -715,7 +715,6 @@ void DeleteTranslator(Translator *tr);
 void ProcessLanguageOptions(LANGUAGE_OPTIONS *langopts);
 
 void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
-char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 
 void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -710,7 +710,6 @@ int IsDigit(unsigned int c);
 int IsDigit09(unsigned int c);
 int IsAlpha(unsigned int c);
 int IsVowel(Translator *tr, int c);
-int IsSuperscript(int letter);
 int isspace2(unsigned int c);
 const char *GetTranslatedPhonemeString(int phoneme_mode);
 ALPHABET *AlphabetFromChar(int c);
@@ -722,14 +721,7 @@ void ProcessLanguageOptions(LANGUAGE_OPTIONS *langopts);
 int Lookup(Translator *tr, const char *word, char *ph_out);
 int LookupFlags(Translator *tr, const char *word, unsigned int **flags_out);
 
-int TranslateNumber(Translator *tr, char *word1, char *ph_out, unsigned int *flags, WORD_TAB *wtab, int control);
-int TranslateRoman(Translator *tr, char *word, char *ph_out, WORD_TAB *wtab);
-
 void ChangeWordStress(Translator *tr, char *word, int new_stress);
-void SetSpellingStress(Translator *tr, char *phonemes, int control, int n_chars);
-int TranslateLetter(Translator *tr, char *letter, char *phonemes, int control);
-void LookupLetter(Translator *tr, unsigned int letter, int next_byte, char *ph_buf, int control);
-void LookupAccentedLetter(Translator *tr, unsigned int letter, char *ph_buf);
 
 int LoadDictionary(Translator *tr, const char *name, int no_error);
 int LookupDictList(Translator *tr, char **wordptr, char *ph_out, unsigned int *flags, int end_flags, WORD_TAB *wtab);

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -246,8 +246,6 @@ extern "C"
 #define CLAUSE_COLON       (30 | CLAUSE_INTONATION_FULL_STOP   | CLAUSE_TYPE_CLAUSE)
 #define CLAUSE_SEMICOLON   (30 | CLAUSE_INTONATION_COMMA       | CLAUSE_TYPE_CLAUSE)
 
-int clause_type_from_codepoint(uint32_t c);
-
 //@}
 
 #define SAYAS_CHARS        0x12
@@ -276,14 +274,6 @@ typedef struct {
 	unsigned short sourceix;
 	unsigned char length;
 } WORD_TAB;
-
-typedef struct {
-	int type;
-	int parameter[N_SPEECH_PARAM];
-} PARAM_STACK;
-
-extern PARAM_STACK param_stack[];
-extern const int param_defaults[N_SPEECH_PARAM];
 
 typedef struct {
 	const char *name;
@@ -711,7 +701,6 @@ int utf8_nbytes(const char *buf);
 
 int lookupwchar(const unsigned short *list, int c);
 int lookupwchar2(const unsigned short *list, int c);
-int Eof(void);
 char *strchr_w(const char *s, int c);
 int IsBracket(int c);
 void InitNamedata(void);
@@ -723,9 +712,7 @@ int IsAlpha(unsigned int c);
 int IsVowel(Translator *tr, int c);
 int IsSuperscript(int letter);
 int isspace2(unsigned int c);
-int towlower2(unsigned int c); // Supports Turkish I
 const char *GetTranslatedPhonemeString(int phoneme_mode);
-const char *WordToString2(unsigned int word);
 ALPHABET *AlphabetFromChar(int c);
 
 Translator *SelectTranslator(const char *name);
@@ -764,7 +751,6 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 int TranslateRules(Translator *tr, char *p, char *phonemes, int size, char *end_phonemes, int end_flags, unsigned int *dict_flags);
 int TranslateWord(Translator *tr, char *word1, WORD_TAB *wtab, char *word_out);
 void TranslateClause(Translator *tr, int *tone, char **voice_change);
-int ReadClause(Translator *tr, char *buf, short *charix, int *charix_top, int n_buf, int *tone_type, char *voice_change);
 
 void SetVoiceStack(espeak_VOICE *v, const char *variant_name);
 void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_DATA *phdata, WORD_PH_DATA *worddata);

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -686,8 +686,6 @@ extern int (*uri_callback)(int, const char *, const char *);
 extern int (*phoneme_callback)(const char *);
 extern void SetLengthMods(Translator *tr, int value);
 
-void LoadConfig(void);
-
 #define LEADING_2_BITS 0xC0 // 0b11000000
 #define UTF8_TAIL_BITS 0x80 // 0b10000000
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -742,8 +742,6 @@ void MakePhonemeList(Translator *tr, int post_pause, bool new_sentence);
 void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
 void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
 
-void CalcLengths(Translator *tr);
-
 int RemoveEnding(Translator *tr, char *word, int end_type, char *word_copy);
 int Unpronouncable(Translator *tr, char *word, int posn);
 void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags, int tonic, int prev_stress);

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -749,8 +749,6 @@ int TranslateWord(Translator *tr, char *word1, WORD_TAB *wtab, char *word_out);
 void TranslateClause(Translator *tr, int *tone, char **voice_change);
 
 void SetVoiceStack(espeak_VOICE *v, const char *variant_name);
-void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_DATA *phdata, WORD_PH_DATA *worddata);
-void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata);
 char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int use_ipa, int *flags);
 
 extern FILE *f_trans; // for logging

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -743,7 +743,6 @@ void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
 void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
 
 void CalcLengths(Translator *tr);
-void CalcPitches(Translator *tr, int clause_tone);
 
 int RemoveEnding(Translator *tr, char *word, int end_type, char *word_copy);
 int Unpronouncable(Translator *tr, char *word, int posn);

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -689,7 +689,6 @@ extern int (*phoneme_callback)(const char *);
 extern void SetLengthMods(Translator *tr, int value);
 
 void LoadConfig(void);
-int TransposeAlphabet(Translator *tr, char *text);
 
 #define LEADING_2_BITS 0xC0 // 0b11000000
 #define UTF8_TAIL_BITS 0x80 // 0b10000000
@@ -709,39 +708,23 @@ void InitText2(void);
 int IsDigit(unsigned int c);
 int IsDigit09(unsigned int c);
 int IsAlpha(unsigned int c);
-int IsVowel(Translator *tr, int c);
 int isspace2(unsigned int c);
-const char *GetTranslatedPhonemeString(int phoneme_mode);
 ALPHABET *AlphabetFromChar(int c);
 
 Translator *SelectTranslator(const char *name);
 int SetTranslator2(const char *name);
 void DeleteTranslator(Translator *tr);
 void ProcessLanguageOptions(LANGUAGE_OPTIONS *langopts);
-int Lookup(Translator *tr, const char *word, char *ph_out);
-int LookupFlags(Translator *tr, const char *word, unsigned int **flags_out);
-
-void ChangeWordStress(Translator *tr, char *word, int new_stress);
-
-int LoadDictionary(Translator *tr, const char *name, int no_error);
-int LookupDictList(Translator *tr, char **wordptr, char *ph_out, unsigned int *flags, int end_flags, WORD_TAB *wtab);
-int HashDictionary(const char *string);
 
 void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
 char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 
 void ApplySpecialAttribute2(Translator *tr, char *phonemes, int dict_flags);
-void AppendPhonemes(Translator *tr, char *string, int size, const char *ph);
 
-int RemoveEnding(Translator *tr, char *word, int end_type, char *word_copy);
-int Unpronouncable(Translator *tr, char *word, int posn);
-void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags, int tonic, int prev_stress);
-int TranslateRules(Translator *tr, char *p, char *phonemes, int size, char *end_phonemes, int end_flags, unsigned int *dict_flags);
 int TranslateWord(Translator *tr, char *word1, WORD_TAB *wtab, char *word_out);
 void TranslateClause(Translator *tr, int *tone, char **voice_change);
 
 void SetVoiceStack(espeak_VOICE *v, const char *variant_name);
-char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int use_ipa, int *flags);
 
 extern FILE *f_trans; // for logging
 

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -38,6 +38,7 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "dictionary.h"
 #include "readclause.h"
 
 #include "speech.h"

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -40,6 +40,7 @@
 
 #include "dictionary.h"
 #include "readclause.h"
+#include "synthdata.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -38,6 +38,8 @@
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
+
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -41,6 +41,7 @@
 #include "dictionary.h"
 #include "readclause.h"
 #include "synthdata.h"
+#include "wavegen.h"
 
 #include "speech.h"
 #include "phoneme.h"

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -32,6 +32,8 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 
+#include "wavegen.h"
+
 #include "synthesize.h"
 #include "speech.h"
 #include "phoneme.h"
@@ -80,6 +82,7 @@ static RESONATOR rbreath[N_PEAKS];
 static int harm_sqrt_n = 0;
 
 #define N_LOWHARM  30
+#define MAX_HARMONIC 400 // 400 * 50Hz = 20 kHz, more than enough
 static int harm_inc[N_LOWHARM]; // only for these harmonics do we interpolate amplitude between steps
 static int *harmspect;
 static int hswitch = 0;
@@ -1393,7 +1396,7 @@ static int SpeedUp(short *outbuf, int length_in, int length_out, int end_of_text
 #endif
 
 // Call WavegenFill2, and then speed up the output samples.
-int WavegenFill()
+int WavegenFill(void)
 {
 	int finished;
 	unsigned char *p_start;

--- a/src/libespeak-ng/wavegen.h
+++ b/src/libespeak-ng/wavegen.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2005 to 2015 by Jonathan Duddington
+ * email: jonsd@users.sourceforge.net
+ * Copyright (C) 2015-2018 Reece H. Dunn
+ * Copyright (C) 2018 Juho Hiltunen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPEAK_NG_WAVEGEN_H
+#define ESPEAK_NG_WAVEGEN_H
+
+#include "voice.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct {
+	int freq;     // Hz<<16
+	int height;   // height<<15
+	int left;     // Hz<<16
+	int right;    // Hz<<16
+	double freq1; // floating point versions of the above
+	double height1;
+	double left1;
+	double right1;
+	double freq_inc; // increment by this every 64 samples
+	double height_inc;
+	double left_inc;
+	double right_inc;
+} wavegen_peaks_t;
+
+
+int GetAmplitude(void);
+void InitBreath(void);
+int PeaksToHarmspect(wavegen_peaks_t *peaks,
+		int pitch,
+		int *htab,
+		int control);
+
+void SetPitch2(voice_t *voice,
+		int pitch1,
+		int pitch2,
+		int *pitch_base,
+		int *pitch_range);
+
+void WavegenInit(int rate,
+		int wavemult_fact);
+
+
+int WavegenFill(void);
+void WavegenSetVoice(voice_t *v);
+int WcmdqFree(void);
+void WcmdqStop(void);
+int WcmdqUsed(void);
+void WcmdqInc(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/tests/readclause.c
+++ b/tests/readclause.c
@@ -29,6 +29,7 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/encoding.h>
 
+#include "readclause.h"
 #include "speech.h"
 #include "phoneme.h"
 #include "voice.h"


### PR DESCRIPTION
Add more header files so that functions in a .c file is declared in a corresponding .h file.


**TODO**
1. Formatting the headers might be off in some files.
2. synthesize.h and translate.h are still large files and included in many other headers. I think the codebase could be organized in even smaller files.
3. There are probably some unnecessary includes in the .c files. These should be removed.
