### PR TITLE
Fix pronunciation of bitwarden

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -1112,6 +1112,7 @@ bison		baIs@n
 bitable		baIt@b@L
 bitecha		baItS@
 ?!3 bitumen	bItSu:m@n
+bitwarden b'ItwO@d@n
 bizarre		bI#z'A@
 bizzare		bI#z'A@
 blanc		blA~nk


### PR DESCRIPTION
Fix pronunciation of [Bitwarden](https://bitwarden.com), the open source password manager.