### PR TITLE
fix manual and clean code related to espeakRATE

### DIFF
--- a/src/espeak-ng.1.ronn
+++ b/src/espeak-ng.1.ronn
@@ -52,7 +52,7 @@ words are provided then text is spoken from stdin a line at a time.
     Pitch adjustment, 0 to 99, default is 50.
 
   * `-s <integer>`:
-    Speed in words per minute, default is 160.
+    Speed in words per minute, default is 175.
 
   * `-v <voice name>`:
     Use voice file of this name from espeak-ng-data/voices. A variant can be

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -41,7 +41,7 @@
 extern int saved_parameters[];
 
 // convert from words-per-minute to internal speed factor
-// Use this to calibrate speed for wpm 80-350
+// Use this to calibrate speed for wpm 80-450 (espeakRATE_MINIMUM - espeakRATE_MAXIMUM)
 static unsigned char speed_lookup[] = {
 	255, 255, 255, 255, 255, //  80
 	253, 249, 245, 242, 238, //  85
@@ -150,7 +150,7 @@ void SetSpeed(int control)
 	double sonic;
 
 	speed.loud_consonants = 0;
-	speed.min_sample_len = 450;
+	speed.min_sample_len = espeakRATE_MAXIMUM;
 	speed.lenmod_factor = 110; // controls the effect of FRFLAG_LEN_MOD reduce length change
 	speed.lenmod2_factor = 100;
 	speed.min_pause = 5;
@@ -166,9 +166,9 @@ void SetSpeed(int control)
 
 	if (control & 2)
 		DoSonicSpeed(1 * 1024);
-	if ((wpm_value >= 450) || ((wpm_value > speed.fast_settings[0]) && (wpm > 350))) {
+	if ((wpm_value >= espeakRATE_MAXIMUM) || ((wpm_value > speed.fast_settings[0]) && (wpm > 350))) {
 		wpm2 = wpm;
-		wpm = 175;
+		wpm = espeakRATE_NORMAL;
 
 		// set special eSpeak speed parameters for Sonic use
 		// The eSpeak output will be speeded up by at least x2
@@ -182,9 +182,9 @@ void SetSpeed(int control)
 			sonic = ((double)wpm2)/wpm;
 			DoSonicSpeed((int)(sonic * 1024));
 			speed.pause_factor = 85;
-			speed.clause_pause_factor = 80;
+			speed.clause_pause_factor = espeakRATE_MINIMUM;
 			speed.min_pause = 22;
-			speed.min_sample_len = 450*2;
+			speed.min_sample_len = espeakRATE_MAXIMUM*2;
 			speed.wav_factor = 211;
 			speed.lenmod_factor = 210;
 			speed.lenmod2_factor = 170;
@@ -192,16 +192,16 @@ void SetSpeed(int control)
 		return;
 	}
 
-	if (wpm > 450)
-		wpm = 450;
+	if (wpm > espeakRATE_MAXIMUM)
+		wpm = espeakRATE_MAXIMUM;
 
 	if (wpm > 360)
 		speed.loud_consonants = (wpm - 360) / 8;
 
 	wpm2 = wpm;
 	if (wpm > 359) wpm2 = 359;
-	if (wpm < 80) wpm2 = 80;
-	x = speed_lookup[wpm2-80];
+	if (wpm < espeakRATE_MINIMUM) wpm2 = espeakRATE_MINIMUM;
+	x = speed_lookup[wpm2-espeakRATE_MINIMUM];
 
 	if (wpm >= 380)
 		x = 7;
@@ -243,7 +243,7 @@ void SetSpeed(int control)
 			speed.wav_factor = wav_factor_350[wpm-350];
 
 		if (wpm >= 390) {
-			speed.min_sample_len = 450 - (wpm - 400)/2;
+			speed.min_sample_len = espeakRATE_MAXIMUM - (wpm - 400)/2;
 			if (wpm > 440)
 				speed.min_sample_len = 420 - (wpm - 440);
 		}
@@ -282,7 +282,7 @@ void SetSpeed(int control)
 	int wpm2;
 
 	speed.loud_consonants = 0;
-	speed.min_sample_len = 450;
+	speed.min_sample_len = espeakRATE_MAXIMUM;
 	speed.lenmod_factor = 110; // controls the effect of FRFLAG_LEN_MOD reduce length change
 	speed.lenmod2_factor = 100;
 
@@ -292,16 +292,16 @@ void SetSpeed(int control)
 
 	if (voice->speed_percent > 0)
 		wpm = (wpm * voice->speed_percent)/100;
-	if (wpm > 450)
-		wpm = 450;
+	if (wpm > espeakRATE_MAXIMUM)
+		wpm = espeakRATE_MAXIMUM;
 
 	if (wpm > 360)
 		speed.loud_consonants = (wpm - 360) / 8;
 
 	wpm2 = wpm;
 	if (wpm > 359) wpm2 = 359;
-	if (wpm < 80) wpm2 = 80;
-	x = speed_lookup[wpm2-80];
+	if (wpm < espeakRATE_MINIMUM) wpm2 = espeakRATE_MINIMUM;
+	x = speed_lookup[wpm2-espeakRATE_MINIMUM];
 
 	if (wpm >= 380)
 		x = 7;
@@ -343,7 +343,7 @@ void SetSpeed(int control)
 			speed.wav_factor = wav_factor_350[wpm-350];
 
 		if (wpm >= 390) {
-			speed.min_sample_len = 450 - (wpm - 400)/2;
+			speed.min_sample_len = espeakRATE_MAXIMUM - (wpm - 400)/2;
 			if (wpm > 440)
 				speed.min_sample_len = 420 - (wpm - 440);
 		}

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -348,7 +348,7 @@ ESPEAK_NG_API void espeak_ng_InitializePath(const char *path)
 
 const int param_defaults[N_SPEECH_PARAM] = {
 	0,   // silence (internal use)
-	175, // rate wpm
+	espeakRATE_NORMAL, // rate wpm
 	100, // volume
 	50,  // pitch
 	50,  // range
@@ -397,7 +397,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Initialize(espeak_ng_ERROR_CONTEXT *con
 	for (param = 0; param < N_SPEECH_PARAM; param++)
 		param_stack[0].parameter[param] = saved_parameters[param] = param_defaults[param];
 
-	SetParameter(espeakRATE, 175, 0);
+	SetParameter(espeakRATE, espeakRATE_NORMAL, 0);
 	SetParameter(espeakVOLUME, 100, 0);
 	SetParameter(espeakCAPITALS, option_capitals, 0);
 	SetParameter(espeakPUNCTUATION, option_punctuation, 0);

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -395,9 +395,9 @@ void VoiceReset(int tone_only)
 	voice->samplerate = samplerate_native;
 	memset(voice->klattv, 0, sizeof(voice->klattv));
 
-	speed.fast_settings[0] = 450;
+	speed.fast_settings[0] = espeakRATE_MAXIMUM;
 	speed.fast_settings[1] = 800;
-	speed.fast_settings[2] = 175;
+	speed.fast_settings[2] = espeakRATE_NORMAL;
 
 	voice->roughness = 2;
 

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -122,7 +122,7 @@ int wcmdq_head = 0;
 int wcmdq_tail = 0;
 
 // pitch,speed,
-int embedded_default[N_EMBEDDED_VALUES]    = { 0,     50, 175, 100, 50,  0,  0, 0, 175, 0, 0, 0, 0, 0, 0 };
+int embedded_default[N_EMBEDDED_VALUES]    = { 0,     50, espeakRATE_NORMAL, 100, 50,  0,  0, 0, espeakRATE_NORMAL, 0, 0, 0, 0, 0, 0 };
 static int embedded_max[N_EMBEDDED_VALUES] = { 0, 0x7fff, 750, 300, 99, 99, 99, 0, 750, 0, 0, 0, 0, 4, 0 };
 
 int current_source_index = 0;

--- a/src/speak-ng.1.ronn
+++ b/src/speak-ng.1.ronn
@@ -48,7 +48,7 @@ words are provided then text is spoken from stdin a line at a time.
     Pitch adjustment, 0 to 99, default is 50.
 
   * `-s <integer>`:
-    Speed in words per minute, default is 160.
+    Speed in words per minute, default is 175.
 
   * `-v <voice name>`:
     Use voice file of this name from espeak-ng-data/voices. A variant can be


### PR DESCRIPTION
Fix manpage to correct default speed  value 175 words per minute. Fixes #555.

Code cleanup: default speed rate is set by espeakRATE. There are already #defines for the minimum, normal and maximum values. Use them instead of hard coded constans.