### PR TITLE
Don't install test libraries with make install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,7 +220,7 @@ src_espeak_ng_SOURCES = src/espeak-ng.c
 # Test version of libespeak-ng.so with access to the internal APIs, so they can
 # be accessed in the test code. This version should not be installed, as the
 # internal APIs are not guaranteed to be stable between releases.
-lib_LTLIBRARIES += src/libespeak-ng-test.la
+noinst_lib_LTLIBRARIES += src/libespeak-ng-test.la
 
 src_libespeak_ng_test_la_LDFLAGS = $(src_libespeak_ng_la_LDFLAGS)
 src_libespeak_ng_test_la_CFLAGS  = \
@@ -264,7 +264,7 @@ check:	tests/encoding.check \
 if !HAVE_LIBFUZZER
 # libfuzzrunner is a stub implementation of libFuzzer that calls the
 # LLVMFuzzerTestOneInput with the files passed to the fuzzer program.
-lib_LTLIBRARIES += tests/libfuzzrunner.la
+noinst_lib_LTLIBRARIES += tests/libfuzzrunner.la
 tests_libfuzzrunner_la_CFLAGS  = -Isrc/libespeak-ng ${AM_CFLAGS}
 tests_libfuzzrunner_la_SOURCES = tests/fuzzrunner.c
 endif


### PR DESCRIPTION
Closes #343. Also disables installing libfuzzrunner which has been implemented after the issue has been raised.

Reece, my commits have been hit and miss lately, so do take extra care checking this one out. I verified this with .`/configure --prefix=<PREFIX> && make install`.<PREFIX>/lib doesn't contain the test libraries anymore.
