### PR TITLE
Enable loading voice definitions from arbitrary files

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -113,6 +113,10 @@ static const char *help_text =
     "--voices=<language>\n"
     "\t   List the available voices for the specified language.\n"
     "\t   If <language> is omitted, then list all voices.\n"
+    "--load     Load voice from a file in current directory by name.\n"
+    "--dump=<file>\n"
+    "\t   Dump the currently loaded voice definition into a file\n"
+    "\t   in the current directory\n"
     "-h, --help Show this help.\n";
 
 int samplerate;
@@ -321,6 +325,8 @@ int main(int argc, char **argv)
 		{ "compile-mbrola", optional_argument, 0, 0x10e },
 		{ "compile-intonations", no_argument, 0, 0x10f },
 		{ "compile-phonemes", optional_argument, 0, 0x110 },
+		{ "load",    no_argument,       0, 0x111 },
+		{ "dump",    required_argument, 0, 0x112 },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -336,6 +342,7 @@ int main(int argc, char **argv)
 	int value;
 	int flag_stdin = 0;
 	int flag_compile = 0;
+	int flag_load = 0;
 	int filesize = 0;
 	int synth_flags = espeakCHARS_AUTO | espeakPHONEMES | espeakENDPAUSE;
 
@@ -349,8 +356,9 @@ int main(int argc, char **argv)
 	int phoneme_options = 0;
 	int option_linelength = 0;
 	int option_waveout = 0;
-
+	
 	espeak_VOICE voice_select;
+	char dumpfile[200];
 	char filename[200];
 	char voicename[40];
 	char devicename[200];
@@ -562,6 +570,12 @@ int main(int argc, char **argv)
 			}
 			return EXIT_SUCCESS;
 		}
+		case 0x111: // --load
+			flag_load = 1;
+			break;
+		case 0x112: // --dump
+			strncpy(dumpfile, optarg2, sizeof(dumpfile) - 1);
+			break;
 		default:
 			exit(0);
 		}
@@ -605,7 +619,10 @@ int main(int argc, char **argv)
 	if (voicename[0] == 0)
 		strcpy(voicename, ESPEAKNG_DEFAULT_VOICE);
 
-	result = espeak_ng_SetVoiceByName(voicename);
+	if(flag_load)
+		result = espeak_ng_SetVoiceByFile(voicename);
+	else
+		result = espeak_ng_SetVoiceByName(voicename);
 	if (result != ENS_OK) {
 		memset(&voice_select, 0, sizeof(voice_select));
 		voice_select.languages = voicename;

--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <time.h>
 
 #include <espeak-ng/espeak_ng.h>
@@ -114,9 +115,6 @@ static const char *help_text =
     "\t   List the available voices for the specified language.\n"
     "\t   If <language> is omitted, then list all voices.\n"
     "--load     Load voice from a file in current directory by name.\n"
-    "--dump=<file>\n"
-    "\t   Dump the currently loaded voice definition into a file\n"
-    "\t   in the current directory\n"
     "-h, --help Show this help.\n";
 
 int samplerate;
@@ -326,7 +324,6 @@ int main(int argc, char **argv)
 		{ "compile-intonations", no_argument, 0, 0x10f },
 		{ "compile-phonemes", optional_argument, 0, 0x110 },
 		{ "load",    no_argument,       0, 0x111 },
-		{ "dump",    required_argument, 0, 0x112 },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -358,7 +355,6 @@ int main(int argc, char **argv)
 	int option_waveout = 0;
 	
 	espeak_VOICE voice_select;
-	char dumpfile[200];
 	char filename[200];
 	char voicename[40];
 	char devicename[200];
@@ -572,9 +568,6 @@ int main(int argc, char **argv)
 		}
 		case 0x111: // --load
 			flag_load = 1;
-			break;
-		case 0x112: // --dump
-			strncpy(dumpfile, optarg2, sizeof(dumpfile) - 1);
 			break;
 		default:
 			exit(0);

--- a/src/include/espeak-ng/espeak_ng.h
+++ b/src/include/espeak-ng/espeak_ng.h
@@ -120,6 +120,9 @@ ESPEAK_NG_API espeak_ng_STATUS
 espeak_ng_SetVoiceByName(const char *name);
 
 ESPEAK_NG_API espeak_ng_STATUS
