### PR TITLE
Add Reed variant

### DIFF
--- a/espeak-ng-data/voices/!v/Reed
+++ b/espeak-ng-data/voices/!v/Reed
@@ -1,0 +1,15 @@
+language variant
+name Reed
+klatt 6
+consonants 85 85
+voicing 130
+breath 45
+
+pitch 85 135
+
+formant 1 72 100 90 90
+formant 2 83 100 75 180
+formant 3 98 100 100 90
+formant 4 98 100 90
+formant 5 100 100 90
+


### PR DESCRIPTION
This variant sounds consistent and similar to Reed voice, found on Eloquence. The klatt 6 implementation do not sounds good on small speakers at 22 khz sample rate.
I see that it seems to be very difficult to make the Speech player work at a lower sample rate, like 11025 or 16000hz, because it would require being able to compile the phonemes at such a sample rate.
As many prefer cascade synthesis, this may be the solution.