### PR TITLE
mb-fr*-en: Give separate names

### DIFF
--- a/espeak-ng-data/voices/mb/mb-fr1-en
+++ b/espeak-ng-data/voices/mb/mb-fr1-en
@@ -1,4 +1,4 @@
-name en-french
+name en-french-1
 language en 10
 gender male
 

--- a/espeak-ng-data/voices/mb/mb-fr4-en
+++ b/espeak-ng-data/voices/mb/mb-fr4-en
@@ -1,5 +1,5 @@
 language en 10
-name en-french
+name en-french-4
 gender female
 
 dictrules 1


### PR DESCRIPTION
Otherwise if e.g. only mbrola-fr4 is installed, when the application tries
to load voice en-french, it actually ends up trying to load mb-fr1-en.