### PR TITLE
Correct link to add_language.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -146,7 +146,7 @@ Specific languages can be compiled by running:
 	make LANG
 
 where `LANG` is the language code of the given language. More information can
-be found in the [Adding or Improving a Language](docs/add_language.md)
+be found in the [Adding or Improving a Language](add_language.md)
 documentation.
 
 #### Cross Compilation


### PR DESCRIPTION
Current link points to docs/docs/add_language.md (because we are already in docs). Duplicated docs is removed.