### PR TITLE
Add English pronounciation of "Krzysztof" to en_dict

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -4726,6 +4726,7 @@ Keanu		kI'A:nu:
 Kieran		ki@r@n
 Kris		krIs
 Kristen		krIst@n
+Krzysztof 	krI2stOf
 Laurence	l0r@ns
 Lawrence	l0r@ns
 Leann		li:'an


### PR DESCRIPTION
This commit adds the usual English pronunciation of my name to the English dictionary.

We could, alternatively, add the native pronunciation, `kS'I2StOf` (or the closest approximation to it I could get out of the English synthesizer), but I'm not sure what the policy on that sort of thing is within the project.