### PR TITLE
Makefile.am: add missing 'espeak-ng' dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -502,6 +502,8 @@ dictsource/%_extra:
 #
 # The rm $@ stops espeak-ng trying to load the old dictionary when it is run
 # (at the cost of a spurious error message.)
+#
+# NOTE: keep in sync with 'espeak-ng-data/yue_dict' more specific rule.
 espeak-ng-data/%_dict: src/espeak-ng phsource/phonemes.stamp
 	@echo "  DICT      $@"
 	rm -f $@
@@ -969,11 +971,15 @@ endif
 yue: espeak-ng-data/yue_dict
 dictsource/yue_listx:
 	ln -svf extra/yue_listx dictsource/
+
+# NOTE: keep in sync with espeak-ng-data/%_dict more generic rule.
 if HAVE_YUE_EXTENDED_DICTIONARY
-espeak-ng-data/yue_dict: dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_listx dictsource/yue_emoji
+espeak-ng-data/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_listx dictsource/yue_emoji
 else
-espeak-ng-data/yue_dict: dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_emoji
+espeak-ng-data/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_emoji
 endif
+	@echo "  DICT      $@"
+	rm -f $@
 	cd dictsource && ESPEAK_DATA_PATH=$(CURDIR) LD_LIBRARY_PATH=../src:${LD_LIBRARY_PATH} ../src/espeak-ng --compile=yue && cd ..
 
 dictsource/yue_emoji:


### PR DESCRIPTION
Noticed build failure on NixOS when built package with 'make -j16':

    build flags: -j16 -l16 SHELL=bash
    Makefile:2844: warning: ignoring prerequisites on suffix rule definition
    make  all-am
    make[1]: Entering directory '/build/espeak-ng'
    Makefile:2844: warning: ignoring prerequisites on suffix rule definition
    touch dictsource/az_extra
    ...
    touch dictsource/yue_extra
    cd dictsource && ESPEAK_DATA_PATH=/build/espeak-ng LD_LIBRARY_PATH=../src: ../src/espeak-ng --compile=yue && cd ..
    bash: line 1: ../src/espeak-ng: No such file or directory
    make[1]: *** [Makefile:3546: espeak-ng-data/yue_dict] Error 127
    make[1]: Leaving directory '/build/espeak-ng'
    make: *** [Makefile:831: all] Error 2

The fix is to add dependency on 'espeak-ng' similar to other rules.