### PR TITLE
add output hooks for wavegen

### DIFF
--- a/src/include/espeak-ng/espeak_ng.h
+++ b/src/include/espeak-ng/espeak_ng.h
@@ -77,6 +77,14 @@ typedef enum {
 	ENGENDER_NEUTRAL = 3,
 } espeak_ng_VOICE_GENDER;
 
+typedef struct
+{
+  void (*outputPhoSymbol)(char* pho_code,int pho_type);
+  void (*outputSilence)(short echo_tail);
+  void (*outputVoiced)(short sample);
+  void (*outputUnvoiced)(short sample);
+} espeak_ng_OUTPUT_HOOKS;
+
 /* eSpeak NG 1.49.0 */
 
 typedef struct espeak_ng_ERROR_CONTEXT_ *espeak_ng_ERROR_CONTEXT;
@@ -188,6 +196,12 @@ espeak_ng_CompilePhonemeDataPath(long rate,
                                  const char *destination_path,
                                  FILE *log,
                                  espeak_ng_ERROR_CONTEXT *context);
+                                 
+ESPEAK_NG_API espeak_ng_STATUS
+espeak_ng_SetOutputHooks(espeak_ng_OUTPUT_HOOKS* hooks);
+ESPEAK_NG_API espeak_ng_STATUS
+espeak_ng_SetConstF0(int f0);
+
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -146,6 +146,14 @@ static void DoAmplitude(int amp, unsigned char *amp_env)
 	WcmdqInc();
 }
 
+static void DoPhonemeAlignment(char* pho, int type)
+{
+	wcmdq[wcmdq_tail][0] = WCMD_PHONEME_ALIGNMENT;
+	wcmdq[wcmdq_tail][1] = pho;
+	wcmdq[wcmdq_tail][2] = type;
+	WcmdqInc();
+}
+
 static void DoPitch(unsigned char *env, int pitch1, int pitch2)
 {
 	intptr_t *q;
@@ -1131,6 +1139,8 @@ void DoEmbedded(int *embix, int sourceix)
 	} while ((word & 0x80) == 0);
 }
 
+extern espeak_ng_OUTPUT_HOOKS* output_hooks;
+
 int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 {
 	static int ix;
@@ -1187,6 +1197,14 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 
 	while ((ix < (*n_ph)) && (ix < N_PHONEME_LIST-2)) {
 		p = &phoneme_list[ix];
+		
+		if(output_hooks && output_hooks->outputPhoSymbol)
+		{
+			char buf[30];
+			int dummy=0;
+			WritePhMnemonic(buf, p->ph, p, 0, &dummy);
+			DoPhonemeAlignment(strdup(buf),p->type);
+		}
 
 		if (p->type == phPAUSE)
 			free_min = 10;

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -433,6 +433,7 @@ extern unsigned char pitch_adjust_tab[MAX_PITCH_VALUE+1];
 #define WCMD_MBROLA_DATA 13
 #define WCMD_FMT_AMPLITUDE 14
 #define WCMD_SONIC_SPEED 15
+#define WCMD_PHONEME_ALIGNMENT 16
 
 #define N_WCMDQ   170
 #define MIN_WCMDQ  25   // need this many free entries before adding new phoneme


### PR DESCRIPTION
I've added some hooks to wavegen, which can be used to output aligned speech. This information can be used by prosody transplantation tools similar to MBROLIGN. There is also a function to set a constant f0 in Hz, which may be used by some prosody transplantation tools. If none of the functions is called, the behaviour of espeak-ng is unchanged. 