### PR TITLE
Fix and related test for issue #772

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ tests/*.check
 !tests/translate.test
 !tests/non-executable-files-with-executable-bit.test
 !tests/bom.test
+!tests/mbrola.test
 
 espeak-ng.pc
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -257,6 +257,7 @@ check:	tests/encoding.check \
 	tests/language-numbers-cardinal.check \
 	tests/language-numbers-ordinal.check \
 	tests/non-executable-files-with-executable-bit.check \
+	tests/mbrola.check \
 	tests/bom.check
 
 ##### fuzzer:

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -80,6 +80,7 @@ static void *my_user_data = NULL;
 static espeak_ng_OUTPUT_MODE my_mode = ENOUTPUT_MODE_SYNCHRONOUS;
 static int out_samplerate = 0;
 static int voice_samplerate = 22050;
+static int min_buffer_length = 60; // minimum buffer length in ms
 static espeak_ng_STATUS err = ENS_OK;
 
 t_espeak_callback *synth_callback = NULL;
@@ -276,10 +277,12 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_InitializeOutput(espeak_ng_OUTPUT_MODE 
 		my_audio = create_audio_device_object(device, "eSpeak", "Text-to-Speech");
 #endif
 
-	// buffer_length is in mS, allocate 2 bytes per sample
-	if (buffer_length == 0)
-		buffer_length = 60;
 
+	// Don't allow buffer be smaller than safe minimum
+	if (buffer_length < min_buffer_length)
+		buffer_length = min_buffer_length;
+
+	// allocate 2 bytes per sample
 	outbuf_size = (buffer_length * samplerate)/500;
 	out_start = (unsigned char *)realloc(outbuf, outbuf_size);
 	if (out_start == NULL)

--- a/tests/mbrola.test
+++ b/tests/mbrola.test
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Test a command for presence and ability to output the sha1 hash of a file.
+check_hashcmd() {
+        which $1 &&
+        $1 </dev/null 2>/dev/null |
+        awk '{if ($1 != "da39a3ee5e6b4b0d3255bfef95601890afd80709") { exit 1; }}'
+}
+
+check_voice_folder() {
+        voice_file=${1#mb-}
+        if [ -f "/usr/share/mbrola/$voice_file" ]; then
+                voice_file="/usr/share/mbrola/$voice_file"
+        elif [ -f "/usr/share/mbrola/$voice_file/$voice_file" ]; then
+                voice_file="/usr/share/mbrola/$voice_file/$voice_file"
+        elif [ -f "/usr/share/mbrola/voices/$voice_file" ]; then
+                voice_file="/usr/share/mbrola/voices/$voice_file"
+        else
+                voice_file=""
+        fi
+}
+
+test_voice () {
+        MBVOICE=$1
+        EXPECTED=$2
+        TEST_TEXT=$3
+        check_voice_folder $MBVOICE
+        if [ "$voice_file" != "" ]; then
+                echo "testing ${MBVOICE} ${TEST_TEXT} ... "
+                ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
+                src/espeak-ng --stdout -v ${MBVOICE} "${TEST_TEXT}" | \
+                $sha1sum | awk '{ print $1 }' > actual.txt
+                echo "${EXPECTED}" > expected.txt
+                diff expected.txt actual.txt || exit 1
+        else
+                echo "$MBVOICE was not tested"
+        fi
+}
+
+# Test some common commands to find the correct one for the system being tested on.
+echo -n "checking for SHA1 hashing command ... "
+if check_hashcmd sha1sum; then
+        sha1sum=sha1sum
+elif check_hashcmd sha1; then
+        sha1sum=sha1
+elif check_hashcmd shasum; then
+        sha1sum=shasum
+else
+        echo "no"
+        exit 1
+fi
+
+
+echo -n "checking if MBROLA is installed ... "
+if [ "`which mbrola`" != "" ]; then
+        echo "yes"
+else
+        echo "no"
+        exit 1
+fi
+
+test_voice mb-fr4 31fae066f45d4a9dc56289344f28dd00bce77875 "Bonjour"
+
+


### PR DESCRIPTION
Reece, I couldn't figure out, how to properly test too small buffer from `tests/api.c`, but I created `tests/mbrola.test` for MBROLA voice and checked, that if line is set to `espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 1, data_path, 0);` in `espeak-ng.c`, test fails.
It may also help in future changes in implementation of eSpeak NG.