### PR TITLE
Fix several Microsoft-specific terms

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -572,7 +572,7 @@ eu	$abbrev
 eur	jU@	$only
 evga	$abbrev
 ewmh	$abbrev
-exe	'Eksi:
+exe	$abbrev
 ftaa	$abbrev
 fyi	$abbrev
 ghz	gIg@h3:ts	$only

--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -572,11 +572,12 @@ eu	$abbrev
 eur	jU@	$only
 evga	$abbrev
 ewmh	$abbrev
-exe	$abbrev
+exe	'Eksi:
 ftaa	$abbrev
 fyi	$abbrev
 ghz	gIg@h3:ts	$only
 gnupg	g@'nu:pi:dZ'i:
+guid	g'u:Id
 hmm	h@m
 hiv	$abbrev
 (http ://)   eItSt2i:t2i:'pi:_
@@ -657,6 +658,7 @@ tbsp	teIb@Lspu:n
 th	T
 thu	T3:        // Thursday
 ?5 thu	TIR        // Thursday
+uia	$abbrev
 ucla	$abbrev
 ucl	$abbrev
 ucs	$abbrev
@@ -684,6 +686,7 @@ uuid	$abbrev
 uv	$abbrev
 VI      $abbrev
 webrtc	w'EbA@t2i:s'i:
+winmd	w'In,Emd'i:
 wuxga	$abbrev
 wwii	dVb@Lju:dVb@Lju:t'u:
 xaml	$abbrev

--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -689,7 +689,6 @@ webrtc	w'EbA@t2i:s'i:
 winmd	w'In,Emd'i:
 wuxga	$abbrev
 wwii	dVb@Lju:dVb@Lju:t'u:
-xaml	$abbrev
 xl	$abbrev		// not roman 40
 xxx	$abbrev		// not roman 30
 xy	$abbrev


### PR DESCRIPTION
Change several Microsoft-specific terms to their most commonly used pronunciations as heard internally:

* GUID, a [globally unique identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier).
* [winmd](https://docs.microsoft.com/en-gb/uwp/winrt-cref/winmd-files), windows metadata files.
* [UIA](https://en.wikipedia.org/wiki/Microsoft_UI_Automation), an accessibility API and the successer to MSAA (already on the list).
* [XAML](https://en.wikipedia.org/wiki/Extensible_Application_Markup_Language).