### PR TITLE
android: limit max speech rate to 449 WPM

### DIFF
--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
@@ -200,7 +200,7 @@ public class VoiceSettingsTest extends TextToSpeechTestCase
     public void testDefaultRate()
     {
         SpeechSynthesis synth = new SpeechSynthesis(getContext(), mCallback);
-        defaultRateTest(300, 450, synth); // clamped to maximum value
+        defaultRateTest(300, 449, synth); // clamped to maximum value
         defaultRateTest(200, 350, synth);
         defaultRateTest(100, 175, synth); // default value
         defaultRateTest( 50,  87, synth);
@@ -335,7 +335,7 @@ public class VoiceSettingsTest extends TextToSpeechTestCase
     public void testEspeakRate()
     {
         SpeechSynthesis synth = new SpeechSynthesis(getContext(), mCallback);
-        espeakRateTest(500, 450, synth); // clamped to maximum value
+        espeakRateTest(500, 449, synth); // clamped to maximum value
         espeakRateTest(400, 400, synth);
         espeakRateTest(200, 200, synth);
         espeakRateTest(175, 175, synth); // default value

--- a/android/src/com/reecedunn/espeak/SpeechSynthesis.java
+++ b/android/src/com/reecedunn/espeak/SpeechSynthesis.java
@@ -241,7 +241,7 @@ public class SpeechSynthesis {
     }
 
     /** Speech rate. */
-    public final Parameter Rate = new Parameter(1, 80, 450, UnitType.WordsPerMinute);
+    public final Parameter Rate = new Parameter(1, 80, 449, UnitType.WordsPerMinute);
 
     /** Audio volume. */
     public final Parameter Volume = new Parameter(2, 0, 200, UnitType.Percentage);


### PR DESCRIPTION
this is the maximum espeak-ng's speech rate without using libsonic
