### PR TITLE
Correctly return `espeak_ng_STATUS` `ENS_COMPILE_ERROR` on failure of `espeak_ng_CompileDictionary`.

### DIFF
--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -21,7 +21,6 @@
 #include "config.h"
 
 #include <ctype.h>
-#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -35,7 +34,6 @@
 
 #include "compiledict.h"
 #include "dictionary.h"           // for EncodePhonemes, strncpy0, HashDicti...
-#include "error.h"                // for create_file_error_context
 #include "mnemonics.h"               // for LookupMnemName, MNEM_TAB
 #include "phoneme.h"              // for PHONEME_TAB_LIST, phonSWITCH, phone...
 #include "readclause.h"           // for towlower2
@@ -1338,7 +1336,7 @@ static espeak_ng_STATUS compile_dictrules(FILE *f_in, FILE *f_out, char *fname_t
 	group_name[0] = 0;
 
 	if ((f_temp = fopen(fname_temp, "wb")) == NULL)
-		return create_file_error_context(context, errno, fname_temp);
+		return create_file_error_context(context, ENS_COMPILE_ERROR, fname_temp);
 
 	for (;;) {
 		linenum++;
@@ -1475,7 +1473,7 @@ static espeak_ng_STATUS compile_dictrules(FILE *f_in, FILE *f_out, char *fname_t
 
 	if ((f_temp = fopen(fname_temp, "rb")) == NULL) {
 		free_rules(rules, n_rules);
-		return create_file_error_context(context, errno, fname_temp);
+		return create_file_error_context(context, ENS_COMPILE_ERROR, fname_temp);
 	}
 
 	prev_rgroup_name = "\n";

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -1551,14 +1551,13 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_CompileDictionary(const char *dsource, 
 	if ((f_in = fopen(fname_in, "r")) == NULL) {
 		sprintf(fname_in, "%srules", path);
 		if ((f_in = fopen(fname_in, "r")) == NULL)
-			return create_file_error_context(context, errno, fname_in);
+			return create_file_error_context(context, ENS_COMPILE_ERROR, fname_in);
 	}
 
 	sprintf(fname_out, "%s%c%s_dict", path_home, PATHSEP, dict_name);
 	if ((f_out = fopen(fname_out, "wb+")) == NULL) {
-		int error = errno;
 		fclose(f_in);
-		return create_file_error_context(context, error, fname_out);
+		return create_file_error_context(context, ENS_COMPILE_ERROR, fname_out);
 	}
 	/* Use dictionary-specific temp names to allow parallel compilation
 	 * of multiple ductionaries. */


### PR DESCRIPTION
`errno` generally maps to 2, which is not an `espeak_ng_STATUS`, which is the expected return type of `espeak_ng_CompileDictionary`.