### PR TITLE
event_notify: Remove spurious 50ms delay

### DIFF
--- a/src/libespeak-ng/event.c
+++ b/src/libespeak-ng/event.c
@@ -161,7 +161,6 @@ static void event_notify(espeak_EVENT *event)
 				events[0].type = espeakEVENT_SENTENCE;
 				my_callback(NULL, 0, events);
 				events[0].type = a_new_type;
-				usleep(50000);
 			}
 			my_callback(NULL, 0, events);
 			a_old_uid = event->unique_identifier;


### PR DESCRIPTION
event_notify currently introduces an arbitrary 50ms delay between speech
requests. This is usually unnoticed since it's small. But when
cancelling a long series of events, they add up to potentially seconds
of delays, while the user was precisely requesting to just cancel
everything as fast as possible.

This 50ms delay was probably meant to work around some issues elsewhere.
If they are still there, they should be fixed, not worked around.