### PR TITLE
Make msan warnings fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: make check
+      run: MSAN_OPTIONS=exitcode=42 make check
 
   tsan:
 


### PR DESCRIPTION
Otherwise they will go unnoticed.