### PR TITLE
add line to README to install pcaudiolib on debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ be installed using the following commands:
 | sonic         | `sudo apt-get install libsonic-dev`                              |
 | ronn          | `sudo apt-get install ruby-ronn`                                 |
 | kramdown      | `sudo apt-get install ruby-kramdown`                             |
+| pcaudiolib    | `sudo apt-get install libpcaudio-dev`                            |
 
 ### Building
 


### PR DESCRIPTION
Literally following the instructions on a base install of Debian results in a build without audio support. This change adds the instruction for installing pcaudiolib development headers, so that the resulting build has audio.