### PR TITLE
Set number handling on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,21 @@ documentation:
 * Add documentation about dictionary flags.
 
 updated languages:
-*  ba (Bashkir) -- boracasli98, Valdis Vitolins
-*  chr (Cherokee) -- Michael Conrad
+*  ba (Bashkir) -- boracasli98, Valdis Vitolins, Juho Hiltunen
 *  de (German) -- Karl Eick
 *  el (Modern Greek) -- Reece Dunn (support for variant Greek letter forms)
 *  en (English) -- Steven Presser, Ben Talagan
 *  ga (Gaelic (Irish)) Chen, Chien-ting 
 *  grc (Ancient Greek) -- Reece Dunn (support for variant Greek letter forms)
+*  hak (Hakka Chinese) -- Juho Hiltunen
+*  haw (Hawaiian) -- Juho Hiltunen
+*  kok (Konkani) -- Juho Hiltunen
+*  nb (Norwegian Bokmål) -- Juho Hiltunen
+*  nci (Classical Nahuatl) -- Juho Hiltunen
 *  hy (Armenian) -- tigransimonyan
 *  ia (Interlingua) -- nesrad
 *  it (Italian) -- Christian Leo
-*  ja (Japanese) -- fukuen
+*  ja (Japanese) -- fukuen, Juho Hiltunen
 *  jbo (Lojban) -- Juho Hiltunen, xunsku
 *  lv (Latvian) -- Valdis Vitolins
 *  mi (Māori) -- boracasli98
@@ -38,7 +42,7 @@ updated languages:
 *  tr (Turkish) -- boracasli98
 *  ur (Urdu) -- Ejaz Shah
 *  uz (Uzbek) -- boracasli98, Valdis Vitolins
-*  zh (Chinese) -- Silas S. Brown, Rongcui Dong, Icenowy Zheng
+*  zh (Chinese) -- Silas S. Brown, Rongcui Dong, Icenowy Zheng, Juho Hiltunen
 
 new languages:
 *  chr (Cherokee) -- Michael Conrad

--- a/docs/numbers.md
+++ b/docs/numbers.md
@@ -12,8 +12,10 @@ language:
 
 These controls how numbers are pronounced.
 
-If `numbers` is set to `0` (the default value), numbers will not be pronounced.
-Setting it to `1` will enable number pronunciation using the dictionary rules.
+If `numbers` is set to `0`, numbers will not be pronounced.
+Setting it to `1` (the default value) will enable number pronunciation using the dictionary rules.
+For more control over number pronunciation, see the flags in `translate.h`.
+
 
     tr->langopts.max_digits
 

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2005 to 2015 by Jonathan Duddington
  * email: jonsd@users.sourceforge.net
  * Copyright (C) 2015-2016, 2020 Reece H. Dunn
+ * Copyright (C) 2021 Juho Hiltunen
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -305,6 +306,7 @@ static Translator *NewTranslator(void)
 	tr->langopts.min_roman = 2;
 	tr->langopts.thousands_sep = ',';
 	tr->langopts.decimal_sep = '.';
+	tr->langopts.numbers = NUM_DEFAULT;
 	tr->langopts.break_numbers = BREAK_THOUSANDS;
 	tr->langopts.max_digits = 14;
 
@@ -477,6 +479,18 @@ Translator *SelectTranslator(const char *name)
 
 	switch (name2)
 	{
+	case L('m', 'i'):
+	case L('m', 'y'):
+	case L4('p', 'i', 'q', 'd'): // piqd
+	case L('p', 'y'):
+	case L('q', 'u'):
+	case L3('q', 'u', 'c'):
+	case L('t', 'h'):
+	case L('u', 'z'):
+	{
+		tr->langopts.numbers = 0; // disable numbers until the definition are complete in _list file
+	}
+		break;
 	case L('a', 'f'):
 	{
 		static const short stress_lengths_af[8] = { 170, 140, 220, 220,  0, 0, 250, 270 };
@@ -1065,6 +1079,7 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.param[LOPT_CAPS_IN_WORD] = 1; // capitals indicate stressed syllables
 		SetLetterVowel(tr, 'y');
 		tr->langopts.max_lengthmod = 368;
+		tr->langopts.numbers = 0; // disable numbers until the definition are complete in _list file
 	}
 		break;
 	case L('k', 'a'): // Georgian

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -32,6 +32,7 @@ extern "C"
 
 #define L(c1, c2) (c1<<8)+c2 // combine two characters into an integer for translator name
 #define L3(c1, c2, c3) (c1<<16)+(c2<<8) + c3 // combine three characters into an integer for translator name
+#define L4(c1, c2, c3, c4) (c1<<24)+(c2<<16)+(c3<<8) + c4 // combine four characters into an integer for translator name
 
 #define CTRL_EMBEDDED    0x01 // control character at the start of an embedded command
 #define REPLACED_E       'E' // 'e' replaced by silent e


### PR DESCRIPTION
Can you check my findings and assumptions. This commit will change many languages.

I was instructing someone who is currently adding a new language. They had problems getting numbers working. Nothing in _list was processed. The reason is that number processing is disabled by default. I think it should be on by default so adding a new language is easier. Also see the reasoning in the commit message.

There can be errors if the number definitions are incomplete. The solution would be to fix the number handling code instead of disabling it by default.

I don't speak most of the language affected here. I used a combination of google translate and manually reading the diffs and _list files to figure it out.

If we don't want to change the default behavior we should turn on number processing for those languages that benefit from it and improve documentation in docs/add_language.md to make sure contributors realize to enable number processing.