### PR TITLE
Enhance detection of gradle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,12 +83,11 @@ dnl ================================================================
 AC_MSG_CHECKING([for gradle])
 if command -v "$GRADLE" >/dev/null; then
     AC_MSG_RESULT([$GRADLE])
-    AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 1])
 else
     GRADLE=
     AC_MSG_RESULT([no])
-    AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 0])
 fi
+AM_CONDITIONAL(HAVE_GRADLE, [test x"$GRADLE" != x])
 
 AC_SUBST(GRADLE)
 

--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ dnl gradle checks.
 dnl ================================================================
 
 AC_MSG_CHECKING([for gradle])
-if test -e ${GRADLE} ; then
+if command -v "$GRADLE" >/dev/null; then
     AC_MSG_RESULT([${GRADLE}])
     AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 1])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ dnl ================================================================
 
 AC_MSG_CHECKING([for gradle])
 if command -v "$GRADLE" >/dev/null; then
-    AC_MSG_RESULT([${GRADLE}])
+    AC_MSG_RESULT([$GRADLE])
     AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 1])
 else
     AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ if command -v "$GRADLE" >/dev/null; then
     AC_MSG_RESULT([$GRADLE])
     AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 1])
 else
+    GRADLE=
     AC_MSG_RESULT([no])
     AM_CONDITIONAL(HAVE_GRADLE, [test 1 = 0])
 fi


### PR DESCRIPTION
I propose these further enhancements to the detection of gradle.

Commit messages reproduced for easier reading:

---

**Check more accurately if gradle exists**

Previously, the configure script would only successfully determine that gradle exists if the user specified an absolute path to the executable. It would fail if the user specified only an executable name or if the default value of "gradle" were used. Now it should succeed in either situation.

---

**Remove unnecessary curly braces around var name**

---

**Show in configure summary when gradle is not found**

Previously, if configure determined that gradle could not be found, the summary at the end of the configure output would nevertheless print the name or path of the nonexistent gradle executable that it tried to find. Now it clears that variable.

---

**Set HAVE_GRADLE in a more autoconfy way**

It is perhaps more autoconfy to have AM_CONDITIONAL evaluate a variable rather than call it with what are essentially constants representing either true or false. It might be even more autoconfy to use AC_CHECK_PROG here instead; I don't know if there's a good reason why that wasn't already done here.
