### PR TITLE
Tone and schwa conversion workaround

### DIFF
--- a/dictsource/py_list
+++ b/dictsource/py_list
@@ -172,3 +172,4 @@ bu    bu_:	$u
 //tsi2h tsi2h_:	$u
 //ta7   ta7_:	$u
 
+kla2t  klat22

--- a/dictsource/py_list
+++ b/dictsource/py_list
@@ -4,6 +4,8 @@
 
 // Note: initial/final "." has already been removed
 
+2	˩
+7	˥
 
 // How Number ASCII is pronounced
 _0	zRon
@@ -24,73 +26,52 @@ _E	hses
 _F	hpet
 _dpt	fjih
 
+_6	@
+67	@˥
+62	@˩
+
+klat klat
+//kla2t klat
+//kla7t klat
+
 
 // how letters are pronounced individually
 _a	a
-b	b@
-c	S@
-d	d@
-_e	e
-f	f@
-g	g@
-h       h@
-_i	i
-j	Z@
-k	k@
-l	l@
-m	m@
-n	n@
-_o	o
-p	p@
-q       N@
-r	R@
-s	s@
-t	t@
-_u	u
-v	v@
-w       w@
-x	x@
-y	j@
-z	z@
+a7	ai
+a2	au
+//b	b@
+//c	S@
+//d	d@
+//_e	e
+//f	f@
+//g	g@
+//h       h@
+//_i	i
+i7	i˥
+//i2	i˩
+//j	Z@
+//k	k@
+//l	l@
+//m	m@
+//n	n@
+//_o	o
+//o7	o˥
+//o2	o˩
+//p	p@
+//q       N@
+//r	R@
+//s	s@
+//t	t@
+//_u	u
+//u7	u˥
+//u2	u˩
+//v	v@
+//w       w@
+//x	x@
+//y	j@
+//z	z@
 
 
-
-// stressed cmavo
-//cai	S'aI_!
-//cu'i	S'uhi_!
-//pei	p'eI_!
-//ru'e	R'uhe_!
-//sai	s'aI_!
-//nai	n'aI_!
-//na	n'a_!
-//ja'a	Z'aha_!
-
-
-// unstressed words. Note single-syllable cmavo are all unstressed in jbo_rules
-//e'o	$u+	// request
-//po'e	$u+	// of
-//zo'e	$u+	// pronoun
-//
-//
-//i	i_:	$u	// sentence break (recognised by eSpeak program). Try a short pause after ".i"
-
-// end-of-clause [_;_] before these
-//noi	_;_noI	$u
-//poi	_;_poI	$u
-//no'u	_;_nohu	$u
-//po'u	_;_pohu	$u
-//goi	_;_goI	$u
-//
-//ija	_;_iZa		// should this series be unstressed?
-//ijanai	_;_iZan'aI
-//ije	_;_iZe
-//ije'i	_;_iZehi
-//ijenai	_;_iZenaI
-//ijo	_;_iZo
-//ijonai	_;_iZon'aI
-//inaja	_;_inaZa
-//
-//to	_::to	$u	// start parenthesis, pause but don't raise intonation
 
 // independent clause terminators (include a long pause after)
 li      li_::	$u
@@ -125,8 +106,8 @@ t6      t@_::	$u
 zlih    zlih_::	$u
 n6      n@_::	$u
 gyih    gjih_::	$u
-//pi7     pi55_::	$u
-//si2     si22_::	$u
+//pi7     pi7_::	$u
+//si2     si2_::	$u
 
 
 // case terminators (short pause after)
@@ -181,13 +162,13 @@ gveh  gveh_:	$u
 vwih  vwih_:	$u
 bveh  bveh_:	$u
 dzih  dzih_:	$u
-//tsi7h tsi55h_:	$u
+//tsi7h tsi7h_:	$u
 vyah  vjah_:	$u
 gvah  gvah_:	$u
 zreh  zreh_:	$u
 bu    bu_:	$u
-//sa7   sa55_:	$u
-//si7   si55_:	$u
-//tsi2h tsi22h_:	$u
-//ta7   ta55_:	$u
+//sa7   sa7_:	$u
+//si7   si7_:	$u
+//tsi2h tsi2h_:	$u
+//ta7   ta7_:	$u
 

--- a/dictsource/py_list
+++ b/dictsource/py_list
@@ -26,7 +26,7 @@ _E	hses
 _F	hpet
 _dpt	fjih
 
-//_6	@
+6	@
 //67	@˥
 //62	@˩
 
@@ -106,8 +106,6 @@ t6      t@_::	$u
 zlih    zlih_::	$u
 n6      n@_::	$u
 gyih    gjih_::	$u
-//pi7     pi7_::	$u
-//si2     si2_::	$u
 
 
 // case terminators (short pause after)

--- a/dictsource/py_list
+++ b/dictsource/py_list
@@ -4,8 +4,8 @@
 
 // Note: initial/final "." has already been removed
 
-2	˩
-7	˥
+//2	˩
+//7	˥
 
 // How Number ASCII is pronounced
 _0	zRon
