### PR TITLE
qdb - lang belta (conlang from The Expanse)

### DIFF
--- a/dictsource/qdb_list
+++ b/dictsource/qdb_list
@@ -1,0 +1,186 @@
+// This file is UTF8 encoded 
+// Spelling to phoneme words for 'lang belta'(conlang from The Expanse).
+
+_0      nada
+_1      waN
+_2      tu:
+_3      se:'ri:
+_4      fu:
+_5      faf
+_6      si:ke:S
+_7      se:N
+_8      et
+_9      naN
+_10     te:N
+_11     waNu:nj@-te:N
+_12     tu:nj@te:N
+_13     se:'ri?u:nj@-te:N
+_14     fu:nj@-te:N
+_15     fafu:nj@-te:N
+_16     si:ke:Su:nj@-te:N
+_17     se:Nu:nj@-te:N
+_18     etu:nj@-te:N
+_19     naNu:nj@-te:N
+_2X     'tu:te:N
+_3X     se:'ri:te:N
+_4X     'fu:te:N
+_5X     'fave:te:N
+_6X     'si:ke:se:te:N
+_7X     'se:Nete:N
+_8X     'e:te:te:N
+_9X     'naNe:te:N
+_0C     xanja
+_1C     xanja
+_0M1    t0se:N
+_1M1    t0se:N
+_0and   u:nj@-
+_dpt    ko:ma
+
+// individual letters (not canon!)
+
+ã       ale:fa%'0ta
+a       'ale:fa
+b       'beravo:
+ch      'tS0li
+c       'tS0li_i:nja
+d       'de:lta
+dzh     'dzu:S
+e       'eko:
+f       'fo:S
+g       'g0f
+i       'i:ndi:%ja
+j       'i:ndi:%ja_i:nja
+k       'ki:lo:
+l       'li:ma
+m       'ma%ji:k
+n       'no:ve:mb0
+o       'o:xo:
+ow      '0Se:ka
+p       'papa
+q       'ki:lo:_i:nja
+r       'ro:me:%jo:
+s       'si%je:ra
+sh      'Sapu:
+t       'Tane:ko:
+u       'u:ni:%f0m
+v       'vi:ke:t0
+w       'wi:se:ki:
+x       'xo:m
+y       'ja%Ne:%ki:
+z       'ze:be:ra
+
+// irregular stress patterns or phonotactics
+
+amawala         $1
+amolof          $1
+anyimal         $1
+bekedabush      $4
+bekpelesh       be:k@-pe:'le:S
+belang          $2
+belek           $2
+belowt          $2
+belu            $2
+bosmang         'bo:s@-maN
+bukipelesh      $4
+dedawang        $1
+dedeya          $1
+depelesh        $3
+ekepesh         $1
+entediye        $1
+ereluf          $1
+etera           $1
+feradiye        $2
+gerowsh         $2
+gutegow         $1
+gutemang        $1
+idzhifobek      $4
+kedawang        $1
+kena            ke:%na
+kepelesh        $3
+keya            ke:%ja
+kometing        $1
+kowpelesh       $3
+langemang       $1
+liperi          $1
+malimang        $1
+mamamang        $1
+metexeng        $1
+nakangego       $2
+nakangikeng     $2
+naterash        $1
+owala           $1
+paxari          $1
+paxoniseki      $3
+pelesh          $2
+peyeting        $1
+polisi          $1
+redzherosh      $1
+rembera         $1
+ruserux         $1
+saviting        $1
+sefesowng       $1
+semowt          $2
+sempere         $1
+seping          $2
+sesata          $1
+seterax         $3
+setop           $2
+setoriye        $2
+shelaf          $2
+sheru           $2
+shetexeting     $2
+soya            $2
+tekidok         $1
+tekimang        $1
+tekiting        $1
+terash          $2
+tungeting       $1
+uzilik          $1
+vediting        $1
+wamotim         $1
+xelixup         $1
+xidawang        $1
+xunyampelesh    $1
+yaterash        $1
+zakomang        $1
+
+// conjunctions
+
+un              u:N
+unte            u:nte: $pause
+amash           amaS $pause
+o               o: $pause
+
+// prepositions
+
+efa             e:fa $brk
+ere             e:re: $brk
+erefo           e:re:fo: $brk
+fing            fi:N $brk
+fingi           fi:Ni: $brk
+fo              fo: $brk
+fode            fo:de: $brk
+fong            fo:N $brk
+nawit           nawi:t $brk
+wit             wi:t $brk
+
+// pronouns
+
+mi              $u $only
+milowda         $u $only
+//beltalowda    $u $only
+to              $u $only
+tolowda         $u $only
+//inyalowda     $u $only
+im              $u $only
+imalowda        $u $only
+imim            $u $only
+sif             $u $only
+
+da              $u $only
+wa              $u $only
+
+de              $u $only
+xi              $u $only
+xiya            $u $only
+deya            $u $only

