### PR TITLE
Fixing ungetc bad behavior under macOS Catalina

### DIFF
--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -796,8 +796,7 @@ static int NextItem(int type)
 
 	if ((c == ')') || (c == ','))
 		c = ' ';
-
-	if (!feof(f_in))
+	else if (!feof(f_in))
 		unget_char(c);
 
 	if (type == tSTRING)


### PR DESCRIPTION
This is a fix for (#674). For archiving purpose, the problem was the following : it seems that the `ungetc` implementation under Catalina has interferences with `ftell`/`fseek` when `ungetc` pushes back a character which is different from the one that is preceding the current file pointer.

The fix consists in avoiding such a situation.
