### PR TITLE
Import missing function symbol from DLL in mbrola wrapper

### DIFF
--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -50,6 +50,7 @@ BOOL load_MBR()
 	init_MBR = (void *)GetProcAddress(hinstDllMBR, "init_MBR");
 	write_MBR = (void *)GetProcAddress(hinstDllMBR, "write_MBR");
 	flush_MBR = (void *)GetProcAddress(hinstDllMBR, "flush_MBR");
+	getFreq_MBR = (void *)GetProcAddress(hinstDllMBR, "getFreq_MBR");
 	read_MBR = (void *)GetProcAddress(hinstDllMBR, "read_MBR");
 	close_MBR = (void *)GetProcAddress(hinstDllMBR, "close_MBR");
 	reset_MBR = (void *)GetProcAddress(hinstDllMBR, "reset_MBR");


### PR DESCRIPTION
This PR fixes an error with MBROLA support for Windows. You can use MBROLA voices with espeak-ng on Windows by building the DLL from https://github.com/numediart/MBROLA and installing the voices following [the documentation](https://github.com/espeak-ng/espeak-ng/blob/master/docs/mbrola.md)