--- a/dictsource/qdb_rules
+++ b/dictsource/qdb_rules
@@ -1,0 +1,100 @@
+// This file is UTF8 encoded 
+// Spelling to phoneme rules for 'lang belta' (conlang from The Expanse)
+
+.replace
+	á	'a
+	é	'e
+	í	'i
+	ó	'o
+	ú	'u
+	à	'a
+	è	'e
+	ì	'i
+	ò	'o
+	ù	'u
+
+.group '
+	'	'
+
+.group a
+	a	a
+	a (_	a?
+
+.group b
+	b	b
+
+.group c
+	ch	tS
+
+.group d
+	dzh	dZ
+	d	d
+
+.group e
+	e	e:
+	e (_	e:?
+
+.group f
+	f	f
+
+.group g
+	g	g
+
+.group i
+	i	i:
+	i (_	i:?
+
+.group k
+	k	k
+
+.group l
+	l	l
+
+.group m
+	m	m
+
+.group n
+	ng	N
+	ny	n^
+	n	n
+
+.group o
+	ow	0
+	ow (_	0?
+	o	o:
+	o (_	o:?
+
+.group p
+	p	p
+
+.group r
+	r	r
+
+.group s
+	sh	S
+	s	s
+
+.group t
+	t	t
+
+.group u
+	u	u:
+	u (_	u:?
+
+.group v
+	v	v
+
+.group w
+	w	w
+
+.group x
+	x	x
+
+.group y
+	y 	%j
+
+.group z
+	z	z
+
+.group
+	ã	A~	// we don't yet know if other nasalized vowels exist

--- a/espeak-ng-data/voices/art/qdb
+++ b/espeak-ng-data/voices/art/qdb
@@ -1,0 +1,6 @@
+name Lang_Belta
+language qdb
+
+numbers 4 3
+
+replace 1 t ?

--- a/phsource/ph_langbelta
+++ b/phsource/ph_langbelta
@@ -1,0 +1,40 @@
+//*******************************************************************
+// VOWELS
+//*******************************************************************
+
+phoneme a
+  vwl  starttype #e  endtype #@
+  ipa æ
+  length 210
+  FMT(vwl_en_us/a)
+endphoneme
+
+phoneme 0
+  vwl  starttype #o   endtype #o
+  ipa ɒ
+  length 140
+  FMT(vowel/0_3)
+endphoneme
+
+//*******************************************************************
+// CONSONANTS
+//*******************************************************************
+
+phoneme r
+  liquid rfx
+  ipa ɽ
+  lengthmod 3
+  Vowelout f1=3 f2=1400 -400 300  f3=-400 80 rms=35 len=15 colr=2
+  Vowelin  f1=2 f2=1400 -400 300  f3=-400 80 len=20
+
+  FMT(r3/@tap_rfx)
+endphoneme
+
+phoneme ?  // glottal stp
+  vls glt stp
+  lengthmod 1
+  nolink
+  Vowelin  glstop
+  Vowelout glstop
+  WAV(ustop/null)
+endphoneme

--- a/phsource/phonemes
+++ b/phsource/phonemes
@@ -2041,5 +2041,5 @@ phonemetable nog kk
 phonemetable uz kk
 include ph_uzbek
 
-phonemetable qdb
+phonemetable qdb en
 include ph_langbelta

--- a/phsource/phonemes
+++ b/phsource/phonemes
@@ -2040,3 +2040,6 @@ phonemetable nog kk
 
 phonemetable uz kk
 include ph_uzbek
+
+phonemetable qdb
+include ph_langbelta


### PR DESCRIPTION
This is a TTS package for _lang belta_, an artificial creole developed by Nick Farmer for "The Expanse" TV show. (NB: it differs significantly from the "belter creole" language in the books) It is an unofficial fan creation.

At the moment, it contains my best interpretation based on conversations with the speech coach for the show, Eric Armstrong, and people such as https://www.youtube.com/watch?v=wcgaIqEioH4 who have learned the language orally, directly from Farmer.

For phonology and references, see documentation at the bottom of the following page:
https://glaemscrafu.jrrvf.com/english/glaemscribe.html?mode=lang_belta-tengwar-dadef

pedantic notes:

- the necessary phonemes were cut-and-pasted from other espeak-ng languages, en-us, en-rp, and jp.
- there may be more aspects of the language revealed in upcoming seasons
- we only have numbers up to (at most) 9'999 at this time
- the 'qdb' abbreviation is q-private and has not been asssigned. 'db' is for _da belte_, the language's toponym