### PR TITLE
Pass -fwrapv option to compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,6 +311,15 @@ AX_CHECK_COMPILE_FLAG([-Wuninitialized],         [CFLAGS="-Wuninitialized $CFLAG
 AX_CHECK_COMPILE_FLAG([-Wunused],                [CFLAGS="-Wunused $CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wunused-parameter],      [CFLAGS="-Wunused-parameter $CFLAGS"])
 
+
+dnl ================================================================
+dnl Enable two-complement signed integer wrapping
+dnl
+dnl Otherwise this is undefined behavior.
+dnl ================================================================
+
+AX_CHECK_COMPILE_FLAG([-fwrapv],                 [CFLAGS="-fwrapv $CFLAGS"])
+
 dnl ================================================================
 dnl libFuzzer checks.
 dnl ================================================================


### PR DESCRIPTION
espeak source code uses signed integer wrapping (e.g. wavephase in
wavegen.c's Wavegen). It happens that this is undefined behavior, so a
compiler would be free optimize away various situations... Fortunately gcc
has an -fwrapv option to make signed integer wrapping defined.

Options would be needed for other compilers.