### PR TITLE
Fix for newer versions of emscripten

### DIFF
--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -100,7 +100,7 @@ CXXFLAGS+=-I ./ -I ../ -I ../src/include/espeak-ng
 #CXXFLAGS+=-s USE_PTHREADS=1
 
 # NOTE: extra flags for emscripten
-EM_CXXFLAGS=-s RESERVED_FUNCTION_POINTERS=2 --memory-init-file 0
+EM_CXXFLAGS=-s RESERVED_FUNCTION_POINTERS=2 --memory-init-file 0 -s FORCE_FILESYSTEM=1 -s WASM=0
 
 
 

--- a/emscripten/js/demo.js
+++ b/emscripten/js/demo.js
@@ -186,7 +186,7 @@ function speak() {
   tts.synthesize(
     user_text,
     function cb(samples, events) {
-      //console.log('  Inside synt cb');
+      console.log('  Receiving synthesis samples...');
       if (!samples) {
         if (pusher) {
           pusher.close();
@@ -207,7 +207,6 @@ function speak() {
   ); // end of tts.synthesize()
   console.log('  Calling synthesize... done');  
   console.log('Leaving speak()');
-
 } // end of speak()
 
 function ipa() {

--- a/emscripten/post.js
+++ b/emscripten/post.js
@@ -88,9 +88,9 @@ eSpeakNGWorker.prototype.synthesize = function (aText, aCallback) {
     return aCallback(data, events) ? 1 : 0;
   }
 
-  var fp = Runtime.addFunction(cb);
+  var fp = addFunction(cb);
   this.synth_(aText, fp);
-  Runtime.removeFunction(fp);
+  removeFunction(fp);
 };
 
 eSpeakNGWorker.prototype.synthesize_ipa = function (aText, aCallback) {


### PR DESCRIPTION
This is a fix in order to compile the emscripten demo with recent versions of emscripten.

The default behaviour of emscripten is now to compile with WASM option, generating a different data file and forcing async loading. For now, I propose to just stay the closest as possible to what was done before and keep a sync loading by just using WASM=0. 

File System function import in the module has also become an option in emscripten, and we absolutely need it, so the flag should be passed explicitly : FORCE_FILESYSTEM=1

The Runtime functions are now imported directly without scoping the Runtime module: updated accordingly.

That's all for the changes.
