### PR TITLE
Fix deleting SpeechWaveGenerator

### DIFF
--- a/src/speechPlayer/src/speechWaveGenerator.h
+++ b/src/speechPlayer/src/speechWaveGenerator.h
@@ -23,6 +23,7 @@ class SpeechWaveGenerator: public WaveGenerator {
 	public:
 	static SpeechWaveGenerator* create(int sampleRate); 
 	virtual void setFrameManager(FrameManager* frameManager)=0;
+	virtual ~SpeechWaveGenerator() {};
 };
 
 #endif


### PR DESCRIPTION
Similarly to dab5457620af "Fix deleting FrameManagerImpl*", we need a
virtual destructor. clang was complaining about it:

src/speechPlayer/src/speechPlayer.cpp:52:2: warning: delete called on 'SpeechWaveGenerator' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
        delete playerHandleInfo->waveGenerator;
        ^