### PR TITLE
Fixing "Language Replace" tests under MacOS

### DIFF
--- a/tests/language-replace.test
+++ b/tests/language-replace.test
@@ -6,6 +6,7 @@ test_replace() {
 	TEST_BROKEN=${3:-false}
 	
 	if [[ "$OSTYPE" == "darwin"* ]]; then
+		# Under MacOS, grep -P does not exist.
 		GREPX='grep -E'
 	else
 		GREPX='grep -P'

--- a/tests/language-replace.test
+++ b/tests/language-replace.test
@@ -14,7 +14,7 @@ test_replace() {
 
 	echo "testing ${TEST_LANG}"
 	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
-		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | {GREPX} "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
+		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | ${GREPX} "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
 	if [ x$TEST_BROKEN = xbroken ] ; then
 		diff expected.txt actual.txt || (echo "... ignoring error (broken)" && true)
 	else

--- a/tests/language-replace.test
+++ b/tests/language-replace.test
@@ -4,17 +4,10 @@ test_replace() {
 	TEST_LANG=$1
 	TEST_TEXT=$2
 	TEST_BROKEN=${3:-false}
-	
-	if [[ "$OSTYPE" == "darwin"* ]]; then
-		# Under MacOS, grep -P does not exist.
-		GREPX='grep -E'
-	else
-		GREPX='grep -P'
-	fi
 
 	echo "testing ${TEST_LANG}"
 	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
-		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | ${GREPX} "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
+		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | grep -E "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
 	if [ x$TEST_BROKEN = xbroken ] ; then
 		diff expected.txt actual.txt || (echo "... ignoring error (broken)" && true)
 	else

--- a/tests/language-replace.test
+++ b/tests/language-replace.test
@@ -4,10 +4,16 @@ test_replace() {
 	TEST_LANG=$1
 	TEST_TEXT=$2
 	TEST_BROKEN=${3:-false}
+	
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		GREPX='grep -E'
+	else
+		GREPX='grep -P'
+	fi
 
 	echo "testing ${TEST_LANG}"
 	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
-		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | grep -P "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
+		src/espeak-ng -Xq -v ${TEST_LANG} "${TEST_TEXT}" | {GREPX} "(Translate|Found:) " | sed -e 's/ \[.*][ ]*$//g' > actual.txt
 	if [ x$TEST_BROKEN = xbroken ] ; then
 		diff expected.txt actual.txt || (echo "... ignoring error (broken)" && true)
 	else


### PR DESCRIPTION
A small PR for fixing the `language-replace.test` script under MacOS. The `grep -P` is unfortunately not portable, but in that simple case the `grep -E` option will do. Any other suggestion is welcome :-)