### PR TITLE
CheckThousandsGroup: Avoid reading uninitialized data

### DIFF
--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -1719,13 +1719,14 @@ static bool CheckThousandsGroup(char *word, int group_len)
 	// Is this a group of 3 digits which looks like a thousands group?
 	int ix;
 
-	if (IsDigit09(word[group_len]) || IsDigit09(-1))
-		return false;
-
 	for (ix = 0; ix < group_len; ix++) {
 		if (!IsDigit09(word[ix]))
 			return false;
 	}
+
+	if (IsDigit09(word[group_len]) || IsDigit09(-1))
+		return false;
+
 	return true;
 }
 

--- a/tests/translate.test
+++ b/tests/translate.test
@@ -83,3 +83,6 @@ test_phon en "r'oUlIN 0nD@ fl'o@ l'aafIN" "🤣" # skip words
 # bug: https://github.com/espeak-ng/espeak-ng/issues/471
 test_phon sk "sm'eju:tsa s'a tv'a:R" "☺"
 test_phon sk "bl'ax sm'eju:tsa s'a tv'a:R" "blah ☺"
+
+# https://github.com/espeak-ng/espeak-ng/pull/1148
+test_phon fr "dY mil v'E~" "2020"


### PR DESCRIPTION
For the case when word is smaller than 4 characters, we should not look at
the 3rd or 4th character before checking the previous ones, otherwise
we'd at best read uninitialized data, at worse non-existing data.