### PR TITLE
Mark re-used buffers as undefined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,8 @@ else
         ])
 fi
 
+AC_CHECK_HEADERS([valgrind/memcheck.h])
+
 if test "$with_async" = "no" ; then
 	have_async=no
 else

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -2608,7 +2608,12 @@ espeak_ng_CompilePhonemeDataPath(long rate,
 	memset(ref_hash_tab, 0, sizeof(ref_hash_tab));
 
 	n_phoneme_tabs = 0;
+	MAKE_MEM_UNDEFINED(&n_phcodes_list, sizeof(n_phcodes_list));
+	MAKE_MEM_UNDEFINED(&phoneme_tab_list2, sizeof(phoneme_tab_list2));
+
 	stack_ix = 0;
+	MAKE_MEM_UNDEFINED(&stack, sizeof(stack));
+
 	StartPhonemeTable("base");
 	CompilePhonemeFiles();
 

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -997,7 +997,9 @@ void InitText2(void)
 	ungot_char2 = 0;
 
 	n_ssml_stack = 1;
+	MAKE_MEM_UNDEFINED(&ssml_stack[1], sizeof(ssml_stack) - sizeof(ssml_stack[0]));
 	n_param_stack = 1;
+	MAKE_MEM_UNDEFINED(&param_stack[1], sizeof(param_stack) - sizeof(param_stack[0]));
 	ssml_stack[0].tag_type = 0;
 
 	for (param = 0; param < N_SPEECH_PARAM; param++)

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -23,6 +23,21 @@
 #include <endian.h>               // for BYTE_ORDER, BIG_ENDIAN
 #include <espeak-ng/espeak_ng.h>
 
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+#    include <sanitizer/msan_interface.h>
+#    define MAKE_MEM_UNDEFINED(addr, len) __msan_unpoison(addr, len)
+#  endif
+#endif
+
+#ifndef MAKE_MEM_UNDEFINED
+#  ifdef HAVE_VALGRIND_MEMCHECK_H
+#    include <valgrind/memcheck.h>
+#    define MAKE_MEM_UNDEFINED(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
+#  else
+#    define MAKE_MEM_UNDEFINED(addr, len) ((void) (addr, len))
+#  endif
+#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -45,6 +45,7 @@
 #endif
 
 #include "sintab.h"
+#include "speech.h"
 
 static void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v);
 
@@ -271,6 +272,7 @@ void WcmdqInc()
 
 static void WcmdqIncHead()
 {
+	MAKE_MEM_UNDEFINED(&wcmdq[wcmdq_head], sizeof(wcmdq[wcmdq_head]));
 	wcmdq_head++;
 	if (wcmdq_head >= N_WCMDQ) wcmdq_head = 0;
 }


### PR DESCRIPTION
These are global arrays reused several times. When using them msan and
valgrind thus believe they are always initialized, which reduces their
capacity to detect uninitialized values. We can however explicitly tell them
when they are reused, and thus to be considered as uninitialized.