### PR TITLE
Map phonemone table ms rules to id rules

### DIFF
--- a/phsource/phonemes
+++ b/phsource/phonemes
@@ -2061,3 +2061,5 @@ include ph_langbelta
 
 phonemetable be ru
 include ph_belarusian
+
+phonemetable ms id


### PR DESCRIPTION
As this is the default behaviour when building eSpeak.

## Issue

Compiling Malay with eSpeak uses the Indonesian phonemetable table.

This is the results on Windows using an installed copy of 1.51, as well as running master at e57e68fc9ac9e777283da80c19c6c0b4bcf3dcef on Windows.

```cmd
espeak-ng --compile-debug=ms
Using phonemetable: 'id'
Compiling: 'ms_list'
        703 entries
Compiling: 'ms_rules'
        125 rules, 27 groups (0)
```

However, a mapping does not exist in `phsource/phonemes`.
This results in consumers, like [NVDA](https://github.com/nvaccess/nvda) building using `ms_rules`, and failing due to a poorly formed phoneme in `ms_rules`.

```log
Compiling: 'C:\Users\sean\projects\nvda\include\espeak\dictsource/ms_rules'
   58: Bad phoneme [2] (U+32) in:        _) e (Co@       E2
        125 rules, 27 groups (0)
```

# Fix

Add phonemetable mapping for ms to id