### PR TITLE
Fix Willamette

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3849,6 +3849,7 @@ wholehearted	$2
 wicked		wIkI2#d	// adjective
 width		wItT
 wilderness	wIld3n@s
+willamette wI'lamIt
 wifi		waIfaI
 winding		waIndIN       // verb
 wind		waInd         $verb


### PR DESCRIPTION
This PR fixes the pronunciation of Willamette per [Wikipedia](https://en.wikipedia.org/wiki/Willamette_Valley).