### PR TITLE
tr: add pronunciation rules for vowels â, ô, û.

### DIFF
--- a/dictsource/tr_rules
+++ b/dictsource/tr_rules
@@ -19,7 +19,6 @@
 
 .group a
         a        a
-
      @) a (_S1   a
 
      @) acak (_S4  adZak
@@ -29,6 +28,10 @@
      @) asın (_S4  as@n
 
      @) avru (pa avr'u
+
+.group â
+	â	 a
+
 
 .group b
         b        b
@@ -210,6 +213,9 @@
 .group ö
         ö        W
 
+.group ô
+	ô	o
+
 .group p
         p        p
         pp       _:_!p
@@ -289,6 +295,10 @@
      @) üyor (_S4  yj%oR
      @) ün (_S2  yn
 
+
+
+.group û
+	û	u  
 
 .group v
         v        v


### PR DESCRIPTION
Related to #500.

Rules for some vowels with circumflex were missing. This commit adds â, ô and û.

Apparently, in turkish circumflex sometimes means lengthening the vowel. It's unclear for which vowels and in what circumstances, so the commit doesn't apply any lengthening to any vowel.