### PR TITLE
refactor and remove redundant call to towlower2()

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -2294,12 +2294,9 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 						}
 					} else {
 						if (iswlower(prev_in)) {
-							// lower case followed by upper case in a word
-							if (UpperCaseInWord(tr, &sbuf[ix], c) == 1) {
-								// convert to lower case and continue
-								c = towlower2(c, tr);
-							} else {
-								c = ' '; // lower case followed by upper case, treat as new word
+							// lower case followed by upper case, possibly CamelCase
+							if (UpperCaseInWord(tr, &sbuf[ix], c) == 0) { // start a new word
+								c = ' ';
 								space_inserted = true;
 								prev_in_save = c;
 							}


### PR DESCRIPTION
`c = towlower2(c, tr)` is donet here: https://github.com/espeak-ng/espeak-ng/blob/19547ce75b8a865c53ff10e7c16e8b88b227f974/src/libespeak-ng/translate.c#L2287

Setting it again if `UpperCaseInWord` returns 1 is redundant. Thus, checking if `UpperCaseInWord` returns 1 is redundant. Action is only required if it returns 0.

This change only cleans up the code. No change in functionality is intended.