### PR TITLE
Add $only to willamette

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3851,7 +3851,7 @@ wholehearted	$2
 wicked		wIkI2#d	// adjective
 width		wItT
 wilderness	wIld3n@s
-willamette wI'lamIt
+willamette wI'lamIt $only
 wifi		waIfaI
 winding		waIndIN       // verb
 wind		waInd         $verb


### PR DESCRIPTION
Follow-up of #1345.

Restrict the new override for "willamette", just in case.