### PR TITLE
fifo: Protect setting my_terminate_is_required

### DIFF
--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -438,7 +438,9 @@ static void init(int process_parameters)
 
 void fifo_terminate()
 {
+	pthread_mutex_lock(&my_mutex);
 	my_terminate_is_required = true;
+	pthread_mutex_unlock(&my_mutex);
 	pthread_cond_signal(&my_cond_start_is_required);
 	pthread_join(my_thread, NULL);
 	my_terminate_is_required = false;


### PR DESCRIPTION
We need to keep the mutex around setting it, to make sure that the
visibility of setting it to true doesn't get delayed, notably not after
the signal (which could entail that the signal becomes useless, leading
to a hang).