+espeak_ng_SetVoiceByFile(const char *filename);
+
+ESPEAK_NG_API espeak_ng_STATUS
 espeak_ng_SetVoiceByProperties(espeak_VOICE *voice_selector);
 
 ESPEAK_NG_API espeak_ng_STATUS

--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -609,6 +609,19 @@ ESPEAK_API const espeak_VOICE **espeak_ListVoices(espeak_VOICE *voice_spec);
 #ifdef __cplusplus
 extern "C"
 #endif
+ESPEAK_API espeak_ERROR espeak_SetVoiceByFile(const char *filename);
+/* Loads a voice given the file path.  Language is not considered.
+   "filename" is a UTF8 string.
+
+   Return: EE_OK: operation achieved
+           EE_BUFFER_FULL: the command can not be buffered;
+             you may try after a while to call the function again.
+	   EE_INTERNAL_ERROR.
+*/
+
+#ifdef __cplusplus
+extern "C"
+#endif
 ESPEAK_API espeak_ERROR espeak_SetVoiceByName(const char *name);
 /* Searches for a voice with a matching "name" field.  Language is not considered.
    "name" is a UTF8 string.

--- a/src/libespeak-ng/espeak_api.c
+++ b/src/libespeak-ng/espeak_api.c
@@ -128,6 +128,11 @@ ESPEAK_API espeak_ERROR espeak_SetVoiceByName(const char *name)
 	return status_to_espeak_error(espeak_ng_SetVoiceByName(name));
 }
 
+ESPEAK_API espeak_ERROR espeak_SetVoiceByFile(const char *filename)
+{
+	return status_to_espeak_error(espeak_ng_SetVoiceByFile(filename));
+}
+
 ESPEAK_API espeak_ERROR espeak_SetVoiceByProperties(espeak_VOICE *voice_selector)
 {
 	return status_to_espeak_error(espeak_ng_SetVoiceByProperties(voice_selector));

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1466,6 +1466,44 @@ static void GetVoices(const char *path, int len_path_voices, int is_language_fil
 
 #pragma GCC visibility push(default)
 
+ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SetVoiceByFile(const char *filename)
+{
+	espeak_VOICE *v;
+	int ix;
+	espeak_VOICE voice_selector;
+	char *variant_name;
+	static char buf[60];
+
+	strncpy0(buf, filename, sizeof(buf));
+
+	variant_name = ExtractVoiceVariantName(buf, 0, 1);
+
+	for (ix = 0;; ix++) {
+		// convert voice name to lower case  (ascii)
+		if ((buf[ix] = tolower(buf[ix])) == 0)
+			break;
+	}
+
+	memset(&voice_selector, 0, sizeof(voice_selector));
+	voice_selector.name = (char *)filename; // include variant name in voice stack ??
+
+	// first check for a voice with this filename
+	// This may avoid the need to call espeak_ListVoices().
+
+	if (LoadVoice(buf, 0x10) != NULL) {
+		if (variant_name[0] != 0)
+			LoadVoice(variant_name, 2);
+
+		DoVoiceChange(voice);
+		voice_selector.languages = voice->language_name;
+		SetVoiceStack(&voice_selector, variant_name);
+		return ENS_OK;
+	}
+
+	return ENS_VOICE_NOT_FOUND;
+}
+
+
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SetVoiceByName(const char *name)
 {
 	espeak_VOICE *v;

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1466,6 +1466,7 @@ static void GetVoices(const char *path, int len_path_voices, int is_language_fil
 
 #pragma GCC visibility push(default)
 
+
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SetVoiceByFile(const char *filename)
 {
 	espeak_VOICE *v;


### PR DESCRIPTION
I use espeak/espeak-ng to synthesize vocals for songs. See / listen https://golubovsky.bandcamp.com/album/unhuman-voices
Synthesizing vocals requires voice definitions very different from voices used for speech. Besides, many voice adjustments are needed in the process of song composition, and different voices needed for different parts of a song. Default location of voice files in an installed espeak is under /usr/lib... that is, area not writable by users which makes it very inconvenient to edit voice definition files "ad-hoc". The patch adds flag-option ```--load``` which makes the voice name provided with ```-v``` being treated as path to a file rather than just a voice name.
Thanks.