### PR TITLE
Increase targetSdk to 30 and support signature scheme v2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 30
         versionCode 22
         versionName "1.52-dev"
     }

--- a/docs/building.md
+++ b/docs/building.md
@@ -300,15 +300,15 @@ this by:
 1.  Creating a certificate, if you do not already have one:
 
         $ keytool -genkey -keystore [YOUR_CERTIFICATE] -alias [ALIAS] -keyalg RSA -storetype PKCS12
-2. Sign the package using your certificate:
-
-        $ jarsigner -sigalg MD5withRSA -digestalg SHA1 \
-          -keystore [YOUR_CERTIFICATE] \
-          android/build/outputs/apk/release/espeak-release-unsigned.apk [ALIAS]
-3. Align the apk using the zipalign tool.
+2. Align the apk using the zipalign tool.
 
         $ zipalign 4 android/build/outputs/apk/release/espeak-release-unsigned.apk \
-          android/build/outputs/apk/release/espeak-release-signed.apk
+          android/build/outputs/apk/release/espeak-release-zipalign.apk
+3. Sign the package using your certificate:
+
+        $ apksigner --ks [YOUR_CERTIFICATE] --ks-key-alias [ALIAS] \
+          --out android/build/outputs/apk/release/espeak-release-signed.apk \
+          android/build/outputs/apk/release/espeak-release-zipalign.apk
 
 
 ### Opening project in Android Studio
@@ -333,4 +333,3 @@ To enable eSpeak, you need to:
 1.  go into the Android `Text-to-Speech settings` UI;
 2.  select `eSpeak TTS` as the default engine;
 3.  use the `Listen to an example` option to check if everything is working.
-


### PR DESCRIPTION
[This removes the warning that this app may not be compatible because it was developed for an older android-version.](https://developer.android.com/about/versions/10/behavior-changes-all#low-target-sdk-warnings) Also, this adds support for signature scheme v2 and v3 [which reduces the attack surface along with other benefits](https://source.android.com/docs/security/features/apksigning#v1). Lastly this adds 64-bit support for the APK, so this app can be installed on 64-bit-only hardware.