### PR TITLE
Fix pronunciation of kubernetes

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -2351,6 +2351,7 @@ kopje		k0pi
 koran		kO@r'A:n
 kosher		koUS3
 kowtow		kaUt2aU
+kubernetes ,ku:b3'nEti:z
 
 la		,la           $only
 la		$abbrev $allcaps


### PR DESCRIPTION
Fix pronunciation of [Kubernetes](https://kubernetes.io/) ([Wikipedia](https://en.wikipedia.org/wiki/Kubernetes), [YouTube](https://www.youtube.com/watch?v=znhnDHAPCZE), [Youtube 2](https://www.youtube.com/watch?v=Dchb_-eEvpg)).