### PR TITLE
Revert "code cleanup: don't add a \0 to voices_language in LoadVoice()"

### DIFF
--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -959,6 +959,8 @@ voice_t *LoadVoice(const char *vname, int control)
 				return NULL; // no dictionary loaded
 			}
 		}
+
+		voice_languages[langix] = 0;
 	}
 
 	return voice;


### PR DESCRIPTION
Fixes #1200 

This reverts commit e91d0a58612a01954687d34c7417cf0fbd3cadaa.

**Problem**

Automatic language switching is now broken for "en" and "fr".
This is because no voice is mapped directly to these language codes.
These normally default to "en-gb" or "fr-fr".

STR, using an installed build of eSpeak 1.51 on Windows, and git bash:

1. Save [bugSample.txt](https://github.com/espeak-ng/espeak-ng/files/8866834/bugSample.txt)
1. Read the text with eSpeak with a German voice: `cat bugSample.txt | "./espeak-ng.exe" -m --stdin -vde`
1. Note that automatic language switching doesn't occur for the second "en" tag
1. Read the text with eSpeak with the default (en-gb) voice: `cat bugSample.txt | "./espeak-ng.exe" -m --stdin`
1. Note that automatic language switching doesn't occur for both "en" tags

**Solution**

Revert the commit which broke this. This was determined via a bisect.