### PR TITLE
More fixes for German

### DIFF
--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -624,6 +624,7 @@ aneinander	an1aIn'and3
 anomalie         $2
 antik           ant'i:k
 archaik         arC'A:Ik
+archiv	$2
 arie             $alt
 arpeggier       arpEdZ'i:r
 arrangier       araNZ'i:r

--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -589,6 +589,7 @@ thunderbird		_^_EN
 time		_^_EN
 timer	_^_EN
 to	_^_EN	$only
+tool	_^_EN
 trip		_^_EN
 tuner		_^_EN
 unix		_^_EN

--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -274,7 +274,7 @@ nach		nA:x	$u+ $brk
 neben			$u+ $brk
 ob		,Ob	$pause $strend $only
 per		pEr	$u+ $brk
-pro		,pro:	$pause
+pro		pro:
 von		fOn	$u+ $brk
 //(von dem)	%fOn%de:m	$brk
 vom		fOm	$u+ $brk
@@ -292,7 +292,7 @@ während		$pause
 // misc
 so		zo:	$u+
 doch		dOx	$u+
-noch			$pause
+noch	$u
 (noch nicht)	n'Ox||n'ICt	$brk
 (nicht mehr)	n'ICt||,me:r
 (nicht mehr)	n,ICt||m'e:r	$atend

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -537,7 +537,7 @@
         g (sA      g
         gd (_N     kt
      _) gh (A      g
-     _) g (nA      g  // allow _gn
+     _) g (nA      g@-  // allow _gn
      B) gn (A      gn
 
      i) gt (_      Ct

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -200,7 +200,9 @@
      _) b (eet     b
      _) b (enzin   b
      _) b (erC     b
+        be (recht  b@
         be (reich  b@
+        be (richt	b@
      _) b (esen    b
      _) b (ess     b
      _) b (esten   b
@@ -326,6 +328,7 @@
         design (_  d%IzaIn
         dge (_     _^_EN
      _) dia        d,i:a
+        dialog	di:al'o:k
      _) diver      d%i:vEr
      _) dort (C@P4 d'Ort
         drive      _^_EN
@@ -360,10 +363,10 @@
         ei         aI
         eu         OY
         ey         aI
-        ey (_      e:
 
         eb (t_     e:p
         eg (t_     e:k
+        eth	e:t
 
         een (_     'e:@n
         ell (_     'El
@@ -545,10 +548,13 @@
      _) g (eHC     g         //  hC, lC, mC, nC, rC
 
  massa) g          Z
+        gabe	gA:b@
+        gehr	ge:r
      @) ght (_     _^_EN
         graph      grAf
         graph (_   gr'A:f
         green      _^_EN
+        groß	gro:s
         guide      _^_EN
         gue (_     k
      _) güte (@P4  g'y:t@
@@ -864,7 +870,6 @@ formal) ie         =I@
         nk (A      nk
     fu) nk         Nk
 
-     _) natur (C@P5  nA:t'u:r
      _) na (tür    n%A:
         nce (_     _^_EN
         nces (_    _^_EN
@@ -874,6 +879,7 @@ formal) ie         =I@
      _) ne (g      ne:
         neglig     ne:gli:Z
         neglige    ne:gli:Z
+        nese (_	n'e:z@
      &) ness (_N   _^_EN
         new       _^_EN
         nieder     ni:d3
@@ -950,6 +956,7 @@ formal) ie         =I@
      _) p (tol     p
 
         pake (t    p%ake:
+        papier	pap'i:r
      _) para (@    p,ara
         passagie   pasaZ'i:
      _) peri       p,e:ri:
@@ -957,10 +964,12 @@ formal) ie         =I@
      _) periphe    p,e:ri:fe:
      _) personen (@P8 pErz'o:n@n
         person     p%Erzo:n
+        persön     p%ErzY:n
         philie     f'i:li:
      _) photo      f,o:to:
      _) pro (@     %pro:
      _) probe      pro:b@
+        prüf	pry:f
 
         po (em     p%o:
         po (et     p%o:
@@ -1077,6 +1086,7 @@ formal) ie         =I@
         st (ö      St
         st (rich	St
         st (ü      St
+        st (uf	St
         st (uh     St
         st (ung    st
 
@@ -1171,6 +1181,8 @@ screen	_^_EN
      _) teen       _^_EN
      _) tele (@    t,e:le:
      _) thermo     tErmo:
+        these	t'e:z@
+        sprachsyn) these	t,e:z@
         touch	_^_EN
         tuerei (_  tu:@r'aI
         thrill     _^_EN
@@ -1204,6 +1216,7 @@ screen	_^_EN
 
         ub (t_     u:p
         ug (t_     u:k
+        ur (_	'u:r
 
      _) ueber (@P5 _|,y:b3
      _) um (@P2    Um

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -369,6 +369,7 @@
 
         eb (t_     e:p
         eg (t_     e:k
+        eth	e:t
 
         een (_     'e:@n
         ell (_     'El

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -590,6 +590,7 @@
      _) ge (org    g%e:
         ge (rman   gE
         ge (rät    g@
+        gestalt	g@Stalt
         ge (strig  gE
 
 

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -195,6 +195,7 @@
      &) baren (_S5 bA:r@n
      &) barer (_S5 bA:r3
      &) bares (_S5 bA:r@s
+        be (ding  b@
      _) b (ebC     b
      _) b (ecC     b
      _) b (eet     b
@@ -224,6 +225,7 @@
         bo (sh     bo:
         buchstab	bu:xStA:b
      _) bundes     b'Und@s
+        bücher	by:C3r
 
 
 .group c
@@ -363,10 +365,10 @@
         ei         aI
         eu         OY
         ey         aI
+        ey (_      e:
 
         eb (t_     e:p
         eg (t_     e:k
-        eth	e:t
 
         een (_     'e:@n
         ell (_     'El
@@ -538,7 +540,7 @@
         gd (_N     kt
      _) gh (A      g
      _) g (nA      g@-  // allow _gn
-     B) gn (A      gn
+     B) gn (A      g@-n
 
      i) gt (_      Ct
     ei) gt (_      kt
@@ -549,7 +551,6 @@
 
  massa) g          Z
         gabe	gA:b@
-        gehr	ge:r
      @) ght (_     _^_EN
         graph      grAf
         graph (_   gr'A:f
@@ -566,7 +567,7 @@
      _) ge (beX    ge:
         geben      ge:b@n
         gebirge (_S7  g@bIrg@
-        gedulds	%g@dUlts
+        gedulds    %g@dUlts
      _) gegen (@P5 ge:g@n
         gegen      ge:g@n
         gegn       ge:gn
@@ -584,7 +585,7 @@
         general (is ge:n@ral
      _) ge (ner    gE
      _) geo        g,e:o:
-     _) geo (pf	g@'O
+     _) geo (pf    g@'O
      _) ge (orP2   g@
      _) ge (org    g%e:
         ge (rman   gE
@@ -669,9 +670,8 @@
 
         i (i       i:_!
 
-ik (_	Ik
+        ik (_      Ik
      s) ik (_      'i:k
-    @r) ik (_      Ik
     br) ik (_      'i:k
     @t) ik (_      =i:k
  polit) ik         'i:k
@@ -870,6 +870,7 @@ formal) ie         =I@
         nk (A      nk
     fu) nk         Nk
 
+     _) natur (C@P5  nA:t'u:r
      _) na (tür    n%A:
         nce (_     _^_EN
         nces (_    _^_EN
@@ -879,13 +880,12 @@ formal) ie         =I@
      _) ne (g      ne:
         neglig     ne:gli:Z
         neglige    ne:gli:Z
-        nese (_	n'e:z@
      &) ness (_N   _^_EN
-        new       _^_EN
+        new        _^_EN
         nieder     ni:d3
         nord (L04st n%Ort
         nord (west n%Ort
-        nuance	ny:'A~s@
+        nuance     ny:'A~s@
 
 .group o
      _) o (_       o:
@@ -956,7 +956,6 @@ formal) ie         =I@
      _) p (tol     p
 
         pake (t    p%ake:
-        papier	pap'i:r
      _) para (@    p,ara
         passagie   pasaZ'i:
      _) peri       p,e:ri:
@@ -965,11 +964,11 @@ formal) ie         =I@
      _) personen (@P8 pErz'o:n@n
         person     p%Erzo:n
         persön     p%ErzY:n
+        prüf	pry:f
         philie     f'i:li:
      _) photo      f,o:to:
      _) pro (@     %pro:
      _) probe      pro:b@
-        prüf	pry:f
 
         po (em     p%o:
         po (et     p%o:
@@ -1080,11 +1079,11 @@ formal) ie         =I@
         ste (ll    StE
      a) ste (ll    stE
         st (ah     St
-        st (art     St
+        st (art    St
         st (ä      St
         st (eh     St
         st (ö      St
-        st (rich	St
+        st (rich   St
         st (ü      St
         st (uf	St
         st (uh     St
@@ -1109,7 +1108,7 @@ formal) ie         =I@
      _) schul (d   S'Ul
 
         schwer     Sve:r
-screen	_^_EN
+        screen     _^_EN
      _) sechs (P5  z'Eks
         seku (nden ze:k'U
      _) selbst (@@P6 z'Elpst
@@ -1118,7 +1117,7 @@ screen	_^_EN
      _) sky        _^_EN
         soldat     z%OldA:t
      &) so (rt_    s_|O
-        summe	zUm@
+        summe      zUm@
 
         speed      _^_EN
   stau) ss         s
@@ -1181,9 +1180,7 @@ screen	_^_EN
      _) teen       _^_EN
      _) tele (@    t,e:le:
      _) thermo     tErmo:
-        these	t'e:z@
-        sprachsyn) these	t,e:z@
-        touch	_^_EN
+        touch      _^_EN
         tuerei (_  tu:@r'aI
         thrill     _^_EN
    _pa) th         t
@@ -1216,7 +1213,6 @@ screen	_^_EN
 
         ub (t_     u:p
         ug (t_     u:k
-        ur (_	'u:r
 
      _) ueber (@P5 _|,y:b3
      _) um (@P2    Um
@@ -1360,8 +1356,10 @@ screen	_^_EN
      _) wasch (@P5 v'aS
      _) wasser (@P6 v'as@r
      _) weit (C@P4 v'aIt
-     _) weiter (@P6 v'aIt@r
+        weiter  v'aIt@r
      _) weither    vaIthe:r
+        welch	vElC
+        wetter	vEt3
      _) wieder (@P6 vi:d3
      _) wo (hin    v%o:
      _) wovor      vo:f'o:r
@@ -1399,7 +1397,7 @@ screen	_^_EN
      _) zere (m    tse:re:
         ziell      tsj'El
      _) zie (ge@P3 ts'i:
-        zitat	tsi:t'A:t
+        zitat      tsi:t'A:t
      _) zeit (@P4  ts'aIt
      _) ziel (@P4  ts'i:l
      _) zier (@P4  ts'i:r
@@ -1457,7 +1455,7 @@ screen	_^_EN
      _) über (@P4  _|,y:b3
      _) über (be@P4 _!'y:b3
      _) über (gangs y:b3
-        übrig	y:brIg#
+        übrig      y:brIg#
 
 
 .group ß
@@ -1483,4 +1481,4 @@ screen	_^_EN
     D_) - (_D      StrIC
      _) - (_D      _
 
-_L05_)	: (_L06D_	%u:r	// Say time
+ _L05_) : (_L06D_  %u:r // Say time

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -128,8 +128,8 @@
      g) al (_      'A:l
      k) al (_      'A:l
      n) al (_      'A:l
-  &kan) al (_      ,A:l
- &sign) al (_      ,A:l
+   kan) al (_      ,A:l
+  sign) al (_      'A:l
      r) al (_      'A:l
      t) al (_      'A:l
      _) aller (@P5 'al@r
@@ -1009,6 +1009,7 @@ formal) ie         =I@
 
         rangier    rA:NZ'i:r
      _) re (d      re:
+        register	re:g'Ist@r
         ressourc   rEs'Urs
         revers     r%e:vErs
 
@@ -1214,7 +1215,7 @@ formal) ie         =I@
 
         ub (t_     u:p
         ug (t_     u:k
-
+        ur (_	'u:r
      _) ueber (@P5 _|,y:b3
      _) um (@P2    Um
      _) umbe (@P4  'Umb@

--- a/dictsource/de_rules
+++ b/dictsource/de_rules
@@ -219,6 +219,7 @@
      _) bike       _^_EN
         binde	bInd@ // for compound words, EG. Bindestrich
      _) bis (hP3   b%Is
+        blend	blEnd
      _) blue       _^_EN
         board      _^_EN
      _) boom       _^_EN


### PR DESCRIPTION
Those are more rules for correct pronunciation. The ey rule at end of word was removed to make espeak pronounce names like Meyer, Speyer, etc. correctly which it didn't do before. The other rules I added are also for correct compound word pronunciation. German's got a lot of compound words, a lot of them espeak can't say, but adding every single word there exists would be hard I guess, those are at least a few