### PR TITLE
Changes in espeak-ng core — improved MBROLA error handling, `all` parameter to list all voices

### DIFF
--- a/src/espeak-ng.1.ronn
+++ b/src/espeak-ng.1.ronn
@@ -122,6 +122,13 @@ words are provided then text is spoken from stdin a line at a time.
   * `--voices[=<language code>]`:
     Lists the available voices. If =&lt;language code&gt; is present then only
     those voices which are suitable for that language are listed.
+    If `xx-yy` language code is passed, then voices with `yy` of `xx` language variants
+    are shown with higher priority than just `xx`.
+    If `variant` is passed, then all voice variants are shown.
+    If `mb` or `mbrola` is passed, then all voices using the MBROLA voice synthesizer
+    are shown.
+    If `all` is passed, then all eSpeak NG voices, voice variants and MBROLA
+    voices are shown.
 
   * `--voices=<directory>`:
     Lists the voices in the specified subdirectory.

--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -347,7 +347,11 @@ static int mbrola_has_errors(void)
 			    strncmp(buf_ptr, "Input Flush Signal", 18) == 0)
 				continue;
 			*lf = 0;
-			fprintf(stderr, "mbrola: %s\n", buf_ptr);
+			if (strstr(buf_ptr, "mbrola: No such file or directory") != NULL)
+				fprintf(stderr,
+						"mbrola executable was not found. Please install MBROLA!\n");
+			else
+				fprintf(stderr, "mbrola: %s\n", buf_ptr);
 			// is this the last line?
 			if (lf == &buf_ptr[result - 1]) {
 				snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -97,6 +97,19 @@ espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans, 
 
 			if (GetFileLength(path) <= 0)
 				sprintf(path, "/usr/share/mbrola/voices/%s", mbrola_voice);
+
+			// Show error message
+			if (GetFileLength(path) <= 0) {
+				fprintf(stderr, "Cannot find MBROLA voice file '%s' in neither of paths:\n"
+						" - /usr/share/mbrola/%s\n"
+						" - /usr/share/mbrola/%s/%s\n"
+						" - /usr/share/mbrola/voices/%s\n"
+						"Please install necessary MBROLA voice!\n",
+						mbrola_voice, mbrola_voice, mbrola_voice, mbrola_voice, mbrola_voice);
+				// Set path back to simple name, otherwise it shows misleading error only for
+				// last unsuccessfully searched path
+				sprintf(path, "%s", mbrola_voice);
+			}
 		}
 	}
 	close_MBR();

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1184,6 +1184,11 @@ static int SetVoiceScores(espeak_VOICE *voice_select, espeak_VOICE **voices, int
 		if (((control & 1) == 0) && (memcmp(vp->identifier, "mb/", 3) == 0))
 			continue;
 
+		if (memcmp(voice_select->languages,"all", 3) == 0) {
+			voices[nv++] = vp;
+			continue;
+		}
+
 		if ((score = ScoreVoice(voice_select, language, n_parts, lang_len, voices_list[ix])) > 0) {
 			voices[nv++] = vp;
 			vp->score = score;


### PR DESCRIPTION
Reece,
please review these changes and merge them if implementation is acceptable.
Thanks!