### PR TITLE
Make distclean-local remove more espeak-ng-data files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,8 +74,12 @@ if HAVE_GRADLE
 endif
 
 distclean-local:
-	rm -rf espeak-ng-data/phondata-manifest
 	rm -f espeak-ng-data/*_dict
+	rm -f espeak-ng-data/intonations
+	rm -f espeak-ng-data/phondata
+	rm -f espeak-ng-data/phondata-manifest
+	rm -f espeak-ng-data/phonindex
+	rm -f espeak-ng-data/phontab
 
 ##### custom rules:
 


### PR DESCRIPTION
If for whatever reason the build got broken, the recompilation of data
would fail because espeak-ng would be unable to re-open the current
files. One is then stuck until removing the files by hand. Let's make "make
distclean" clear these all to be sure to be able to restart from zero.