### PR TITLE
Code cleanup

### DIFF
--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -45,7 +45,6 @@
 #include "translate.h"
 
 static FILE *f_log = NULL;
-extern char *dir_dictionary;
 
 extern char word_phonemes[N_WORD_PHONEMES];    // a word translated into phoneme codes
 

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -503,7 +503,7 @@ char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int 
 
 	first = true;
 	for (mnem = ph->mnemonic; (c = mnem & 0xff) != 0; mnem = mnem >> 8) {
-		if ((c == '/') && (option_phoneme_variants == 0))
+		if (c == '/') // NOTE: this line used to be (c == '/') && (option_phoneme_variants == 0)) but always evaluated true
 			break; // discard phoneme variant indicator
 
 		if (use_ipa) {

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -289,18 +289,6 @@ static TONE_NUCLEUS tone_nucleus_table[N_TONE_NUCLEUS_TABLE] = {
 	{ PITCHfall,   70, 18, PITCHfall,   70, 24, NULL, 32, 20, 0 },      // 12 test
 };
 
-// index by 0=. 1=, 2=?, 3=! 4=none, 5=emphasized
-unsigned char punctuation_to_tone[INTONATION_TYPES][PUNCT_INTONATIONS] = {
-	{  0,  1,  2,  3, 0, 4 },
-	{  0,  1,  2,  3, 0, 4 },
-	{  5,  6,  2,  3, 0, 4 },
-	{  5,  7,  1,  3, 0, 4 },
-	{  8,  9, 10,  3, 0, 0 },
-	{  8,  8, 10,  3, 0, 0 },
-	{ 11, 11, 11, 11, 0, 0 }, // 6 test
-	{ 12, 12, 12, 12, 0, 0 }
-};
-
 int n_tunes = 0;
 TUNE *tunes = NULL;
 

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -664,7 +664,7 @@ int IsSuperscript(int letter)
 	return 0;
 }
 
-int TranslateLetter(Translator *tr, char *word, char *phonemes, int control)
+int TranslateLetter(Translator *tr, char *word, char *phonemes, int control, ALPHABET *current_alphabet)
 {
 	// get pronunciation for an isolated letter
 	// return number of bytes used by the letter

--- a/src/libespeak-ng/numbers.h
+++ b/src/libespeak-ng/numbers.h
@@ -21,6 +21,8 @@
 #ifndef ESPEAK_NG_NUMBERS_H
 #define ESPEAK_NG_NUMBERS_H
 
+#include "translate.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -32,7 +34,7 @@ int IsSuperscript(int letter);
 void SetSpellingStress(Translator *tr, char *phonemes, int control, int n_chars);
 int TranslateRoman(Translator *tr, char *word, char *ph_out, WORD_TAB *wtab);
 int TranslateNumber(Translator *tr, char *word1, char *ph_out, unsigned int *flags, WORD_TAB *wtab, int control);
-int TranslateLetter(Translator *tr, char *word, char *phonemes, int control);
+int TranslateLetter(Translator *tr, char *word, char *phonemes, int control, ALPHABET *current_alphabet);
 
 
 #ifdef __cplusplus

--- a/src/libespeak-ng/phoneme.h
+++ b/src/libespeak-ng/phoneme.h
@@ -224,8 +224,6 @@ phoneme_feature_t phoneme_feature_from_string(const char *feature);
 #define phonPAUSE_CLAUSE 27
 #define phonVOWELTYPES   28  // 28 to 33
 
-extern const unsigned char pause_phonemes[8];  // 0, vshort, short, pause, long, glottalstop
-
 #define N_PHONEME_TABS     150     // number of phoneme tables
 #define N_PHONEME_TAB      256     // max phonemes in a phoneme table
 #define N_PHONEME_TAB_NAME  32     // must be multiple of 4

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -132,24 +132,6 @@ int clause_type_from_codepoint(uint32_t c)
 	return CLAUSE_NONE;
 }
 
-const int param_defaults[N_SPEECH_PARAM] = {
-	0,   // silence (internal use)
-	175, // rate wpm
-	100, // volume
-	50,  // pitch
-	50,  // range
-	0,   // punctuation
-	0,   // capital letters
-	0,   // wordgap
-	0,   // options
-	0,   // intonation
-	0,
-	0,
-	0,   // emphasis
-	0,   // line length
-	0,   // voice type
-};
-
 int towlower2(unsigned int c)
 {
 	// check for non-standard upper to lower case conversions

--- a/src/libespeak-ng/readclause.h
+++ b/src/libespeak-ng/readclause.h
@@ -33,7 +33,6 @@ typedef struct {
 } PARAM_STACK;
 
 extern PARAM_STACK param_stack[];
-extern const int param_defaults[N_SPEECH_PARAM];
 
  int clause_type_from_codepoint(uint32_t c);
 int towlower2(unsigned int c); // Supports Turkish I

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -377,6 +377,7 @@ espeak_ng_STATUS SetParameter(int parameter, int value, int relative)
 
 	int new_value = value;
 	int default_value;
+	extern const int *param_defaults;
 
 	if (relative) {
 		if (parameter < 5) {

--- a/src/libespeak-ng/setlengths.h
+++ b/src/libespeak-ng/setlengths.h
@@ -30,6 +30,11 @@ extern "C"
 
 void CalcLengths(Translator *tr);
 
+espeak_ng_STATUS SetParameter(int parameter, 
+	int value,
+	int relative
+	);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libespeak-ng/spect.c
+++ b/src/libespeak-ng/spect.c
@@ -36,12 +36,9 @@
 #include "spect.h"
 #include "ieee80.h"
 
-extern unsigned char pk_shape1[];
-extern int pk_select;
 extern char voice_name[];
 
 static int frame_width;
-int pk_select;
 
 static int default_freq[N_PEAKS] =
 { 200, 500, 1200, 3000, 3500, 4000, 6900, 7800, 9000 };
@@ -245,7 +242,6 @@ SpectSeq *SpectSeqCreate()
 	spect->frames = NULL;
 	spect->name = NULL;
 
-	pk_select = 1;
 	spect->grid = 1;
 	spect->duration = 0;
 	spect->pitch1 = 0;

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -333,6 +333,25 @@ ESPEAK_NG_API void espeak_ng_InitializePath(const char *path)
 	strcpy(path_home, PATH_ESPEAK_DATA);
 }
 
+const int param_defaults[N_SPEECH_PARAM] = {
+	0,   // silence (internal use)
+	175, // rate wpm
+	100, // volume
+	50,  // pitch
+	50,  // range
+	0,   // punctuation
+	0,   // capital letters
+	0,   // wordgap
+	0,   // options
+	0,   // intonation
+	0,
+	0,
+	0,   // emphasis
+	0,   // line length
+	0,   // voice type
+};
+
+
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Initialize(espeak_ng_ERROR_CONTEXT *context)
 {
 	int param;
@@ -919,6 +938,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Terminate(void)
 	return ENS_OK;
 }
 
+const char *version_string = PACKAGE_VERSION;
 ESPEAK_API const char *espeak_Info(const char **ptr)
 {
 	if (ptr != NULL)

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -35,6 +35,7 @@
 #include "dictionary.h"
 #include "mbrola.h"
 #include "readclause.h"
+#include "setlengths.h"
 #include "synthdata.h"
 #include "wavegen.h"
 

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -61,13 +61,9 @@ int phoneme_tab_number = 0;
 
 int wavefile_ix; // a wavefile to play along with the synthesis
 int wavefile_amp;
-int wavefile_ix2;
-int wavefile_amp2;
 
 int seq_len_adjust;
 int vowel_transition[4];
-int vowel_transition0;
-int vowel_transition1;
 
 static espeak_ng_STATUS ReadPhFile(void **ptr, const char *fname, int *size, espeak_ng_ERROR_CONTEXT *context)
 {

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -41,7 +41,6 @@
 #include "synthesize.h"
 #include "translate.h"
 
-const char *version_string = PACKAGE_VERSION;
 const int version_phdata  = 0x014801;
 
 // copy the current phoneme table into here

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -480,7 +480,6 @@ extern unsigned char *out_start;
 extern unsigned char *out_end;
 extern espeak_EVENT *event_list;
 extern t_espeak_callback *synth_callback;
-extern const char *version_string;
 extern const int version_phdata;
 
 #define N_SOUNDICON_TAB  80   // total entries in soundicon_tab
@@ -488,7 +487,6 @@ extern const int version_phdata;
 extern int n_soundicon_tab;
 extern SOUND_ICON soundicon_tab[N_SOUNDICON_TAB];
 
-espeak_ng_STATUS SetParameter(int parameter, int value, int relative);
 void DoEmbedded(int *embix, int sourceix);
 void DoMarker(int type, int char_posn, int length, int value);
 void DoPhonemeMarker(int type, int char_posn, int length, char *name);

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -444,10 +444,7 @@ extern int samplerate_native;
 
 extern int wavefile_ix;
 extern int wavefile_amp;
-extern int wavefile_ix2;
-extern int wavefile_amp2;
 extern int vowel_transition[4];
-extern int vowel_transition0, vowel_transition1;
 
 #define N_ECHO_BUF 5500   // max of 250mS at 22050 Hz
 extern int echo_head;
@@ -478,16 +475,13 @@ extern unsigned char *envelope_data[N_ENVELOPE_DATA];
 extern int formant_rate[];         // max rate of change of each formant
 extern SPEED_FACTORS speed;
 
-extern long count_samples;
 extern unsigned char *out_ptr;
 extern unsigned char *out_start;
 extern unsigned char *out_end;
-extern int event_list_ix;
 extern espeak_EVENT *event_list;
 extern t_espeak_callback *synth_callback;
 extern const char *version_string;
 extern const int version_phdata;
-extern double sonicSpeed;
 
 #define N_SOUNDICON_TAB  80   // total entries in soundicon_tab
 #define N_SOUNDICON_SLOTS 4    // number of slots reserved for dynamic loading of audio files

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -294,6 +294,18 @@ static Translator *NewTranslator(void)
 	tr->langopts.break_numbers = BREAK_THOUSANDS; // 1000, 1000,000  1,000,000 etc
 	tr->langopts.max_digits = 14;
 
+	// index by 0=. 1=, 2=?, 3=! 4=none, 5=emphasized
+	unsigned char punctuation_to_tone[INTONATION_TYPES][PUNCT_INTONATIONS] = {
+		{  0,  1,  2,  3, 0, 4 },
+		{  0,  1,  2,  3, 0, 4 },
+		{  5,  6,  2,  3, 0, 4 },
+		{  5,  7,  1,  3, 0, 4 },
+		{  8,  9, 10,  3, 0, 0 },
+		{  8,  8, 10,  3, 0, 0 },
+		{ 11, 11, 11, 11, 0, 0 }, // 6 test
+		{ 12, 12, 12, 12, 0, 0 }
+	};
+
 	memcpy(tr->punct_to_tone, punctuation_to_tone, sizeof(tr->punct_to_tone));
 
 	memcpy(tr->langopts.tunes, default_tunes, sizeof(tr->langopts.tunes));

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -49,7 +49,6 @@ Translator *translator2 = NULL; // secondary translator for certain words
 static char translator2_language[20] = { 0 };
 
 FILE *f_trans = NULL; // phoneme output text
-int option_tone2 = 0;
 int option_tone_flags = 0; // bit 8=emphasize allcaps, bit 9=emphasize penultimate stress
 int option_phonemes = 0;
 int option_phoneme_events = 0;

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -459,7 +459,7 @@ static char *SpeakIndividualLetters(Translator *tr, char *word, char *phonemes, 
 		capitals |= 4; // speak charater code for unknown letters
 
 	while ((*word != ' ') && (*word != 0)) {
-		word += TranslateLetter(tr, word, phonemes, capitals | non_initial);
+		word += TranslateLetter(tr, word, phonemes, capitals | non_initial, current_alphabet);
 		posn++;
 		non_initial = true;
 		if (phonemes[0] == phonSWITCH) {
@@ -770,7 +770,7 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 			if (posn > 0)
 				non_initial = true;
 
-			wordx += TranslateLetter(tr, wordx, unpron_phonemes, non_initial);
+			wordx += TranslateLetter(tr, wordx, unpron_phonemes, non_initial, current_alphabet);
 			posn++;
 			if (unpron_phonemes[0] == phonSWITCH) {
 				// change to another language in order to translate this word

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -60,7 +60,6 @@ static int option_sayas2 = 0; // used in translate_clause()
 static int option_emphasis = 0; // 0=normal, 1=normal, 2=weak, 3=moderate, 4=strong
 int option_ssml = 0;
 int option_phoneme_input = 0; // allow [[phonemes]] in input
-int option_phoneme_variants = 0; // 0= don't display phoneme variant mnemonics
 int option_wordgap = 0;
 
 static int count_sayas_digits;

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -527,8 +527,6 @@ static int CheckDottedAbbrev(char *word1)
 	return count;
 }
 
-extern char *phondata_ptr;
-
 static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char *word_out)
 {
 	// word1 is terminated by space (0x20) character

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -281,7 +281,6 @@ typedef struct {
 	int flags;
 } ALPHABET;
 
-extern ALPHABET *current_alphabet;
 // alphabet flags
 #define AL_DONT_NAME    0x01 // don't speak the alphabet name
 #define AL_NOT_LETTERS  0x02 // don't use the language for speaking letters

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -650,7 +650,6 @@ extern int option_punctuation;
 extern int option_endpause;
 extern int option_ssml;
 extern int option_phoneme_input;   // allow [[phonemes]] in input text
-extern int option_phoneme_variants;
 extern int option_sayas;
 extern int option_wordgap;
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -639,7 +639,6 @@ typedef struct {
 	int clause_terminator;
 } Translator;
 
-extern int option_tone2;
 #define OPTION_EMPHASIZE_ALLCAPS  0x100
 #define OPTION_EMPHASIZE_PENULTIMATE 0x200
 extern int option_tone_flags;

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -281,7 +281,6 @@ typedef struct {
 	int flags;
 } ALPHABET;
 
-extern ALPHABET alphabets[];
 extern ALPHABET *current_alphabet;
 // alphabet flags
 #define AL_DONT_NAME    0x01 // don't speak the alphabet name
@@ -654,7 +653,6 @@ extern int option_sayas;
 extern int option_wordgap;
 
 extern int count_characters;
-extern int count_words;
 extern int count_sentences;
 extern int skip_characters;
 extern int skip_words;

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -669,7 +669,6 @@ extern char skip_marker[N_MARKER_LENGTH];
 
 #define N_PUNCTLIST  60
 extern wchar_t option_punctlist[N_PUNCTLIST];  // which punctuation characters to announce
-extern unsigned char punctuation_to_tone[INTONATION_TYPES][PUNCT_INTONATIONS];
 
 extern Translator *translator;
 extern Translator *translator2;

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -703,7 +703,7 @@ voice_t *LoadVoice(const char *vname, int control)
 			stress_add_set = Read8Numbers(p, stress_add);
 			break;
 		case V_INTONATION: // intonation
-			sscanf(p, "%d %d", &option_tone_flags, &option_tone2);
+			sscanf(p, "%d", &option_tone_flags);
 			if ((option_tone_flags & 0xff) != 0) {
 				if (langopts)
 					langopts->intonation_group = option_tone_flags & 0xff;

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -127,8 +127,6 @@ static int embedded_max[N_EMBEDDED_VALUES] = { 0, 0x7fff, 750, 300, 99, 99, 99, 
 
 int current_source_index = 0;
 
-extern FILE *f_wave;
-
 #if HAVE_SONIC_H
 static sonicStream sonicSpeedupStream = NULL;
 double sonicSpeed = 1.0;


### PR DESCRIPTION
Remove various unused declarations and extern declarations. Move declarations to files and headers they are actually used.

Contributes to cleaner code and #68.