@@ -26,19 +26,19 @@ _E	hses
 _F	hpet
 _dpt	fjih
 
-_6	@
-67	@˥
-62	@˩
+//_6	@
+//67	@˥
+//62	@˩
 
-klat klat
+//klat klat
 //kla2t klat
 //kla7t klat
 
 
 // how letters are pronounced individually
-_a	a
-a7	ai
-a2	au
+//_a	a
+//a7	ai
+//a2	au
 //b	b@
 //c	S@
 //d	d@
@@ -47,7 +47,7 @@ a2	au
 //g	g@
 //h       h@
 //_i	i
-i7	i˥
+//i7	i˥
 //i2	i˩
 //j	Z@
 //k	k@

--- a/dictsource/py_rules
+++ b/dictsource/py_rules
@@ -107,7 +107,7 @@
 	ˈ	'       // U+2c8  stress marker (from syllable capitalisation)
 // tones not working
 .replace
-//	7	i
-//	2	u
-	2	˩
-	7	˥
+	7	i
+	2	u
+//	2	˩
+//	7	˥

--- a/dictsource/py_rules
+++ b/dictsource/py_rules
@@ -81,7 +81,7 @@
 .group y
 	y 	j
 
-.group 6
+.replace 
 	6 	@
 
 .group h
@@ -109,5 +109,6 @@
 .replace
 	7	i
 	2	u
+	//6	@
 //	2	˩
 //	7	˥

--- a/dictsource/py_rules
+++ b/dictsource/py_rules
@@ -6,7 +6,7 @@
 
 .group a
 	a	a
-	a7	a˥
+
 
 .group b
 	b	b
@@ -92,11 +92,11 @@
 
 
 // low tone
-.group 2        
-	2 	˩
-// high tone
-.group 7        
-	7	˥
+//.group 2        
+//	2 	˩
+//// high tone
+//.group 7        
+//	7	˥
 
 .group
 	.	_!	// dot
@@ -106,6 +106,8 @@
 
 	ˈ	'       // U+2c8  stress marker (from syllable capitalisation)
 // tones not working
-//.group
-//       1	˥
-//       2	˩
+.replace
+//	7	i
+//	2	u
+	2	˩
+	7	˥

--- a/dictsource/py_rules
+++ b/dictsource/py_rules
@@ -6,6 +6,7 @@
 
 .group a
 	a	a
+	a7	a˥
 
 .group b
 	b	b
@@ -89,10 +90,13 @@
 .group z
 	z	z
 
+
 // low tone
-.group 2        22 
+.group 2        
+	2 	˩
 // high tone
-.group 7        55
+.group 7        
+	7	˥
 
 .group
 	.	_!	// dot
@@ -103,5 +107,5 @@
 	ˈ	'       // U+2c8  stress marker (from syllable capitalisation)
 // tones not working
 //.group
-//       1	55
-//       2	22
+//       1	˥
+//       2	˩

--- a/phsource/ph_pyash
+++ b/phsource/ph_pyash
@@ -7,3 +7,17 @@ phoneme e
   FMT(vowel/e_mid2)
 endphoneme
 
+phoneme ˥   //  tone: high level
+  stress
+  Tone(50, 50, envelope/p_level, NULL)
+endphoneme
+
+phoneme ˩   //  tone: low level
+  stress
+  Tone(20, 20, envelope/p_level, NULL)
+endphoneme
+
+phoneme ˧   //  tone: mid level
+  stress
+  Tone(30, 30, envelope/p_level, NULL)
+endphoneme

--- a/phsource/ph_pyash
+++ b/phsource/ph_pyash
@@ -7,6 +7,13 @@ phoneme e
   FMT(vowel/e_mid2)
 endphoneme
 
+phoneme @    //  Schwa, e.g. alph**a**
+  vwl   starttype #@  endtype #@
+  unstressed
+  length 140
+  FMT(vowel/@)
+endphoneme
+
 phoneme ˥   //  tone: high level
   stress
   Tone(50, 50, envelope/p_level, NULL)

--- a/phsource/ph_pyash
+++ b/phsource/ph_pyash
@@ -12,6 +12,11 @@ phoneme ˥   //  tone: high level
   Tone(50, 50, envelope/p_level, NULL)
 endphoneme
 
+phoneme 22   //  tone: low level
+  stress
+  Tone(20, 20, envelope/p_level, NULL)
+endphoneme
+
 phoneme ˩   //  tone: low level
   stress
   Tone(20, 20, envelope/p_level, NULL)


### PR DESCRIPTION
So it was not properly saying the tones, and instead saying the numbers before. 
I couldn't get it to say the tone properly but instead got it to put an i for high tone, and a u for low tone, so it creates a diphthong. 
this should at least make it understandable, even if not really accurate. 

Also managed to get it pronounce words with a schwa (6) in them at least half decently. it still breaks up the word, but doesn't pronounce each letter individually. 

Don't know if there are any fixes for these issues, but it is at least better than before. 