### PR TITLE
mbrola: Fix portuguese and french voices priorities

### DIFF
--- a/espeak-ng-data/voices/mb/mb-br1
+++ b/espeak-ng-data/voices/mb/mb-br1
@@ -1,4 +1,5 @@
-language pt 7
+language pt-br 6
+language pt 8
 name brazil-mbrola-1
 gender male
 

--- a/espeak-ng-data/voices/mb/mb-br2
+++ b/espeak-ng-data/voices/mb/mb-br2
@@ -1,4 +1,5 @@
-language pt 7
+language pt-br 6
+language pt 8
 name brazil-mbrola-2
 gender female
 

--- a/espeak-ng-data/voices/mb/mb-br3
+++ b/espeak-ng-data/voices/mb/mb-br3
@@ -1,4 +1,5 @@
-language pt 7
+language pt-br 6
+language pt 8
 name brazil-mbrola-3
 gender male
 pitch 80 120

--- a/espeak-ng-data/voices/mb/mb-br4
+++ b/espeak-ng-data/voices/mb/mb-br4
@@ -1,4 +1,5 @@
-language pt 7
+language pt-br 6
+language pt 8
 name brazil-mbrola-4
 gender female
 

--- a/espeak-ng-data/voices/mb/mb-ca1
+++ b/espeak-ng-data/voices/mb/mb-ca1
@@ -1,3 +1,4 @@
+language fr-ca 6
 language fr 10
 name fr-canadian-mbrola-1
 gender male

--- a/espeak-ng-data/voices/mb/mb-ca2
+++ b/espeak-ng-data/voices/mb/mb-ca2
@@ -1,3 +1,4 @@
+language fr-ca 6
 language fr 10
 name fr-canadian-mbrola-2
 gender male

--- a/espeak-ng-data/voices/mb/mb-fr1
+++ b/espeak-ng-data/voices/mb/mb-fr1
@@ -1,3 +1,4 @@
+language fr-fr 7
 language fr 7
 name french-mbrola-1
 gender male

--- a/espeak-ng-data/voices/mb/mb-fr2
+++ b/espeak-ng-data/voices/mb/mb-fr2
@@ -1,3 +1,4 @@
+language fr-fr 8
 language fr 8
 name french-mbrola-2
 gender female

--- a/espeak-ng-data/voices/mb/mb-fr3
+++ b/espeak-ng-data/voices/mb/mb-fr3
@@ -1,3 +1,4 @@
+language fr-fr 8
 language fr 8
 name french-mbrola-3
 gender male

--- a/espeak-ng-data/voices/mb/mb-fr4
+++ b/espeak-ng-data/voices/mb/mb-fr4
@@ -1,3 +1,4 @@
+language fr-fr 7
 language fr 7
 name french-mbrola-4
 gender female

--- a/espeak-ng-data/voices/mb/mb-fr5
+++ b/espeak-ng-data/voices/mb/mb-fr5
@@ -1,4 +1,5 @@
-language fr 8
+language fr-be 6
+language fr 9
 name french-mbrola-5
 gender male
 pitch 82 117

--- a/espeak-ng-data/voices/mb/mb-fr6
+++ b/espeak-ng-data/voices/mb/mb-fr6
@@ -1,3 +1,4 @@
+language fr-fr 8
 language fr 8
 name french-mbrola-6
 gender male

--- a/espeak-ng-data/voices/mb/mb-fr7
+++ b/espeak-ng-data/voices/mb/mb-fr7
@@ -1,4 +1,5 @@
-language fr 8
+language fr-be 6
+language fr 9
 name french-mbrola-5
 gender male
 pitch 82 117

--- a/espeak-ng-data/voices/mb/mb-pt1
+++ b/espeak-ng-data/voices/mb/mb-pt1
@@ -1,3 +1,4 @@
+language pt-pt 7
 language pt 7
 name portugal-mbrola-1
 gender female


### PR DESCRIPTION
- We want to use br* voices in priority for Brazilian Portugues, but not
  for general Portuguese.
- We want to use ca* and Belgian voices for Canadian and Belgian French,
  but rather not for general French.