### PR TITLE
Fix pronunciation of Aira

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -810,6 +810,7 @@ aha		A:h'A:
 ahem		@h'@m
 ahoy		a#hOI
 aidenn		eId@n
+aira 'aIr@ $only
 airbus		e@bVs
 airpower	'e@p,aU3
 aisle		aI@l


### PR DESCRIPTION
Fix the pronunciation of [Aira](http://aira.io), a popular visual interpretation service for the blind.