### PR TITLE
Support `configure --with-sanitize=address|undefined|memory`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,12 @@ AM_CFLAGS = \
 	-Isrc/include -Isrc/include/compat -I src/ucd-tools/src/include \
 	-D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112L \
 	-Wno-endif-labels
+AM_LDFLAGS =
+
+if OPT_SANITIZE
+AM_CFLAGS += -fsanitize=$(SANITIZE)
+AM_LDFLAGS += -fsanitize=$(SANITIZE)
+endif
 
 EXTRA_DIST=
 
@@ -137,7 +143,7 @@ espeak_ng_include_HEADERS = \
 lib_LTLIBRARIES += src/libespeak-ng.la
 
 src_libespeak_ng_la_LDFLAGS = -version-info $(SHARED_VERSION) -lpthread -lm \
-	${PCAUDIOLIB_LIBS}
+	${PCAUDIOLIB_LIBS} ${AM_LDFLAGS}
 
 src_libespeak_ng_la_CFLAGS = \
 	-fPIC -fvisibility=hidden \
@@ -177,6 +183,8 @@ src_libespeak_ng_la_SOURCES = \
 	src/libespeak-ng/voices.c \
 	src/libespeak-ng/wavegen.c
 
+nodist_EXTRA_src_libespeak_ng_la_SOURCES =
+
 if OPT_KLATT
 src_libespeak_ng_la_CFLAGS  += -DINCLUDE_KLATT
 src_libespeak_ng_la_SOURCES += src/libespeak-ng/klatt.c
@@ -202,9 +210,10 @@ man1_MANS += src/speak-ng.1
 endif
 
 src_speak_ng_LDADD   = src/libespeak-ng.la
-src_speak_ng_LDFLAGS = -static -lm ${PCAUDIOLIB_LIBS}
+src_speak_ng_LDFLAGS = -static -lm ${PCAUDIOLIB_LIBS} ${AM_LDFLAGS}
 src_speak_ng_CFLAGS  = -Isrc/libespeak-ng ${AM_CFLAGS}
 src_speak_ng_SOURCES = src/speak-ng.c
+nodist_EXTRA_src_speak_ng_SOURCES =
 
 bin_PROGRAMS += src/espeak-ng
 
@@ -214,6 +223,13 @@ endif
 
 src_espeak_ng_LDADD   = src/libespeak-ng.la ${PCAUDIOLIB_LIBS}
 src_espeak_ng_SOURCES = src/espeak-ng.c
+
+if OPT_SANITIZE
+nodist_EXTRA_src_libespeak_ng_la_SOURCES += dummy_src_libespeak_ng_la.cpp
+nodist_EXTRA_src_speak_ng_SOURCES += dummy_src_speak_ng.cpp
+endif
+nodist_EXTRA_tests_ssml_fuzzer_test_SOURCES = dummy_tests_ssml_fuzer_test.cpp
+
 
 ##### tests:
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ dnl Program checks.
 dnl ================================================================
 
 AC_PROG_CC
+AC_PROG_CXX
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AC_PROG_LN_S
@@ -99,6 +100,19 @@ if test "$FREEBSD_FOUND" = "yes" ; then
 else
 	AC_MSG_RESULT([no])
 fi
+
+
+dnl ================================================================
+dnl Sanitizer checks.
+dnl ================================================================
+
+AC_ARG_WITH([sanitize],
+    [AS_HELP_STRING([--with-sanitize=no|address|memory|undefined], [use the LLVM sanitizer @<:@default=no@:>@])],
+    [SANITIZE=$with_sanitize],
+    [SANITIZE=no])
+AM_CONDITIONAL(OPT_SANITIZE, [test ! x"$SANITIZE" = xno])
+AC_SUBST(SANITIZE)
+
 
 dnl ================================================================
 dnl library checks.
@@ -282,6 +296,7 @@ AX_CHECK_COMPILE_FLAG([-Wuninitialized],         [CFLAGS="-Wuninitialized $CFLAG
 AX_CHECK_COMPILE_FLAG([-Wunused],                [CFLAGS="-Wunused $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wunused-parameter],      [CFLAGS="-Wunused-parameter $CFLAGS"])
 
+
 dnl ================================================================
 dnl Generate output.
 dnl ================================================================
@@ -297,6 +312,7 @@ AC_MSG_NOTICE([
 
         C99 Compiler:                  ${CC}
         C99 Compiler flags:            ${CFLAGS}
+        Sanitize:                      ${SANITIZE}
 
         Sonic:                         ${have_sonic}
         PCAudioLib:                    ${have_pcaudiolib}


### PR DESCRIPTION
Fixes https://github.com/espeak-ng/espeak-ng/issues/423.