### PR TITLE
Misc Cherokee language fixes.

### DIFF
--- a/dictsource/chr_rules
+++ b/dictsource/chr_rules
@@ -213,25 +213,25 @@
     L02)	us	(L03L03L01 u~h`s
     
 .group v
-    v	V~:
+    v	&~:
     
-    v	(L03_	V~43
-    v	(L03L03_	V~43
-    v	(L03L03L03_	V~43
+    v	(L03_	&~43
+    v	(L03L03_	&~43
+    v	(L03L03L03_	&~43
     
-    v	(_	V~43
-    vxb	(_	V~1
-    vxc	(_	V~2
-    vxd	(_	V~3
-    vxf	(_	V~4
+    v	(_	&~43
+    vxb	(_	&~1
+    vxc	(_	&~2
+    vxd	(_	&~3
+    vxf	(_	&~4
     
-    v	(L03L01 V~
-    v	(L03L03L01 V~
-    v	(L03L03L03L01 V~
+    v	(L03L01 &~
+    v	(L03L03L01 &~
+    v	(L03L03L03L01 &~
     
-    vs	(L01 V~h`s
-    vs	(L03L01 V~h`s
-    vs	(L03L03L01 V~h`s
+    vs	(L01 &~h`s
+    vs	(L03L01 &~h`s
+    vs	(L03L03L01 &~h`s
 
 .group ạ
     ạ 0
@@ -269,9 +269,9 @@
     L02) ụs u~h`s
     
 .group ṿ
-    ṿ V~
-    ṿ V~43
-    ṿs V~h`s
+    ṿ &~
+    ṿ (_ &~43
+    ṿs &~h`s
 
 .group ch
     ch tS

--- a/phsource/ph_cherokee
+++ b/phsource/ph_cherokee
@@ -218,9 +218,22 @@ endphoneme
 
 //ṿ, v
 phoneme V~
-  vwl lng starttype #@ endtype #@
-  length 300
-  FMT(vnasal/V_n, 100)
+	vwl lng starttype #@ endtype #@
+//  vwl lng starttype #@ endtype #@
+//  length 300
+//  FMT(vnasal/V_n, 100)
+	ChangePhoneme(&~)
+endphoneme
+
+phoneme &~
+  vwl  starttype #@ endtype #@
+  ipa ɐU+0303
+  length 180
+  IF thisPh(isFinalVowel) THEN
+    FMT(vnasal/a#_n2)
+  ELSE
+    FMT(vnasal/a#_n)
+  ENDIF
 endphoneme
 
 phoneme V~`
@@ -315,11 +328,32 @@ phoneme t
 
   IF nextPh(isPause2) THEN
     WAV(ustop/t_)
+  ELIF nextPh(r) OR nextPh(R) OR nextPh(R2) THEN
+    WAV(ustop/tr)
   ELIF nextPh(@-) THEN
     WAV(ustop/t_dnt, 50)
-  ELSE
-	  WAV(ustop/t_dnt, 100)
   ENDIF
+  WAV(ustop/t, 90)
+endphoneme
+
+phoneme d
+  vcd alv stp
+  voicingswitch t
+  lengthmod 5
+  Vowelin f1=1  f2=1700 -300 300  f3=-100 80
+  Vowelout f1=2 f2=1700 -300 300  f3=-100 80 brk
+
+  IF PreVoicing THEN
+    FMT(d/xd)
+  ENDIF
+
+  IF nextPh(isPause2) THEN
+    FMT(d/d_)  addWav(x/d_)
+//  ELIF nextPh(r) THEN
+//    FMT(d/dr) addWav(x/d)
+  ENDIF
+
+  FMT(d/d) addWav(x/d)
 endphoneme
 
 phoneme dZ // **j**udge
@@ -400,3 +434,40 @@ phoneme m
     FMT(m/m_)
   ENDIF
 endphoneme
+
+phoneme w
+  liquid
+  lengthmod 7
+  starttype #u
+  
+  IF nextPh(isVowel) THEN
+  
+    NextVowelStarts
+      VowelStart(w/w2)
+      VowelStart(w/wa)
+      VowelStart(w/we)
+      VowelStart(w/wi)
+      VowelStart(w/wo)
+      VowelStart(w/wu)
+    EndSwitch
+
+    VowelEnding(w/xw, -30)
+
+    IF prevPhW(isNasal) THEN
+      FMT(w/w2)
+    ELSEIF prevPhW(h) THEN
+      // none,  [hw]
+    ELSE
+    	FMT(w/w2)
+      //FMT(w/_w)
+    ENDIF
+  ELSE
+    // no vowel follows
+    Vowelout len=50
+    IF prevPh(#i) THEN
+      FMT(w/iw_)
+    ENDIF
+    FMT(w/w_)
+  ENDIF
+endphoneme
+


### PR DESCRIPTION
Switch to Portuguese /&~/ for &lt;v&gt;.
Use aveolar /d/ instead of dental /d[/.

The base phonemes file defines alveolar /d/ with the definition for a
dental /d[/ ????