### PR TITLE
Improve pronunciation consonants of "ts"

### DIFF
--- a/phsource/ph_luxembourgish
+++ b/phsource/ph_luxembourgish
@@ -294,7 +294,7 @@ endphoneme
 phoneme TS
   vls pla afr sib
   ipa ʦ
-  WAV(ustop/tsh)
+  WAV(ustop/ts)
 endphoneme
 
 phoneme dZ


### PR DESCRIPTION
I fixed the pronunciaton consonants of "ts" because is sound wrongly pronunciation