### PR TITLE
mbrola: Fix setting fr7 voice

### DIFF
--- a/espeak-ng-data/voices/mb/mb-fr7
+++ b/espeak-ng-data/voices/mb/mb-fr7
@@ -1,6 +1,6 @@
 language fr 8
-name french-mbrola-5
+name french-mbrola-7
 gender male
 pitch 82 117
-mbrola fr5 fr_phtrans
+mbrola fr7 fr_phtrans
 


### PR DESCRIPTION
It currently erroneously sets the fr5 voice.