### PR TITLE
Fixing sequences of ? and !

### DIFF
--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -1000,6 +1000,15 @@ int ReadClause(Translator *tr, char *buf, short *charix, int *charix_top, int n_
 					UngetC(c_next);
 			}
 
+			// Handling of sequences of ? and ! like ??!?, !!??!, ?!! etc
+			// Use only first char as determinant
+			if((c1 == '?') || (c1 == '!')) {
+				while((c2 == '?') || (c2 == '!')) {
+					c_next = GetC();
+					c2 = c_next;
+				}
+			}
+
 			punct_data = 0;
 			if ((punct_data = clause_type_from_codepoint(c1)) != CLAUSE_NONE) {
 				if (punct_data & CLAUSE_PUNCTUATION_IN_WORD) {

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -1000,17 +1000,18 @@ int ReadClause(Translator *tr, char *buf, short *charix, int *charix_top, int n_
 					UngetC(c_next);
 			}
 
-			// Handling of sequences of ? and ! like ??!?, !!??!, ?!! etc
-			// Use only first char as determinant
-			if((c1 == '?') || (c1 == '!')) {
-				while((c2 == '?') || (c2 == '!')) {
-					c_next = GetC();
-					c2 = c_next;
-				}
-			}
-
 			punct_data = 0;
 			if ((punct_data = clause_type_from_codepoint(c1)) != CLAUSE_NONE) {
+
+				// Handling of sequences of ? and ! like ??!?, !!??!, ?!! etc
+				// Use only first char as determinant
+				if(punct_data & (CLAUSE_QUESTION | CLAUSE_EXCLAMATION)) {
+					while(clause_type_from_codepoint(c2) & (CLAUSE_QUESTION | CLAUSE_EXCLAMATION)) {
+						c_next = GetC();
+						c2 = c_next;
+					}
+				}
+
 				if (punct_data & CLAUSE_PUNCTUATION_IN_WORD) {
 					// Armenian punctuation inside a word
 					stressed_word = true;


### PR DESCRIPTION
Hi, this is an attempt to fix #583. This specifically targets sequences of `?` and `!` (like `?!?!!!`,`???`, `!!!`, etc) and treats the whole sequence as its first char only.