### PR TITLE
Add ךְ and ךָ

### DIFF
--- a/dictsource/he_rules
+++ b/dictsource/he_rules
@@ -193,6 +193,8 @@
 
 .group ך
        ך        X
+       ךָ        Xa
+       ךְ        X
 
 .group ל
        ל        l


### PR DESCRIPTION
Adds ךְ and ךָ to Hebrew.
Example use for ךְ and ךָ:
לָךְ (Lakh) means "for you (for females)" while לְךָ (lekha) means "for you (for males)".