### PR TITLE
Prevent compile-phonemes use of phontab, en_dict

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -484,10 +484,16 @@ dictsource/%_emoji:
 dictsource/%_extra:
 	touch $@
 
+# NOTE: % (pattern) rules are GNU make specific we can extract the 'stem' that
+# matched the % in the target ($@) using $(*F) (which isn't GNU make specific,
+# just this interpretation is.)
+#
+# The rm $@ stops espeak-ng trying to load the old dictionary when it is run
+# (at the cost of a spurious error message.)
 espeak-ng-data/%_dict: src/espeak-ng phsource/phonemes.stamp
 	@echo "  DICT      $@"
-	@cd dictsource && ESPEAK_DATA_PATH=$(CURDIR) LD_LIBRARY_PATH=../src:${LD_LIBRARY_PATH} ../src/espeak-ng \
-		--compile=`echo $@ | sed -e 's,espeak-ng-data/,,g' -e 's,_dict,,g'` && cd ..
+	rm -f $@
+	cd dictsource && ESPEAK_DATA_PATH=$(CURDIR) ../src/espeak-ng --compile="$(*F)"
 
 dictionaries: \
 	espeak-ng-data/af_dict \

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -1853,7 +1853,7 @@ static PHONEME_TAB_LIST *FindPhonemeTable(const char *string)
 		if (strcmp(phoneme_tab_list2[ix].name, string) == 0)
 			return &phoneme_tab_list2[ix];
 	}
-	error("Unknown phoneme table: '%s'", string);
+	error("compile: unknown phoneme table: '%s'", string);
 	return NULL;
 }
 
@@ -2541,7 +2541,7 @@ espeak_ng_CompilePhonemeDataPath(long rate,
 
 	samplerate_native = samplerate = rate;
 	LoadPhData(NULL, NULL);
-	if (LoadVoice("", 0) == NULL)
+	if (LoadVoice("", 8/*compiling phonemes*/) == NULL)
 		return ENS_VOICE_NOT_FOUND;
 
 	WavegenInit(rate, 0);


### PR DESCRIPTION
espeak-ng --compile-phonemes generates phontab, but during the
generation it starts by reading the old phontab.  If works just fine,
apart from an error message, if this doesn't exist but if it does exist
it is not clear whether it might end up using old or bad data (e.g.
possibly crashing if phontab is corrupted making it very non-obvious how
to fix the problem...)

The same applies to en_dict as a result of espeak-ng defaulting to the
voice 'en'; again the phontab build works if en_dict is absent but a
spurious message is output.  It's not clear what would happen if someone
tried to build a reduced espeak-ng configuration with just one (non
'en') language.

The fix is to change espeak_ng_CompilePhonemeDataPath to call LoadVoice
with a new flag to indicate the voice structure is just required to
compile phoneme data (I changed the error message as well to make it
clear where it comes from - there are two identical error messages, the
other one is in voices.c)

Within LoadVoice the flag causes LoadVoice to not set a default language
or voicename and to skip loading the old phontab or dictionary (both of
which fail in a git clean -dfx build).

I checked the result by doing a compile from-scratch build sequence with
and without the patch, i.e. I did:

git clean -dfx
./autogen.sh
./configure --prefix=a-test-directory
make
make install

Then I compared the two copies of "a-test-directory" as well as the log
file output:

$ diff -r logs/*
diff -r logs/original/make.log logs/patched/make.log
175,176d174
< Unknown phoneme table: 'en'
< Can't read dictionary file:
'/home/jbowler/src/espeak-ng/master/espeak-ng-data/en_dict'

$ diff --no-dereference -r local.original local.patched
Binary files local.original/bin/speak-ng and local.patched/bin/speak-ng differ
Binary files local.original/lib/libespeak-ng.a and local.patched/lib/libespeak-ng.a differ
Binary files local.original/lib/libespeak-ng.so.1.1.51 and local.patched/lib/libespeak-ng.so.1.1.51 differ

So the change has not altered phontab or any of the other generated
files, only the binaries as would be expected.  (Note that I am
comparing truely clean builds; what you get if you download the source
and build from scratch.  This is the standard approach for people who
build for distribution.)

Signed-off-by: John Bowler <jbowler@acm.org>