### PR TITLE
#725: ' (quote) versus " (quotes) is almost impossible to audibly differentiate

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -127,7 +127,7 @@ _$	d0l3
 _%	p3s'Ent
 ?5 _%	pVRs'Ent
 _&	amp@sand
-_'	kwoUt
+_'	t'Ik
 _[	lEftbrakI2t
 _]	raItbrakI2t
 _(	lEftpa#rEn


### PR DESCRIPTION
Users of screen readers (eg: Orca, NVDA, JAWS) and other TTS assistive technologies rely on accurate and easy-to-understand reading of the text. One context in which this becomes especially critical is systems administration and software development, where TTS users need to be able to clearly and easily differentiate types of punctuation with minimal effort in the midst of reading a larger portion of text. For example, the two characters have significantly different meanings in shells and in some programming languages.

This PR changes the name of the quote (') character to "tick", as this was difficult to differentiate from """, which reads as "quotes"