### PR TITLE
MatchRule: Do not underflow the text

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -1963,6 +1963,12 @@ static void MatchRule(Translator *tr, char *word[], char *word_start, int group_
 				if (distance_left > 18)
 					distance_left = 19;
 
+				if (!*pre_ptr) {
+					// we had already reached the beginning of text!
+					// reading before this does not make sense, that cannot match
+					failed = 1;
+					break;
+				}
 				utf8_in(&last_letter_w, pre_ptr);
 				pre_ptr--;
 				letter_xbytes = utf8_in2(&letter_w, pre_ptr, 1)-1;


### PR DESCRIPTION
Some rules test against character not being of a certain type. That may
match with the \0 beginning-of-text marker, and thus actually step over
it and let MatchRule continue with uninitialized data before it, leading
to potential random behavior.

This commits fixes it by making sure that we don't read before that \0.