### PR TITLE
Fix pronunciation of Boise

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -1129,6 +1129,7 @@ blurry		bl3:ri
 boardmember	$1
 bobsled		$alt1
 boing		bOIN
+boise	'bOIsi	$only
 bologna		b@loUni
 bolognese	b0l@n'eIz
 bombard		$2


### PR DESCRIPTION
This PR adds [Boise](https://en.wikipedia.org/wiki/Boise,_Idaho) to en_list based on its pronunciation listed on Wikipedia and observed in common usage.