### PR TITLE
Add KlattFiniSP

### DIFF
--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -2631,6 +2631,8 @@ espeak_ng_CompilePhonemeDataPath(long rate,
 
 	fclose(f_report);
 
+	WavegenFini();
+
 	if (resample_count > 0) {
 		fprintf(f_errors, "\n%d WAV files resampled to %d Hz\n", resample_count, samplerate_native);
 		fprintf(log, "Compiled phonemes: %d errors, %d files resampled to %d Hz.\n", error_count, resample_count, samplerate_native);

--- a/src/libespeak-ng/klatt.c
+++ b/src/libespeak-ng/klatt.c
@@ -467,6 +467,13 @@ void KlattReset(int control)
 	}
 }
 
+void KlattFini(void)
+{
+#ifdef INCLUDE_SPEECHPLAYER
+	KlattFiniSP();
+#endif
+}
+
 /*
    function FRAME_INIT
 

--- a/src/libespeak-ng/klatt.h
+++ b/src/libespeak-ng/klatt.h
@@ -179,6 +179,7 @@ typedef struct {
 }  klatt_peaks_t;
 
 void KlattInit(void);
+void KlattFini(void);
 void KlattReset(int control);
 int Wavegen_Klatt(int length, int resume, frame_t *fr1, frame_t *fr2, WGEN_DATA *wdata, voice_t *wvoice);
 

--- a/src/libespeak-ng/sPlayer.c
+++ b/src/libespeak-ng/sPlayer.c
@@ -97,9 +97,13 @@ void KlattInitSP() {
 	speechPlayerHandle=speechPlayer_initialize(22050);
 }
 
-void KlattResetSP() {
+void KlattFiniSP() {
 	speechPlayer_terminate(speechPlayerHandle);
-	speechPlayerHandle=speechPlayer_initialize(22050);
+}
+
+void KlattResetSP() {
+	KlattFiniSP();
+	KlattInitSP();
 }
 
 int Wavegen_KlattSP(WGEN_DATA *wdata, voice_t *wvoice, int length, int resume, frame_t *fr1, frame_t *fr2){

--- a/src/libespeak-ng/sPlayer.h
+++ b/src/libespeak-ng/sPlayer.h
@@ -11,6 +11,7 @@ extern "C" {
 
 	void KlattInitSP(void);
 	void KlattResetSP(void);
+	void KlattFiniSP(void);
 	int Wavegen_KlattSP(WGEN_DATA *wdata, voice_t *wvoice, int length, int resume, frame_t *fr1, frame_t *fr2);
 
 #ifdef __cplusplus

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -364,6 +364,13 @@ void WavegenInit(int rate, int wavemult_fact)
 #endif
 }
 
+void WavegenFini(void)
+{
+#ifdef INCLUDE_KLATT
+	KlattFini();
+#endif
+}
+
 int GetAmplitude(void)
 {
 	int amp;

--- a/src/libespeak-ng/wavegen.h
+++ b/src/libespeak-ng/wavegen.h
@@ -60,6 +60,8 @@ void SetPitch2(voice_t *voice,
 void WavegenInit(int rate,
 		int wavemult_fact);
 
+void WavegenFini(void);
+
 
 int WavegenFill(void);
 void WavegenSetVoice(voice_t *v);


### PR DESCRIPTION
speechPlayer_terminate was never called without calling
speechPlayer_initialize right after, so there would always be a FrameManager
laying behind.