### PR TITLE
Add missing phoneme table reset

### DIFF
--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -291,6 +291,7 @@ void MakePhonemeList(Translator *tr, int post_pause, bool start_sentence)
 		}
 	}
 
+	SelectPhonemeTable(tr->phoneme_tab_ix);
 	n_ph_list3 = SubstitutePhonemes(ph_list3) - 2;
 
 	for (j = 0; (j < n_ph_list3) && (ix < N_PHONEME_LIST-3);) {
@@ -321,6 +322,7 @@ void MakePhonemeList(Translator *tr, int post_pause, bool start_sentence)
 	ph_list3[0].ph = ph;
 	word_start = 1;
 
+	SelectPhonemeTable(tr->phoneme_tab_ix);
 	for (j = 0; insert_ph || ((j < n_ph_list3) && (ix < N_PHONEME_LIST-3)); j++) {
 		plist3 = &ph_list3[j];
 
@@ -589,4 +591,6 @@ void MakePhonemeList(Translator *tr, int post_pause, bool start_sentence)
 	phlist[ix++].ph = phoneme_tab[phonPAUSE_SHORT];
 
 	n_phoneme_list = ix;
+
+	SelectPhonemeTable(tr->phoneme_tab_ix);
 }


### PR DESCRIPTION
When there are language switches, when we rewind to the start of the
phoneme list we have to reset the phoneme table back.

This avoids some branching that depends on undefined values, caught by
valgrind in the case e.g. of an emoji substitution that contains a
language switch.

Ref #874