### PR TITLE
Fix for Chrome Autoplay Policy Changes

### DIFF
--- a/emscripten/js/demo.js
+++ b/emscripten/js/demo.js
@@ -148,6 +148,11 @@ function stop() {
 function speak() {
   console.log('Inside speak()');
 
+  if (ctx.state === 'suspended') {
+    console.log('Resuming AudioContext...');
+    ctx.resume();
+    console.log('Resuming AudioContext... done');
+  }
   console.log('  Stopping...');
   stop();
   console.log('  Stopping... done');


### PR DESCRIPTION
The espeakng.js demo does not currently work on Chrome due to the following [Autoplay policy changes](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes).