### PR TITLE
Fix stress of "vilmente"

### DIFF
--- a/dictsource/es_list
+++ b/dictsource/es_list
@@ -334,6 +334,7 @@ Uds	ustedes		$text $capital $dot
 
 // pronunciation exceptions
 ser	s'e@-* $only // it's not a abbrev
+vilmente $1
 
 // Proper Names and countries
 amsterdam	$3


### PR DESCRIPTION
Vilmente is an adverb, so it should be stressed as such.
