### PR TITLE
Update es-419

### DIFF
--- a/espeak-ng-data/lang/roa/es-419
+++ b/espeak-ng-data/lang/roa/es-419
@@ -1,11 +1,11 @@
 name Spanish (Latin America)
 language es-419
 language es-mx 6
-language es 6
 
 phonemes es-la
 dictrules 2
 intonation 2
 stressLength 170 200  230 180  0 0  250 280
 
-replace 00 T s
+tunes s6 c6 q6 e6
+


### PR DESCRIPTION
This fixes the intonation in Latin American Spanish questions, removes the phoneme replacement (T to s) because it is already included in phonemes es_la. It also eliminates the line languaje es 6, because when the voice is in the dialect of Spain and it automatically changes to the dialect of Latin America, it does not return to the dialect of Spain.