### PR TITLE
Add female forms of "Ingenieur" to German exception list and treat gender asterisk as punctuation

### DIFF
--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -16,7 +16,7 @@
 // spoken when "speak punctuation" option is on.
 
 _.	pUNkt
-*	StErn	$max3
+_*	StErn	$max3
 %	pro:ts'Ent	$max3
 +	plUs	$max3
 =	glaIC	$max3
@@ -769,6 +769,8 @@ inder		Ind3
 indes		Ind'Es
 indessen	Ind'Es@n
 ingenieur	IndZ@nj'Y:r
+ingenieurin IndZ@nj'Y:rin
+ingenieurinnen IndZ@nj'Y:rinnen
 injurie		$alt
 inka		INkA:
 inkaisch	INkA:IS


### PR DESCRIPTION
Changes:
- add 'Ingenieurin', 'Ingenieurinnen' to German exception list
- add "_" modifier to asterisk, so that it will be treated as punctuation.

Rationale:
Terms "Ingenieur" is pronounced correctly, whereas "Ingenieurin/Ingenieurinnen" are not.
Asterisk ("Gendersternchen") is a quasi-standard for writing gender-inclusive text in German.