### PR TITLE
Fix mb-ic1 and mb-ee1 voice names

### DIFF
--- a/espeak-ng-data/voices/mb/mb-ee1
+++ b/espeak-ng-data/voices/mb/mb-ee1
@@ -1,4 +1,4 @@
-name estonian-mbrola
+name estonian-mbrola-1
 language et
 gender male
 

--- a/espeak-ng-data/voices/mb/mb-ic1
+++ b/espeak-ng-data/voices/mb/mb-ic1
@@ -1,4 +1,4 @@
-name mbrola-icelandic
+name icelandic-mbrola-1
 language is 6
 gender male
 


### PR DESCRIPTION
All other mbrola voices follow the "language-mbrola-number" name format.