### PR TITLE
Fix crash in voices.c:SetVoiceScores

### DIFF
--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1155,7 +1155,7 @@ static int SetVoiceScores(espeak_VOICE *voice_select, espeak_VOICE **voices, int
 		if (((control & 1) == 0) && (memcmp(vp->identifier, "mb/", 3) == 0))
 			continue;
 
-		if (memcmp(voice_select->languages,"all", 3) == 0) {
+		if (voice_select->languages == NULL || memcmp(voice_select->languages,"all", 3) == 0) {
 			voices[nv++] = vp;
 			continue;
 		}


### PR DESCRIPTION
The only way (in Dec. 2019) to get espeak_ListVoices to actually list
all the voices, including variants and mbrola voices used to be to pass
a non-null voice selector with a null language pointer.  This still
seems to be supported in SetVoiceScores, which still checks for a null
language (see the check right at the top), however new code has been added
for a pseudo voice "all" lower down which seems to do the same thing but
crashes with null.  This change allows "old" code to continue working.

Signed-off-by: John Bowler <jbowler@acm.org>