### PR TITLE
Fix pronunciation of schengen

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3289,6 +3289,7 @@ scenario	s@nA@rioU
 scepter		sEpt3
 sceptre		sEpt3
 ?3 schematic	sk@matIk
+schengen 'SEN@n
 schist		SIst
 sci		saI
 sciatica	saI'atIk@


### PR DESCRIPTION
Fix pronunciation of schengen, per [Wikipedia](https://en.wikipedia.org/wiki/Schengen_Area) and [YouTube](https://www.youtube.com/watch?v=t7GJHpbto1Y).