### PR TITLE
Fixed UTF8 BOM and consequent damage to !v files

### DIFF
--- a/espeak-ng-data/voices/!v/Andy
+++ b/espeak-ng-data/voices/!v/Andy
@@ -1,35 +1,20 @@
-	language variant
-
+language variant
 name Andy
-
 gender Male
 
-
 #echo 230 30
-
 pitch 85 110
 
 flutter 0
 formant 0 80 80 80 80
-
 formant 1 100 100 100 120
-
 formant 2 100 88 100
-
 formant 3 0 0 0
-
 formant 4 80 80 80
-
 formant 5 80 80 80
-
 formant 6 0 0 0
-
 formant 7 0 0 0
-
 formant 8 0 0 0
-
-
-
 stressAdd 0 0 0 0 0 0 0 200
-
 stressAmp 35 35 35 35 35 35 35 35 35
+

--- a/espeak-ng-data/voices/!v/AnxiousAndy
+++ b/espeak-ng-data/voices/!v/AnxiousAndy
@@ -1,34 +1,20 @@
-	language variant
-
+language variant
 name anxiousAndy
-
 gender Male
 
-
 #echo 230 30
-
 pitch 115 110
 
 flutter 0
 formant 0 80 80 80 80
-
 formant 1 100 100 100 120
-
 formant 2 100 100 100
-
 formant 3 0 0 0
-
 formant 4 0 0 0
-
 formant 5 100 100 100
-
 formant 6 100 100 100
-
 formant 7 100 100 100
-
 formant 8 100 100 100
-
 stressAdd 100 100 100 100 100 100 100 300
-
 stressAmp 35 35 35 35 35 35 35 35 35
 

--- a/espeak-ng-data/voices/!v/Lee
+++ b/espeak-ng-data/voices/!v/Lee
@@ -1,33 +1,20 @@
-	language variant
-
+language variant
 name Lee
-
 gender Male
 
-
 #echo 230 30
-
 pitch 85 110
 
 flutter 0
 formant 0 80 80 80 80
-
 formant 1 80 80 100 100
-
 formant 2 80 80 80
-
 formant 3 9 9 9
-
 formant 4 290 290
-
 formant 5 130 0 0
-
 formant 6 90 90 90
-
 formant 7 90 90 90
-
 formant 8 90 90 90
-
 stressAdd 0 0 0 200 0 0 0 100
-
 stressAmp 30 30 30 30 30 30 30 30 30
+

--- a/espeak-ng-data/voices/!v/gustave
+++ b/espeak-ng-data/voices/!v/gustave
@@ -1,4 +1,4 @@
-﻿language variant
+language variant
 name Gustave
 
 pitch  80 123

--- a/espeak-ng-data/voices/!v/linda
+++ b/espeak-ng-data/voices/!v/linda
@@ -1,36 +1,20 @@
-	language variant
-
+language variant
 name Linda
-
 gender female
 
-
 #echo 130 15
-
-pitch 200 247  
-
+pitch 200 247
 flutter 3
 formant 0 88 85 154
-
 formant 1 135 58 169 -30
-
 formant 2 131 75 152 -260
-
 formant 3 123 75 150
-
 formant 4 125 80 150
-
 formant 5 125 80 150
-
 formant 6 110 80 150
-
 formant 7 110 75 150
-
 formant 8 110 75 150
 
-
-
 stressAdd -20 -20 -20 -20 0 3 20 120
-
 stressAmp 18 16 20 20 20 20 27 20
 

--- a/espeak-ng-data/voices/!v/marcelo
+++ b/espeak-ng-data/voices/!v/marcelo
@@ -1,4 +1,4 @@
-?language variant
+language variant
 name Marcelo
 
 pitch  65 115


### PR DESCRIPTION
The six modified files all had spurious characters introduced apparently
as a result of files with the UTF8 BOM marker, U-FFFE, which is
conventionally used at the start of text files to indicate a UTF-8 file
and is invisible under normal circumstances (e.g. the file is opened as
a text file).

None of these files are recognized by espeak-ng on Linux systems because
the 'language variant' line is seen by espeak-ng as starting with a new
character.

'gustave' is an uncorrupted file, it correctly starts with the BOM in
UTF-8 (three bytes), however even though it is correct espeak-ng does
not read it (this may be a separate bug!)

'marcelo' somehow got the BOM character replaced by a literal '?',
notice that 'git diff' on these changes will, indeed, show the removed
character in 'gustave' as a literal '?'.  Notice also that the character
in question, the BOM, is actually the Unicode 'zero width no-break
space', so it is pretty invisible.

The remaining files seem to have suffered major corruption possible as a
result of dostounix style convertions.  The line endings, normally <lf>
on Unix or <cr><lf> on Windows, had been converted to <cr><lf><lf> and
the BOM had been replaced by a <tab> character.

Signed-off-by: John Bowler <jbowler@acm.org>