### PR TITLE
Oss-fuzz integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -222,6 +222,7 @@ endif
 
 src_espeak_ng_LDADD   = src/libespeak-ng.la ${PCAUDIOLIB_LIBS}
 src_espeak_ng_SOURCES = src/espeak-ng.c
+nodist_EXTRA_src_espeak_ng_SOURCES = force-cxx-linking.cxx
 
 ##### tests:
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -222,7 +222,9 @@ endif
 
 src_espeak_ng_LDADD   = src/libespeak-ng.la ${PCAUDIOLIB_LIBS}
 src_espeak_ng_SOURCES = src/espeak-ng.c
+if HAVE_LIBFUZZER
 nodist_EXTRA_src_espeak_ng_SOURCES = force-cxx-linking.cxx
+endif
 
 ##### tests:
 

--- a/src/ucd-tools/src/case.c
+++ b/src/ucd-tools/src/case.c
@@ -2822,8 +2822,9 @@ static const struct case_conversion_entry case_conversion_data[] =
 codepoint_t ucd_toupper(codepoint_t c)
 {
 	int begin = 0;
-	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	while (begin <= end)
+	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	int end   = size;
+	while (begin <= end && (begin + end) / 2 < size)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);
@@ -2840,8 +2841,9 @@ codepoint_t ucd_toupper(codepoint_t c)
 codepoint_t ucd_tolower(codepoint_t c)
 {
 	int begin = 0;
-	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-       while (begin < end)
+	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	int end   = size;
+	while (begin <= end && (begin + end) / 2 < size)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);
@@ -2858,8 +2860,9 @@ codepoint_t ucd_tolower(codepoint_t c)
 codepoint_t ucd_totitle(codepoint_t c)
 {
 	int begin = 0;
-	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	while (begin <= end)
+	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	int end   = size;
+	while (begin <= end && (begin + end) / 2 < size)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);

--- a/src/ucd-tools/src/case.c
+++ b/src/ucd-tools/src/case.c
@@ -2841,7 +2841,7 @@ codepoint_t ucd_tolower(codepoint_t c)
 {
 	int begin = 0;
 	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	while (begin <= end)
+       while (begin < end)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);

--- a/src/ucd-tools/src/case.c
+++ b/src/ucd-tools/src/case.c
@@ -2822,9 +2822,8 @@ static const struct case_conversion_entry case_conversion_data[] =
 codepoint_t ucd_toupper(codepoint_t c)
 {
 	int begin = 0;
-	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	int end   = size;
-	while (begin <= end && (begin + end) / 2 < size)
+	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	while (begin <= end)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);
@@ -2841,9 +2840,8 @@ codepoint_t ucd_toupper(codepoint_t c)
 codepoint_t ucd_tolower(codepoint_t c)
 {
 	int begin = 0;
-	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	int end   = size;
-	while (begin <= end && (begin + end) / 2 < size)
+	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	while (begin <= end)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);
@@ -2860,9 +2858,8 @@ codepoint_t ucd_tolower(codepoint_t c)
 codepoint_t ucd_totitle(codepoint_t c)
 {
 	int begin = 0;
-	int size  = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
-	int end   = size;
-	while (begin <= end && (begin + end) / 2 < size)
+	int end   = sizeof(case_conversion_data)/sizeof(case_conversion_data[0]);
+	while (begin <= end)
 	{
 		int pos = (begin + end) / 2;
 		const struct case_conversion_entry *item = (case_conversion_data + pos);

--- a/tests/ssml-fuzzer.c
+++ b/tests/ssml-fuzzer.c
@@ -39,14 +39,19 @@ static int SynthCallback(short *wav, int numsamples, espeak_EVENT *events) {
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	if (!initialized) {
+               setenv("ESPEAK_DATA_PATH",".",0);
 		espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, NULL, 0);
 		espeak_SetSynthCallback(SynthCallback);
 		initialized = 1;
 	}
 
 	int synth_flags = espeakCHARS_UTF8 | espeakPHONEMES | espeakSSML;
-	espeak_Synth((char*) data, size + 1, 0, POS_CHARACTER, 0,
+       char *str = malloc(size+1);
+       memcpy(str, data, size);
+       str[size] = 0;
+       espeak_Synth((char*) str, size + 1, 0, POS_CHARACTER, 0,
 	             synth_flags, NULL, NULL);
+       free(str);
 
 	return 0;
 }


### PR DESCRIPTION
cf https://github.com/google/oss-fuzz/pull/5543

- fix a buffer overflow in ucd_tolower leading to failure when
compiling with address sanitizer
- force the use of C++ compiler for espeak-ng
- adding a malloc to have a null-terminated string in the fuzz target
- setting (but not overwriting) ESPEAK_DATA_PATH environment
variable inside the fuzz target
