### PR TITLE
removed mispronounced words in Turkish Dictionary and improved some word pronunciations

### DIFF
--- a/dictsource/tr_listx
+++ b/dictsource/tr_listx
@@ -15,8 +15,8 @@ Artvin $1
 astsubay $1
 Avrupa $1
 Aydın $1
-bağışlamak ba:Sla'mak
-bağışlayın ba:S'laj@n
+bağışlamak ba:@@Sla'mak
+bağışlayın ba:@@S'laj@n
 banka $1
 Bartın $1
 Batman $1
@@ -58,16 +58,12 @@ Erzurum $1
 Fenerbahçe $2
 Galatasaray $2
 Gaziantep $2
-gideceğim JIdI'dZEm
-gidecek JIdI'dZec
-(gidecek misin) JIdI'dZec||mIsIn
 Giresun $2
 (göz kırpmak) $1
 Gümüşhane JY'mYSa:ne
 Hakkari hak'ca:RI
 Hakkâri hak'ca:RI
 Hatay $1
-(hey çocuğum) $2
 Hitler $1
 ığdır $1
 ısparta $2
@@ -76,9 +72,6 @@ ingiltere $3
 insanca $2
 iskenderun $2 
 istanbul $2
-(istanbul'a gidecek) Is'tanbULaJIdIdZec
-(istanbul'a o gidecek) IstanbULa'oJIdIdZec
-(istanbul'a gittim) Is'tanbULaJIt:Im
 istasyon $3
 (ister mi) $2
 (ister misin) $2
@@ -151,7 +144,6 @@ Ukrayna $2
 Urfa $1
 Uşak $1
 uyuma $2
-(Van'da mı yaşıyorsun) van'dam@jaS@josUn
 yaptın $2
 yaşıyor $2
 Yozgat $1


### PR DESCRIPTION
Some words have been added to the dictionary for street language. But Espeak really mispronounced them.

I removed the mispronounced words.
And I wrote a better pronunciation rule for the following words:
* `bağışlamak ba:@@Sla'mak`
* `bağışlayın ba:@@S'laj@n`

These words should be lengthened by 1.5 in the first letter **"ı" (305)**, in a subtle tone. (letter "ğ" is the reason for this. Normally there is no such rule.)
Previously, the letter "ı" (305) here was ignored.
Although the street language for Turkish looks like this, it is not. Since we have a dynamic language, it is not possible to implement all of them.

Therefore, I request you to accept these changes.
The tests were done on Windows. Pronunciations improved.


Sorry for the insufficient English. I may have chosen some words wrong.
If you want details, please reply, I am eager to contribute to this wonderful project.