### PR TITLE
Refactoring

### DIFF
--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -1579,6 +1579,4 @@ static void Translator_Russian(Translator *tr)
 
 	tr->langopts.numbers = NUM_DECIMAL_COMMA | NUM_OMIT_1_HUNDRED;
 	tr->langopts.numbers2 = 0x2 + NUM2_THOUSANDS_VAR1; // variant numbers before thousands
-	tr->langopts.phoneme_change = 1;
-	tr->langopts.testing = 2;
 }

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -565,7 +565,6 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 	int spell_word;
 	int emphasize_allcaps = 0;
 	int wflags;
-	int wmark;
 	int was_unpronouncable = 0;
 	int loopcount;
 	int add_suffix_phonemes = 0;
@@ -582,7 +581,6 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 		wtab = wtab_null;
 	}
 	wflags = wtab->flags;
-	wmark = wtab->wmark;
 
 	dictionary_flags[0] = 0;
 	dictionary_flags[1] = 0;
@@ -683,11 +681,6 @@ static int TranslateWord3(Translator *tr, char *word_start, WORD_TAB *wtab, char
 			// change to another language in order to translate this word
 			strcpy(word_phonemes, phonemes);
 			return 0;
-		}
-
-		if ((wmark > 0) && (wmark < 8)) {
-			// the stressed syllable has been specified in the text  (TESTING)
-			dictionary_flags[0] = (dictionary_flags[0] & ~0xf) | wmark;
 		}
 
 		if (!found && (dictionary_flags[0] & FLAG_ABBREV)) {
@@ -1965,7 +1958,6 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 	int char_inserted = 0;
 	int clause_pause;
 	int pre_pause_add = 0;
-	int word_mark = 0;
 	int all_upper_case = FLAG_ALL_UPPER;
 	bool finished = false;
 	bool single_quoted = false;
@@ -2447,7 +2439,6 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 				}
 				words[word_count].pre_pause = pre_pause;
 				words[word_count].flags |= (all_upper_case | word_flags | word_emphasis);
-				words[word_count].wmark = word_mark;
 
 				if (pre_pause > 0) {
 					// insert an extra space before the word, to prevent influence from previous word across the pause
@@ -2476,7 +2467,6 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 				word_flags = next_word_flags;
 				next_word_flags = 0;
 				pre_pause = 0;
-				word_mark = 0;
 				all_upper_case = FLAG_ALL_UPPER;
 				syllable_marked = false;
 			}

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -268,7 +268,6 @@ typedef struct {
 	unsigned int flags;
 	unsigned short start;
 	unsigned char pre_pause;
-	unsigned char wmark;
 	unsigned short sourceix;
 	unsigned char length;
 } WORD_TAB;

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -549,14 +549,12 @@ typedef struct {
 	int intonation_group;
 	unsigned char tunes[6];
 	int long_stop;          // extra mS pause for a lengthened stop
-	int phoneme_change;     // TEST, change phonemes, after translation
 	char max_initial_consonants;
 	char spelling_stress;   // 0=default, 1=stress first letter
 	char tone_numbers;
 	char ideographs;      // treat as separate words
 	bool textmode;          // the meaning of FLAG_TEXTMODE is reversed (to save data when *_list file is compiled)
 	char dotless_i;         // uses letter U+0131
-	int testing;            // testing options: bit 1= specify stressed syllable in the form:  "outdoor/2"
 	int listx;    // compile *_listx after *list
 	const unsigned int *replace_chars;      // characters to be substitutes
 	int our_alphabet;           // offset for main alphabet (if not set in letter_bits_offset)


### PR DESCRIPTION
1. refactor setting tone_out in TranslateClause:
Ints tone and tone2 are only used to set tone_out when it's not NULL. It's simpler to set tone_out directly instead. Overriding tone_type in ReadClause seems to only affect Armenian (LANG=hy).

2. remove unused wmark and all related code:
Char  wmark and int word_mark are always 0 so the if clause is never run.

3. remove unused ints testing and phoneme_change:
They are set for Russian (LANG=ru) but there's no code that checks them.
