### PR TITLE
Small update for F-Droid

### DIFF
--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Text-to-speech engine for Android. Based on the eSpeak engine created by Jonathan Duddington.
+Text-to-speech engine for Android. Based on the eSpeak engine.

--- a/fastlane/metadata/android/es-ES/short_description.txt
+++ b/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,1 +1,1 @@
-Motor de síntesis de voz para Android. Basado en el motor eSpeak creado por Jonathan Duddington.
+Motor de síntesis de voz para Android. Basado en el motor eSpeak.


### PR DESCRIPTION
I'm sorry I couldn't update this sooner. This is a continuation of PR #820 to list eSpeak NG in F-Droid.

[They recommend](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7136#note_455850781) having short descriptions shorter than 80 characters to prevent F-Droid clients from truncating them, so I'm just doing that with this new commit.

They also recommend [increasing `versionCode`](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7136#note_456343476) in every release, to allow auto-updates. In particular, they ask that the current `versionCode` (20) is larger than the `versionCode` for the [latest tag release](https://github.com/espeak-ng/espeak-ng/releases/tag/1.50).

