### PR TITLE
kk: add initial support for Kazakh language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ new languages:
 
 *  hak (Hakka Chinese) -- Chen Chien-ting
 *  ht (Haitian Creole) -- Valdis Vitolins
+*  kk (Kazakh) -- boracasli14, Valdis Vitolins
 *  ru-lv (Russian Latvia) -- Valdis Vitolins
 *  shn (Shan Tay Yai) -- ronaldaug
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -494,6 +494,7 @@ dictionaries: \
 	espeak-ng-data/ja_dict \
 	espeak-ng-data/jbo_dict \
 	espeak-ng-data/ka_dict \
+	espeak-ng-data/kk_dict \
 	espeak-ng-data/kl_dict \
 	espeak-ng-data/kn_dict \
 	espeak-ng-data/ko_dict \
@@ -667,6 +668,9 @@ espeak-ng-data/ja_dict: dictsource/ja_list dictsource/ja_rules dictsource/ja_ext
 
 ka: espeak-ng-data/ka_dict
 espeak-ng-data/ka_dict: dictsource/ka_list dictsource/ka_rules dictsource/ka_extra dictsource/ka_emoji
+
+kk: espeak-ng-data/kk_dict
+espeak-ng-data/kk_dict: dictsource/kk_list dictsource/kk_rules dictsource/kk_extra dictsource/kk_emoji
 
 kl: espeak-ng-data/kl_dict
 espeak-ng-data/kl_dict: dictsource/kl_list dictsource/kl_rules dictsource/kl_extra

--- a/dictsource/kk_list
+++ b/dictsource/kk_list
@@ -1,0 +1,41 @@
+// This file is UTF8 encoded 
+// Spelling to phoneme rules for Kazakh
+
+б	b@
+в	v@
+г	g@
+ғ	G@
+д	d@	
+ж	Z@
+з	z@
+й	j@
+к	k@
+қ	q@
+л	l@
+м	m@
+н	n@
+ң	N@
+п	p@
+р	*@
+с	s@
+т	t@
+ф	f@
+х	x@
+һ	h@
+ц	ts@
+ч	tS@
+ш	S@
+щ	StS@
+
+// Native numbers 0-10
+_0n	nYl
+_1n	bI*
+_2n	jekI
+_3n	u#S
+_4n	t8*t
+_5n	beS
+_6n	alt*
+_7n	ZetI
+_8n	segIz
+_9n	toG@z
+_10n	on

--- a/dictsource/kk_rules
+++ b/dictsource/kk_rules
@@ -1,0 +1,129 @@
+// This file is UTF8 encoded 
+// Spelling to phoneme rules for Kazakh
+
+
+.group а
+        а        A
+
+.group ә
+        ә        &
+
+.group б
+        б        b
+	
+.group в
+        в        v
+
+.group г
+        г        g
+
+.group ғ
+        ғ        G
+
+.group д
+        д        d
+
+.group е
+        е        e
+
+.group ё
+        ё        jo
+
+.group ж
+        ж        Z
+
+.group з
+        з        z
+
+.group и
+        и        @j
+
+.group й
+        й        j
+
+.group к
+        к        k
+
+.group қ
+        қ        q
+
+.group л
+        л        l
+
+.group м
+        м        m
+
+.group н
+        н        n
+
+.group ң
+        ң        N
+
+.group о
+        о        o
+
+.group ө
+        ө        8
+
+.group п
+        п        p
+
+.group р
+        р        *
+
+.group с
+        с        s
+
+.group т
+        т        t
+
+.group у
+        у        w
+
+.group ұ
+        ұ        U
+
+.group ү
+        ү        u#
+
+.group ф
+        ф        f
+
+.group х
+        х        x
+
+.group һ
+        һ        h
+
+.group ц
+        ц        ts
+
+.group ч
+        ч        tS
+
+.group ш
+        ш        S
+
+.group щ
+        щ        SS
+
+.group ъ
+        ъ        ?
+
+.group ы
+        ы        @
+
+.group і
+        і        I
+
+.group ь
+        ь        ?
+
+.group э
+        э        e
+
+.group ю
+        ю        ju
+
+.group я
+        я        ja

--- a/espeak-ng-data/lang/trk/kk
+++ b/espeak-ng-data/lang/trk/kk
@@ -1,0 +1,4 @@
+name Kazakh
+language kk
+status testing
+


### PR DESCRIPTION
`kk_list` and `kk_rules` files are taken from https://github.com/rhdunn/espeak/issues/125.