### PR TITLE
Remove Eclipse IDE local user specific project settings file.

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
-org.eclipse.jdt.core.compiler.source=1.6


### PR DESCRIPTION
IDE local user files should not be in the project. And it appears to specify Java 1.6 as the JDK to use when loading the project workspace up in Eclipse.