### PR TITLE
cmn: use voiceless uvular fricative as pronounciation of pinyin h

### DIFF
--- a/dictsource/zh_rules
+++ b/dictsource/zh_rules
@@ -125,7 +125,7 @@ language).
     @) g (K	_^_EN
 
 .group h
-       h        x
+       h        X
     @) h (K	_^_EN
 
 .group i


### PR DESCRIPTION
According to [1] and [2] , the pronounciation of the pinyin character
h is not accurately [x].
According to [2], [χ] is instead a possible pronounication in young
users.

As a young native speaker of Mandarin, I feel the sound of [χ] in espeak
more satisfied than [x] here.

[1] https://en.wikipedia.org/wiki/Standard_Chinese_phonology
[2] https://phesoca.com/aws/268/

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>