### PR TITLE
Fix out-of-bound vowel_stress access

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -927,8 +927,9 @@ static int GetVowelStress(Translator *tr, unsigned char *phonemes, signed char *
 		} else if (phcode == phonSYLLABIC) {
 			// previous consonant phoneme is syllablic
 			vowel_stress[count] = (char)stress;
-			if ((stress == 0) && (control & 1))
-				vowel_stress[count++] = STRESS_IS_UNSTRESSED; // syllabic consonant, usually unstressed
+			if ((stress < 0) && (control & 1))
+				vowel_stress[count] = STRESS_IS_UNSTRESSED; // syllabic consonant, usually unstressed
+			count++;
 		}
 
 		*ph_out++ = phcode;
@@ -1473,6 +1474,7 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 	}
 
 	p = phonetic;
+	/* Note: v progression has to strictly follow the vowel_stress production in GetVowelStress */
 	while (((phcode = *p++) != 0) && (output < max_output)) {
 		if ((ph = phoneme_tab[phcode]) == NULL)
 			continue;
@@ -1481,6 +1483,8 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 			tr->prev_last_stress = 0;
 		else if (((ph->type == phVOWEL) && !(ph->phflags & phNONSYLLABIC)) || (*p == phonSYLLABIC)) {
 			// a vowel, or a consonant followed by a syllabic consonant marker
+
+			assert(v <= vowel_count);
 
 			v_stress = vowel_stress[v];
 			tr->prev_last_stress = v_stress;

--- a/tests/language-pronunciation.test
+++ b/tests/language-pronunciation.test
@@ -211,7 +211,7 @@ h'ivjo jap'asa w,atende'ane _|kind'ugu" "Watu wote wamezaliwa huru, hadhi na hak
 test_phon ta "n'a:n k'Vn.n.a:d.i s'a:ppid.,Uve:n
 'adVna:l ;'enVkkU 'orU k'e:d.Um v'Vra:dU" "நான் கண்ணாடி சாப்பிடுவேன், அதனால் எனக்கு ஒரு கேடும் வராது." "Taml"
 test_phon te "n'e:nu g'a:Ju t'inag,alanu m'ariju 'ala: c'e:sina: n'a:ku 'e:mi 'ibbandi l'e:du" "నేను గాజు తినగలను మరియు అలా చేసినా నాకు ఏమి ఇబ్బంది లేదు" "Telu"
-test_phon tn "B'aTU B'oKl B'a ts'i:tswl B'a g,olUl,os-'igill_:_: ll g'o l,ekallk'ana k'a s-'iRiti_:_: ll d,itSwan'elU
+test_phon tn "B'aTU B'oKl B'a ts'i:tswl B'a g,olUl,os-ig'ill_:_: ll g'o l,ekallk'ana k'a s-iR'iti_:_: ll d,itSwan'elU
 B'a_| aB'etswl g'o_| ak'an^a_:_: ll _|m,aik'ul#U
 ,m-ml B'a tSwan'ets-i g'o d,iRll'ana k'a _|m'owa_! wa B,okaul'eNgwl" "Batho botlhe ba tsetswe ba gololosegile le go lekalekana ka seriti le ditshwanelo. Ba abetswe go akanya le maikutlo, mme ba tshwanetse go direlana ka mowa wa bokaulengwe." "Latn"
 test_phon tk "tYRkm'WntSW


### PR DESCRIPTION
./src/espeak-ng -v ar --path=$PWD 5777

would access out of the vowel_stress array, because GetVowelStress, in the
phcode == phonSYLLABIC case, only increments count if stress is 0.  This
code seems fishy, and is not coherent with the loop in SetWordStress.  I
made it similar to the other case above, thus fixing the out-of-bound
access.

This is modifiying the stress in the tn test, I don't know whether this
is expected.