### PR TITLE
zh_listx: fix bogus `冉冉` item

### DIFF
--- a/dictsource/extra/zh_listx
+++ b/dictsource/extra/zh_listx
@@ -40942,7 +40942,6 @@ $textmode
 (内 里)	nei4li3
 (内 里)	nei4li3
 (冈 本)	gang1ben3
-(冉 冉)	ran3ran3
 (再 不)	zai4bu5
 (再 不)	zai4bu5
 (再 也)	zai4ye3


### PR DESCRIPTION
This item will lead `冉冉` to be pronounced 3 times rather than 2, and
it's not necessary because this character has no overloaded
pronounciation.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>