### PR TITLE
fix conditional for GRADLE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -235,7 +235,7 @@ check_LTLIBRARIES += src/libespeak-ng-test.la
 
 src_libespeak_ng_test_la_LDFLAGS = $(src_libespeak_ng_la_LDFLAGS)
 src_libespeak_ng_test_la_CFLAGS  = \
-	-fPIC -pedantic -fno-exceptions -D PATH_ESPEAK_DATA=\"$(DATADIR)\" -DLIBESPEAK_NG_EXPORT \
+	-fPIC -pedantic -fno-exceptions -DPATH_ESPEAK_DATA=\"$(DATADIR)\" -DLIBESPEAK_NG_EXPORT \
 	${PCAUDIOLIB_CFLAGS} ${AM_CFLAGS}
 src_libespeak_ng_test_la_SOURCES = $(src_libespeak_ng_la_SOURCES)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,7 +134,7 @@ src_libespeak_ng_la_LDFLAGS = -version-info $(SHARED_VERSION) -lpthread -lm \
 
 src_libespeak_ng_la_CFLAGS = \
 	-fPIC -fvisibility=hidden \
-	-pedantic -fno-exceptions -D PATH_ESPEAK_DATA=\"$(DATADIR)\" -DLIBESPEAK_NG_EXPORT \
+	-pedantic -fno-exceptions -DPATH_ESPEAK_DATA=\"$(DATADIR)\" -DLIBESPEAK_NG_EXPORT \
 	${PCAUDIOLIB_CFLAGS} ${AM_CFLAGS}
 
 src_libespeak_ng_la_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -83,10 +83,10 @@ dnl ================================================================
 AC_MSG_CHECKING([for gradle])
 if test -e ${GRADLE} ; then
     AC_MSG_RESULT([${GRADLE}])
-    AM_CONDITIONAL(HAVE_GRADLE, [1])
+    AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 1])
 else
     AC_MSG_RESULT([no])
-    AM_CONDITIONAL(HAVE_GRADLE, [0])
+    AM_CONDITIONAL(HAVE_GRADLE, [test 0 = 0])
 fi
 
 AC_SUBST(GRADLE)


### PR DESCRIPTION
without this fix (assuming it does, what the original author intended to check for), the configure script spits out an error:

checking for ndk-build                                                                              no
checking for gradle                                                                                 no
${_source}/configure: line 13806: 0: command not found
checking if zsp-gcc supports C99 without any flags                                                  yes
checking if zsp-gcc supports C99 with the -std=c99 flag                                             yes

that's because the condition in AM_CONDITIONAL is expected to be a valid shell expression for an if-statement, not just plain value:

{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gradle" >&5
printf %s "checking for gradle... " >&6; }
if test -e ${GRADLE} ; then
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${GRADLE}" >&5
printf "%s\n" "${GRADLE}" >&6; }
     if 1; then
  HAVE_GRADLE_TRUE=
  HAVE_GRADLE_FALSE='#'
else
  HAVE_GRADLE_TRUE='#'
  HAVE_GRADLE_FALSE=
fi

else
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
printf "%s\n" "no" >&6; }
     if 0; then
  HAVE_GRADLE_TRUE=
  HAVE_GRADLE_FALSE='#'
else
  HAVE_GRADLE_TRUE='#'
  HAVE_GRADLE_FALSE=
fi

fi