### PR TITLE
revert faulty code cleanup commit to fix garbled text in some cases

### DIFF
--- a/src/libespeak-ng/phoneme.h
+++ b/src/libespeak-ng/phoneme.h
@@ -249,6 +249,7 @@ phoneme_add_feature(PHONEME_TAB *phoneme,
 // Several phoneme tables may be loaded into memory. phoneme_tab points to
 // one for the current voice
 extern int n_phoneme_tab;
+extern int current_phoneme_table;
 extern PHONEME_TAB *phoneme_tab[N_PHONEME_TAB];
 
 typedef struct {

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -45,6 +45,7 @@ const int version_phdata  = 0x014801;
 
 // copy the current phoneme table into here
 int n_phoneme_tab;
+int current_phoneme_table;
 PHONEME_TAB *phoneme_tab[N_PHONEME_TAB];
 
 unsigned short *phoneme_index = NULL;
@@ -346,12 +347,12 @@ static void SetUpPhonemeTable(int number)
 	}
 }
 
-int SelectPhonemeTable(int number)
+void SelectPhonemeTable(int number)
 {
 	n_phoneme_tab = 0;
 	SetUpPhonemeTable(number); // recursively for included phoneme tables
 	n_phoneme_tab++;
-	return number;
+	current_phoneme_table = number;
 }
 
 int LookupPhonemeTable(const char *name)

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -53,7 +53,7 @@ frameref_t *LookupSpect(PHONEME_TAB *this_ph,
 		PHONEME_LIST *plist);
 
 int PhonemeCode(unsigned int mnem);
-int SelectPhonemeTable(int number);
+void SelectPhonemeTable(int number);
 int  SelectPhonemeTableName(const char *name);
 
 #ifdef __cplusplus

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -1561,6 +1561,9 @@ int SpeakNextClause(int control)
 		return 0;
 	}
 
+	if (current_phoneme_table != voice->phoneme_tab_ix)
+		SelectPhonemeTable(voice->phoneme_tab_ix);
+
 	// read the next clause from the input text file, translate it, and generate
 	// entries in the wavegen command queue
 	TranslateClause(translator, &clause_tone, &voice_change);


### PR DESCRIPTION
As discussed in #915 commit c0ff3696b950a0fce6fd7e08f9b707969f046e4b causes Latin text to be mispronounced after Javanese or Cyrillic characters are read. While it is not entirely clear why this happens it has been decided that reverting faulty code cleanup is the best course of action for now. cc @jaacoppi . I've tested this only under Windows  with  VS 2019 as the build environment and I can confirm this revert fixes the issue for me.