### PR TITLE
portability: use suffix rules instead of pattern rules.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,7 +77,7 @@ distclean-local:
 
 ##### custom rules:
 
-SUFFIXES=.html .md .ronn
+SUFFIXES=.html .md .ronn .check .test _emoji _extra _dict
 
 .md.html: _layouts/webpage.html
 	cat $< | sed -e 's/\.md)/.html)/g' -e 's/\.ronn/.html/g' | \
@@ -245,7 +245,7 @@ tests_api_test_CFLAGS  = -Isrc/libespeak-ng ${AM_CFLAGS}
 tests_api_test_LDADD   = src/libespeak-ng-test.la
 tests_api_test_SOURCES = tests/api.c
 
-%.check: %.test
+.test.check:
 	@echo "  TEST      $<"
 	@ESPEAK_DATA_PATH=$(PWD) $< && echo "  PASSED    $<"
 
@@ -435,7 +435,7 @@ espeakdata: \
 
 ##### dictionaries:
 
-dictsource/%_emoji:
+dictsource/_emoji:
 	@echo "  EMOJI     $@"
 	@if test x"${CLDR_PATH}" = x ; then \
 		touch $@ ; \
@@ -446,10 +446,10 @@ dictsource/%_emoji:
 			${CLDR_PATH} > $@ ; \
 	fi
 
-dictsource/%_extra:
+dictsource/_extra:
 	touch $@
 
-espeak-ng-data/%_dict: src/espeak-ng phsource/phonemes.stamp
+espeak-ng-data/_dict: src/espeak-ng phsource/phonemes.stamp
 	@echo "  DICT      $@"
 	@cd dictsource && ESPEAK_DATA_PATH=$(PWD) LD_LIBRARY_PATH=../src:${LD_LIBRARY_PATH} ../src/espeak-ng \
 		--compile=`echo $@ | sed -e 's,espeak-ng-data/,,g' -e 's,_dict,,g'` && cd ..


### PR DESCRIPTION
%-style pattern rules are a GNU extension and only used by gnu automake. Suffix rules guarantee portability with non-gnu systems.

Makefile.am already uses suffx rules for documentation (` .md.html` and `.ronn.html`), so this also makes the usage more consistent.

Closes #396.

Further reading:[https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html]( https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html) and [https://stackoverflow.com/questions/27975545/how-to-deal-with-autoconf-warning-style-pattern-rules-are-a-gnu-make-extens#27975701](https://stackoverflow.com/questions/27975545/how-to-deal-with-autoconf-warning-style-pattern-rules-are-a-gnu-make-extens#27975701)
