### PR TITLE
Fix uninitialized phonemes_repeat array

### DIFF
--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -245,6 +245,7 @@ static Translator *NewTranslator(void)
 	tr->encoding = ESPEAKNG_ENCODING_ISO_8859_1;
 	dictionary_name[0] = 0;
 	tr->dictionary_name[0] = 0;
+	tr->phonemes_repeat[0] = 0;
 	tr->dict_condition = 0;
 	tr->dict_min_size = 0;
 	tr->data_dictrules = NULL; // language_1   translation rules file


### PR DESCRIPTION
valgrind reports

==3632264== Conditional jump or move depends on uninitialised value(s)
==3632264==    at 0x4846688: strcmp (vg_replace_strmem.c:924)
==3632264==    by 0x490EC12: LookupDictList (dictionary.c:2889)
==3632264==    by 0x49554C6: TranslateWord3 (translate.c:588)
==3632264==    by 0x4957FCE: TranslateWord (translate.c:1100)
==3632264==    by 0x4959344: TranslateWord2 (translate.c:1361)
==3632264==    by 0x4961390: TranslateClause (translate.c:2621)
==3632264==    by 0x494FF7A: SpeakNextClause (synthesize.c:1569)
==3632264==    by 0x4939B9D: Synthesize (speech.c:457)
==3632264==    by 0x493AE6A: sync_espeak_Synth (speech.c:570)
==3632264==    by 0x493B286: espeak_ng_Synthesize (speech.c:678)
==3632264==    by 0x4916925: espeak_Synth (espeak_api.c:90)
==3632264==    by 0x10CF5D: main (espeak-ng.c:691)

And indeed tr->phonemes_repeat may not necessarily be initialized.