### PR TITLE
Fix bug #706: pronunciation error with abbreviations followed by 's

### DIFF
--- a/tests/translate.test
+++ b/tests/translate.test
@@ -27,6 +27,12 @@ test_phonemes lv \
 test_phonemes en "d'eIbju:tI2d" "débuted"
 test_phonemes en-US "d'eIbju:t#I#d" "débuted"
 
+# s at the end of abbreviations
+# https://github.com/espeak-ng/espeak-ng/issues/706
+test_phonemes en ",aIb,i:;'Em m'It 'Ib@mz m'Its ,aIb,i:;'Em ,Em,aIt'i:; ,eIp,i:;'eItS s,i:;,i:;'Es ,aIt,i:;'Eks ,aIb,i:;'Emz ,Em,aIt'i:z ,eIp,i:;'eItSIz s,i:;,i:;'EsIz ,aIt,i:;'EksIz" "ibm mit ibms mits IBM MIT APH CES ITX IBMs MIT's APHs CES's ITXs"
+test_phonemes lv "'ibm m'it 'ibm-s m'its 'ibm m'it 'aph ts'Es 'it_ks 'ibm-s m'its 'aphs ts'Ess 'it_kss" "ibm mit ibms mits IBM MIT APH CES ITX IBMs MIT's APHs CES's ITXs"
+test_phonemes ru "(en),aIb,i:;'Em m'It 'Ib@mz m'Its ,aIb,i:;'Em ,Em,aIt'i:; ,eIp,i:;'eItS s,i:;,i:;'Es ,aIt,i:;'Eks 'Ib@mz m'Its 'afz s'EI2zI2z 'ItEksz(ru)" "ibm mit ibms mits IBM MIT APH CES ITX IBMs MIT's APHs CES's ITXs"
+
 # bug: https://github.com/nvaccess/nvda/issues/7740
 test_phonemes ta "'il." "ள்"
 test_phonemes my "kon'i" "7"


### PR DESCRIPTION
@rhdunn, please review and merge fix for #706
I also made it work properly for other languages where, plural/genitive with ...s or ...'s doesn't have meaning (i.e. ..s is considered part of the root word) and updated tests.