### PR TITLE
MatchRule: Do not overflow the text

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -1758,6 +1758,12 @@ static void MatchRule(Translator *tr, char *word[], char *word_start, int group_
 				if (distance_right > 18)
 					distance_right = 19;
 				last_letter_w = letter_w;
+				if (!post_ptr[-1]) {
+					// we had already reached the end of text!
+					// reading after that does not make sense, that cannot match
+					failed = 1;
+					break;
+				}
 				letter_xbytes = utf8_in(&letter_w, post_ptr)-1;
 				letter = *post_ptr++;
 


### PR DESCRIPTION
Some rules test against character not being of a certain type. That may
match with the \0 end-of-text marker, and thus actually step over
it and let MatchRule continue with uninitialized data after it, leading
to potential random behavior.

This commits fixes it by making sure that we don't read past that \0.

This seems to be changing the pronunciation of "capitals" from k'apIt@Lz to
k'apIt,alz, I don't know why, I guess the rule for it was actually
bogus?