### PR TITLE
Make polint use 0-based indexing

### DIFF
--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -1399,10 +1399,10 @@ static int LoadEnvelope2(FILE *f)
 		env_y[n_points] = env_y[n_points-1];
 	}
 
-	ix = -1;
+	ix = 0;
 	ix2 = 0;
 	if (n_points > 0) for (x = 0; x < ENV_LEN; x++) {
-		if (n_points > 3 && x > env_x[ix+4])
+		if (n_points > 3 && x > env_x[ix+3])
 			ix++;
 		if (n_points > 2 && x >= env_x[ix2+1])
 			ix2++;

--- a/src/libespeak-ng/spect.c
+++ b/src/libespeak-ng/spect.c
@@ -60,24 +60,24 @@ float polint(float xa[], float ya[], int n, float x)
 	float y; // result
 	float c[9], d[9];
 
-	dif = fabs(x-xa[1]);
+	dif = fabs(x-xa[0]);
 
 	for (i = 1; i <= n; i++) {
-		if ((dift = fabs(x-xa[i])) < dif) {
+		if ((dift = fabs(x-xa[i-1])) < dif) {
 			ns = i;
 			dif = dift;
 		}
-		c[i] = ya[i];
-		d[i] = ya[i];
+		c[i] = ya[i-1];
+		d[i] = ya[i-1];
 	}
-	y = ya[ns--];
+	y = ya[--ns];
 	for (m = 1; m < n; m++) {
 		for (i = 1; i <= n-m; i++) {
-			ho = xa[i]-x;
-			hp = xa[i+m]-x;
+			ho = xa[i-1]-x;
+			hp = xa[i+m-1]-x;
 			w = c[i+1]-d[i];
 			if ((den = ho-hp) == 0.0)
-				return ya[2]; // two input xa are identical
+				return ya[1]; // two input xa are identical
 			den = w/den;
 			d[i] = hp*den;
 			c[i] = ho*den;


### PR DESCRIPTION
This avoids having to make LoadEnvelope2 pass &env_x[-1], which is very
strongly frowned upon by sanitizers such as usan.