### PR TITLE
Fix pronunciation for Luxembourgish

### DIFF
--- a/phsource/ph_luxembourgish
+++ b/phsource/ph_luxembourgish
@@ -294,7 +294,7 @@ endphoneme
 phoneme TS
   vls pla afr sib
   ipa ʦ
-  WAV(ustop/tsh)
+  WAV(ustop/ts)
 endphoneme
 
 phoneme dZ


### PR DESCRIPTION
I fixed the pronunciation of "ts" because is the pronunciation is wrong for Luxembourgish!