### PR TITLE
Properly compare strings

### DIFF
--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -921,7 +921,7 @@ static void copy_rule_string(char *string, int *state_out)
 					mr = mnem_rules;
 					while (mr->mnem != NULL) {
 						len = strlen(mr->mnem);
-						if (memcmp(p, mr->mnem, len) == 0) {
+						if (strncmp(p, mr->mnem, len) == 0) {
 							value = mr->value;
 							p += len;
 							break;

--- a/src/libespeak-ng/compilembrola.c
+++ b/src/libespeak-ng/compilembrola.c
@@ -95,7 +95,7 @@ espeak_ng_STATUS espeak_ng_CompileMbrolaVoice(const char *filepath, FILE *log, e
 		if ((p = strstr(buf, "//")) != NULL)
 			*p = 0; // truncate line at comment
 
-		if (memcmp(buf, "volume", 6) == 0) {
+               if (strncmp(buf, "volume", 6) == 0) {
 			mbrola_ctrl = atoi(&buf[6]);
 			continue;
 		}

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -2672,7 +2672,7 @@ static const char *LookupDict2(Translator *tr, const char *word, const char *wor
 					}
 				}
 
-				if (memcmp(word2, p, n_chars) != 0)
+				if (strncmp(word2, p, n_chars) != 0)
 					condition_failed = 1;
 
 				if (condition_failed) {


### PR DESCRIPTION
Strictly speaking, we are not supposed to use memcmp to compare strings
since we are not supposed to read beyond \0, which memcmp is supposed to
potentially do. Sanitizers would warn about it, and using strncmp happens to
provide the proper semantic while being not really slower, so better
just use them.