### PR TITLE
addPluralSuffixes: Use space as heading separator

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -378,9 +378,9 @@ char *strchr_w(const char *s, int c)
 // append plural suffixes depending on preceding letter
 static void addPluralSuffixes(int flags, Translator *tr, char last_char, char *word_phonemes)
 {
-	char word_zz[4] = { 0, 'z', 'z', 0 };
-	char word_iz[4] = { 0, 'i', 'z', 0 };
-	char word_ss[4] = { 0, 's', 's', 0 };
+	char word_zz[4] = { ' ', 'z', 'z', 0 };
+	char word_iz[4] = { ' ', 'i', 'z', 0 };
+	char word_ss[4] = { ' ', 's', 's', 0 };
 	if (flags & FLAG_HAS_PLURAL) {
 		// s or 's suffix, append [s], [z] or [Iz] depending on previous letter
 		if (last_char == 'f')


### PR DESCRIPTION
Otherwise asan reports this during make check:

testing en ibm mit ibms mits IBM MIT APH CES ITX IBMs MIT's APHs CES's ITXs
==3733154==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe420233ef at pc 0x7f2e8a30aef1 bp 0x7ffe42022c80 sp 0x7ffe42022c78
READ of size 1 at 0x7ffe420233ef thread T0
    #0 0x7f2e8a30aef0 in utf8_in2 src/libespeak-ng/translate.c:281
    #1 0x7f2e8a2a6db1 in MatchRule src/libespeak-ng/dictionary.c:2058
    #2 0x7f2e8a2a89e9 in TranslateRules src/libespeak-ng/dictionary.c:2301
    #3 0x7f2e8a30cc77 in addPluralSuffixes src/libespeak-ng/translate.c:393
    #4 0x7f2e8a30e2c9 in TranslateWord3 src/libespeak-ng/translate.c:684
    #5 0x7f2e8a31210b in TranslateWord src/libespeak-ng/translate.c:1100
    #6 0x7f2e8a313ef2 in TranslateWord2 src/libespeak-ng/translate.c:1361
    #7 0x7f2e8a31f4e2 in TranslateClause src/libespeak-ng/translate.c:2623
    #8 0x7f2e8a305010 in SpeakNextClause src/libespeak-ng/synthesize.c:1569
    #9 0x7f2e8a2e390e in Synthesize src/libespeak-ng/speech.c:457
    #10 0x7f2e8a2e552a in sync_espeak_Synth src/libespeak-ng/speech.c:570
    #11 0x7f2e8a2e5d1f in espeak_ng_Synthesize src/libespeak-ng/speech.c:678
    #12 0x7f2e8a2af2fd in espeak_Synth src/libespeak-ng/espeak_api.c:90
    #13 0x5618104c9137 in main src/espeak-ng.c:691
    #14 0x7f2e8953d7fc in __libc_start_main ../csu/libc-start.c:332
    #15 0x5618104c6569 in _start (/home/samy/ens/projet/1/speech/espeak-ng-git/src/.libs/espeak-ng+0x6569)

Address 0x7ffe420233ef is located in stack of thread T0 at offset 47 in frame
    #0 0x7f2e8a30cb3b in addPluralSuffixes src/libespeak-ng/translate.c:380

  This frame has 3 object(s):
    [32, 36) 'word_zz' (line 381)
    [48, 52) 'word_iz' (line 382) <== Memory access at offset 47 underflows this variable
    [64, 68) 'word_ss' (line 383)

and indeed, RULE_NOVOWELS keeps looking back until it finds a spacing
character, so we have to provide it with one.