### PR TITLE
Fix deleting FrameManagerImpl*

### DIFF
--- a/src/speechPlayer/src/frame.h
+++ b/src/speechPlayer/src/frame.h
@@ -51,6 +51,7 @@ class FrameManager {
 	virtual void queueFrame(speechPlayer_frame_t* frame, unsigned int minNumSamples, unsigned int numFadeSamples, int userIndex, bool purgeQueue)=0;
 	virtual const speechPlayer_frame_t* const getCurrentFrame()=0;
 	virtual const int getLastIndex()=0; 
+	virtual ~FrameManager() {};
 };
 
 #endif


### PR DESCRIPTION
delete playerHandleInfo->frameManager seemingly doesn't actually call
FrameManagerImpl~, probably because playerHandleInfo->frameManager is
only a FrameManager, which doesn't have a destructor, and nothing is
saying that it's actually a FrameManagerImpl behind, and thus FrameManagerImpl~ should be called.

I don't know enough C++ to determine how this is supposed to be fixed
properly.