### PR TITLE
Use correct BCP47 variant subtag for X-Sampa; shorten other variants

### DIFF
--- a/docs/phonemes.md
+++ b/docs/phonemes.md
@@ -66,10 +66,10 @@ transcriptions are consistent.
 | [`foncxs`](phonemes/cxs.md)           | CXS          | Conlang X-SAMPA                                      | ASCII    |
 | `fonipa`                              | IPA          | International Phonetic Alphabet                      | Unicode  |
 | [`fonkirsh`](phonemes/kirshenbaum.md) |              | Kirshenbaum (ASCII-IPA)                              | ASCII    |
-| [`fonxsampa`](phonemes/xsampa.md)     | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
-| `fonzsampa`                           | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
+| [`fonxsamp`](phonemes/xsampa.md)      | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
+| `fonzsamp`                            | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
 
-1. `foncxs`, `fonkirsh`, and `fonzsampa` are private use extensions defined in
+1. `foncxs`, `fonkirsh`, and `fonzsamp` are private use extensions defined in
    the [bcp47-extensions](https://raw.githubusercontent.com/espeak-ng/bcp47-data/master/bcp47-extensions)
    file.
 

--- a/docs/phonemes/cxs.md
+++ b/docs/phonemes/cxs.md
@@ -56,11 +56,10 @@ articulations, and diphthongs such as `ts` and consonant clusters such as
 | `foncxs`                     | CXS          | Conlang X-SAMPA                                      | ASCII    |
 | [`fonipa`](../phonemes.md)   | IPA          | International Phonetic Alphabet                      | Unicode  |
 | [`fonkirsh`](kirshenbaum.md) |              | Kirshenbaum (ASCII-IPA)                              | ASCII    |
-| [`fonxsampa`](xsampa.md)     | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
-| `fonxsampa`                  | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
-| `fonzsampa`                  | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
+| [`fonxsamp`](xsampa.md)      | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
+| `fonzsamp`                   | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
 
-1. `foncxs`, `fonkirsh`, and `fonzsampa` are private use extensions defined in
+1. `foncxs`, `fonkirsh`, and `fonzsamp` are private use extensions defined in
    the [bcp47-extensions](https://raw.githubusercontent.com/espeak-ng/bcp47-data/master/bcp47-extensions)
    file.
 

--- a/docs/phonemes/kirshenbaum.md
+++ b/docs/phonemes/kirshenbaum.md
@@ -40,10 +40,10 @@ and `>` characters after the base phoneme (`p<dnt>`).
 | [`foncxs`](cxs.md)         | CXS          | Conlang X-SAMPA                                      | ASCII    |
 | [`fonipa`](../phonemes.md) | IPA          | International Phonetic Alphabet                      | Unicode  |
 | `fonkirsh`                 |              | Kirshenbaum (ASCII-IPA)                              | ASCII    |
-| [`fonxsampa`](xsampa.md)   | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
-| `fonzsampa`                | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
+| [`fonxsamp`](xsampa.md)    | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
+| `fonzsamp`                 | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
 
-1. `foncxs`, `fonkirsh`, and `fonzsampa` are private use extensions defined in
+1. `foncxs`, `fonkirsh`, and `fonzsamp` are private use extensions defined in
    the [bcp47-extensions](https://raw.githubusercontent.com/espeak-ng/bcp47-data/master/bcp47-extensions)
    file.
 

--- a/docs/phonemes/xsampa.md
+++ b/docs/phonemes/xsampa.md
@@ -53,10 +53,10 @@ consonant clusters such as `t-s`.
 | [`foncxs`](cxs.md)           | CXS          | Conlang X-SAMPA                                      | ASCII    |
 | [`fonipa`](../phonemes.md)   | IPA          | International Phonetic Alphabet                      | Unicode  |
 | [`fonkirsh`](kirshenbaum.md) |              | Kirshenbaum (ASCII-IPA)                              | ASCII    |
-| `fonxsampa`                  | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
-| `fonzsampa`                  | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
+| `fonxsamp`                   | X-SAMPA      | Extended Speech Assessment Methods Phonetic Alphabet | ASCII    |
+| `fonzsamp`                   | Z-SAMPA      | Zompist Bulletin Board (ZBB) SAMPA                   | ASCII    |
 
-1. `foncxs`, `fonkirsh`, and `fonzsampa` are private use extensions defined in
+1. `foncxs`, `fonkirsh`, and `fonzsamp` are private use extensions defined in
    the [bcp47-extensions](https://raw.githubusercontent.com/espeak-ng/bcp47-data/master/bcp47-extensions)
    file.
 


### PR DESCRIPTION
According to page 5 of [RFC5645](https://tools.ietf.org/html/bcp47#page-1-5),
variant subtags must have 5 to 8 characters. A 9-character subtag is
sytactically ill-formed and should be rejected by conforming parsers.

Technically, BCP47 does not allow the use of unregistered variant subtags.
For `fonkirsh`, I’ve filed a
[language variant subtag registration request](https://mailarchive.ietf.org/arch/msg/ietf-languages/1IrLl3n4wJ4Fr1xXV34QquJn8Bc)
with the IETF. If IETF rejects my request, we could probably add
Kirshenbaum to Unicode’s registry for [RFC6497](https://tools.ietf.org/html/rfc6497).

Not sure what to do about the other non-registered variants. If they’re
commonly used, it might be an option to register them as well, but
they seem to be even more exotic than Kirshenbaum, and we wouldn’t to
bloat the BCP47 registry too much. If espeak-ng really wants to handle these
alphabets, it would probably make sense to use BCP47 private-use extensions,
such as `x-fonzsamp`. According to IETF BCP47, private-use subtags can have
up to (but not more than) 8 characters, so I’m shortening these too.