### PR TITLE
Link ssml-fuzzer.test against C++ standard library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -274,6 +274,9 @@ noinst_bin_PROGRAMS += tests/ssml-fuzzer.test
 tests_ssml_fuzzer_test_LDADD   = src/libespeak-ng.la ${LIB_FUZZING_ENGINE}
 tests_ssml_fuzzer_test_SOURCES = tests/ssml-fuzzer.c
 tests_ssml_fuzzer_test_DEPENDENCIES = src/libespeak-ng.la tests/libfuzzrunner.la
+# Force C++ linker because LLVM libFuzzer needs the C++ standard library.
+nodist_EXTRA_tests_ssml_fuzzer_test_SOURCES = dummy.cpp
+
 
 tests/ssml-fuzzer.check: tests/ssml-fuzzer.test
 	@echo "  TEST      $<"

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ dnl Program checks.
 dnl ================================================================
 
 AC_PROG_CC
+AC_PROG_CXX
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AC_PROG_LN_S


### PR DESCRIPTION
The LLVM libFuzzer is written in C++, so the fuzzer needs to be linked
as a C++ program. The automake trick for choosing the linker is
documented in [chapter 8.3.5 “Libtool Convenience
Libraries”](https://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html#Libtool-Convenience-Libraries)
of the GNU automake manual.

https://github.com/espeak-ng/espeak-ng/issues/407