### PR TITLE
Fix termination test in event processing

### DIFF
--- a/src/libespeak-ng/event.c
+++ b/src/libespeak-ng/event.c
@@ -254,7 +254,7 @@ static void *polling_thread(void *p)
 {
 	(void)p; // unused
 
-	while (my_terminate_is_required) {
+	while (!my_terminate_is_required) {
 		bool a_stop_is_required = false;
 
 		(void)pthread_mutex_lock(&my_mutex);


### PR DESCRIPTION
e13b602 ("Avoid using pthread_cancel") introduced a bogus termination test,
this fixes it.

Fixes #572