### PR TITLE
Fix pronunciation of Bellevue and Bothell

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -1070,6 +1070,7 @@ beatin		bi:t#In
 bedouin		bEdu:I2n
 beige		beIZ
 belisha		b@l'i:S@
+bellevue	b'Elvju:
 bellyaching	bElIeIkIN
 bely		bI#laI
 bereft		bI#rEft
@@ -1141,6 +1142,7 @@ boogey		boogie $text
 boomeranged	bu:m3aNd
 borealis	bo@rI'alIs
 bosun		boUs@n
+bothell	b'0T@L
 bourguignonne	bU@gIn'j0n
 boutique	bu:t'i:k
 boutonniere	bu:?n'i@3


### PR DESCRIPTION
Fix the pronunciation of [Bothell](https://en.wikipedia.org/wiki/Bothell,_Washington) and [Bellevue](https://en.wikipedia.org/wiki/Bellevue,_Washington), a town and city respectively in Washington State, according to their Wikipedia IPA.