### PR TITLE
Russian: fix for words with ши and жи at end

### DIFF
--- a/dictsource/ru_rules
+++ b/dictsource/ru_rules
@@ -209,10 +209,10 @@
 .group и
         и       i
      H) и       y       // preceded by hard consonant
-     ж) и       y
+     ж) и (_      y
      _) и       I
         и (_    I
-     ш) и       y
+     ш) и (_      y
 
 .group й
         й       j


### PR DESCRIPTION
words like ножи, персонажи, напиши, покажи.