### PR TITLE
Fix out of bound access when buffer size is odd

### DIFF
--- a/src/libespeak-ng/klatt.c
+++ b/src/libespeak-ng/klatt.c
@@ -421,7 +421,7 @@ static int parwave(klatt_frame_ptr frame)
 			echo_head = 0;
 
 		sample_count++;
-		if (out_ptr >= out_end)
+		if (out_ptr + 2 > out_end)
 			return 1;
 	}
 	return 0;

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -889,7 +889,7 @@ static int Wavegen()
 		if (echo_head >= N_ECHO_BUF)
 			echo_head = 0;
 
-		if (out_ptr >= out_end)
+		if (out_ptr + 2 > out_end)
 			return 1;
 	}
 }
@@ -922,7 +922,7 @@ static int PlaySilence(int length, bool resume)
 		if (echo_head >= N_ECHO_BUF)
 			echo_head = 0;
 
-		if (out_ptr >= out_end)
+		if (out_ptr + 2 > out_end)
 			return 1;
 	}
 	return 0;
@@ -975,7 +975,7 @@ static int PlayWave(int length, bool resume, unsigned char *data, int scale, int
 		if (echo_head >= N_ECHO_BUF)
 			echo_head = 0;
 
-		if (out_ptr >= out_end)
+		if (out_ptr + 2 > out_end)
 			return 1;
 	}
 	return 0;


### PR DESCRIPTION
Valgrind reports

==20307== Invalid write of size 1
==20307==    at 0x4E856FE: Wavegen.part.1 (wavegen.c:880)
==20307==    by 0x4E86682: Wavegen (wavegen.c:670)
==20307==    by 0x4E86682: Wavegen2 (wavegen.c:1235)
==20307==    by 0x4E86682: WavegenFill2 (wavegen.c:1317)
==20307==    by 0x4E86CA7: WavegenFill (wavegen.c:1398)
==20307==    by 0x4E7093F: Synthesize (speech.c:442)
==20307==    by 0x4E712E0: sync_espeak_Synth (speech.c:549)
==20307==    by 0x4E8A5C0: process_espeak_command (espeak_command.c:317)
==20307==    by 0x4E8B387: say_thread (fifo.c:333)
==20307==    by 0x50E85A9: start_thread (pthread_create.c:463)
==20307==    by 0x53F5CBE: clone (clone.S:95)
==20307==  Address 0xad5e1bd is 0 bytes after a block of size 2,205 alloc'd
==20307==    at 0x4C2CABF: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20307==    by 0x4C2EE04: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20307==    by 0x4E70CFC: espeak_ng_InitializeOutput (speech.c:286)
==20307==    by 0x4E6176E: espeak_Initialize (espeak_api.c:67)
==20307==    by 0x10A5D8: initialize_espeak (espeak.c:303)
==20307==    by 0x109D1D: main (espeakup.c:201)
==20307==

Indeed, the out_ptr >= out_end test is not enough: it only checks that
one byte can fit the buffer, while klatt and wavegen produce two bytes.