### PR TITLE
Fix pronunciation of Puget, Sammamish, and Snohomish

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3260,6 +3260,7 @@ saliva		s@laIv@
 salmon		sam@n
 ?3 salon	$alt3
 saloon		$alt3
+sammamish s@'m'amIS
 san		,san $only
 sanguine	$alt2
 santoor		$alt3

--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3406,6 +3406,7 @@ slough		slVf	$verb
 slugabed	slVg@bEd
 snafu		snafu:
 snafus		snafu:z
+snohomish snoU'hoUmIS
 snooker		snu:k3
 sociopath	soUsI@paT
 sofa		soUf@

--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3036,6 +3036,7 @@ psychosis	saIk'oUsIs
 psychotic	saIk'0tIk
 pud		pUd           // and pudding
 pueblo		pwEbloU
+puget pju:dZIt
 punative	pju:n@tIv
 puny		pju:ni
 purist		pjU@Ist


### PR DESCRIPTION
Fix pronunciation of [puget](https://en.wikipedia.org/wiki/Puget_Sound), [Sammamish](https://en.wikipedia.org/wiki/Sammamish,_Washington), and [Snohomish](https://en.wikipedia.org/wiki/Snohomish_County,_Washington) per Wikipedia.