### PR TITLE
Add support for Solaris

### DIFF
--- a/src/include/compat/endian.h
+++ b/src/include/compat/endian.h
@@ -105,6 +105,23 @@
 #	define __BIG_ENDIAN    BIG_ENDIAN
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
+#elif defined(__sun) && defined(__SVR4) /* Solaris */
+#   include <sys/byteorder.h>
+
+#   define htobe16(x) BE_16(x)
+#   define htole16(x) LE_16(x)
+#   define be16toh(x) BE_16(x)
+#   define le16toh(x) LE_16(x)
+
+#   define htobe32(x) BE_32(x)
+#   define htole32(x) LE_32(x)
+#   define be32toh(x) BE_32(x)
+#   define le32toh(x) LE_32(x)
+
+#   define htobe64(x) BE_64(x)
+#   define htole64(x) LE_64(x)
+#   define be64toh(x) BE_64(x)
+#   define le64toh(x) LE_64(x)
 #else
 #	error platform not supported
 #endif


### PR DESCRIPTION
We recently managed to migrate older eSpeak to eSpeak NG on Solaris and this is what we needed to add in order to make it work.

I tested it on both little and big endian (SPARC and Intel CPUs) and everything seems to work.
