### PR TITLE
Fix path for hy-arevmda in windows installer

### DIFF
--- a/src/windows/installer/Product.wxs
+++ b/src/windows/installer/Product.wxs
@@ -772,7 +772,7 @@
                   <File Name="hy" Source="$(var.ProjectDir)..\..\..\espeak-ng-data\lang\ine\hy" KeyPath="yes"/>
                 </Component>
                 <Component Id="hy_arevmda" Win64="$(var.Win64)" Guid="E7510729-A886-4BCD-A616-9B4D74D8BA43">
-                  <File Name="hy-arevmda" Source="$(var.ProjectDir)..\..\..\espeak-ng-data\lang\ine\hy-arevmda" KeyPath="yes"/>
+                  <File Name="hyw" Source="$(var.ProjectDir)..\..\..\espeak-ng-data\lang\ine\hyw" KeyPath="yes"/>
                 </Component>
                 <Component Id="sq" Win64="$(var.Win64)" Guid="80790CCF-4B20-4AC3-A19F-72890470D4F5">
                   <File Name="sq" Source="$(var.ProjectDir)..\..\..\espeak-ng-data\lang\ine\sq" KeyPath="yes"/>


### PR DESCRIPTION
Fix path for hy-arevmda (replace hy-arevmda with hyw, now windows installer works again).

Per changelog: 

1.49.3 - (In Development)
Add a --disable-rpath option to prevent libtool hardcoding rpaths in the executable.
Renamed the hy-arevmda language to hyw, following the 2018-03-30 change to the BCP 47 language subtag registry making the newly registered hyw language code the preferred value for hy-arevmda. This change keeps support for detecting the hy-arevela and hy-arevmda language tags.

This was not reflected in the windows installer project (Product.wxs) and broke windows build. This pull request fixes that, I was able to compile and install espeak-ng in windows 10 with visual studio 2019 community edition.