### PR TITLE
compiledict.c: change 'temp' to "${dict}temp" temporary file

### DIFF
--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -1558,7 +1558,9 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_CompileDictionary(const char *dsource, 
 		fclose(f_in);
 		return create_file_error_context(context, error, fname_out);
 	}
-	sprintf(fname_temp, "%s%ctemp", path_home, PATHSEP);
+	/* Use dictionary-specific temp names to allow parallel compilation
+	 * of multiple ductionaries. */
+	sprintf(fname_temp, "%s%c%stemp", path_home, PATHSEP, dict_name);
 
 	value = N_HASH_DICT;
 	Write4Bytes(f_out, value);


### PR DESCRIPTION
This way we can compile multiple dictionaries at a time without
stepping on 'temp' file from different compilation steps:

    $ make -j8 -B
    ...
    make[1]: *** [Makefile:3082: espeak-ng-data/an_dict] Segmentation fault (core dumped)
    make[1]: *** Deleting file 'espeak-ng-data/an_dict'
    make[1]: *** [Makefile:3082: espeak-ng-data/az_dict] Segmentation fault (core dumped)
    make[1]: *** Deleting file 'espeak-ng-data/az_dict'