### PR TITLE
Add arm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  deps: libpcaudio-dev libsonic-dev ronn kramdown
+  deps: libpcaudio-dev libsonic-dev ronn kramdown python3
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        arch: [x86-64, x86-32]
+        arch: [x86-64, x86-32, arm-32, armel-32, arm-64]
         sanitizer: [no, address, leak, memory, thread, undefined, valgrind]
 
         include:
@@ -77,12 +77,30 @@ jobs:
           - arch: x86-32
             archdeps: "gcc-multilib g++-multilib libpcaudio-dev:i386 libsonic-dev:i386 libc6-dbg:i386"
             archconfigflags: "-m32"
+            archimage: ''
 
           - arch: x86-64
             archdeps: ""
             archconfigflags: ''
+            archimage: ''
+
+          - arch: arm-32
+            archdeps: "build-essential automake autoconf libtool"
+            archconfigflags: "-D_FILE_OFFSET_BITS=64"
+            archimage: 'raspios_lite:latest'
+
+          - arch: armel-32
+            archdeps: "build-essential automake autoconf libtool"
+            archconfigflags: "-D_FILE_OFFSET_BITS=64"
+            archimage: 'raspi_1_bullseye:20220121'
+
+          - arch: arm-64
+            archdeps: "build-essential automake autoconf libtool"
+            archconfigflags: ""
+            archimage: 'raspios_lite_arm64:latest'
 
         exclude:
+
           # These are not supported on 32bit
           - arch: x86-32
             sanitizer: leak
@@ -90,9 +108,19 @@ jobs:
             sanitizer: memory
           - arch: x86-32
             sanitizer: thread
+
           # 32-bit macOS is not supported
           - os: macos-latest
             arch: x86-32
+
+          # arm macOS is not supported
+          - os: macos-latest
+            arch: arm-32
+          - os: macos-latest
+            arch: armel-32
+          - os: macos-latest
+            arch: arm-64
+
           # These are not supported on macos
           - os: macos-latest
             sanitizer: leak
@@ -101,35 +129,86 @@ jobs:
           - os: macos-latest
             sanitizer: valgrind
 
+          # These are not supported on arm
+          - arch: arm-32
+            sanitizer: memory
+          - arch: armel-32
+            sanitizer: memory
+          - arch: arm-64
+            sanitizer: memory
+          - arch: arm-32
+            sanitizer: thread
+          - arch: armel-32
+            sanitizer: thread
+          - arch: arm-64
+            sanitizer: thread
+          - arch: armel-32
+            sanitizer: valgrind
+
+          # These are not supported under qemu-user
+          - arch: arm-32
+            sanitizer: address
+          - arch: arm-32
+            sanitizer: leak
+          - arch: arm-32
+            sanitizer: valgrind
+          - arch: armel-32
+            sanitizer: address
+          - arch: armel-32
+            sanitizer: leak
+          - arch: arm-64
+            sanitizer: address
+          - arch: arm-64
+            sanitizer: leak
+          - arch: arm-64
+            sanitizer: valgrind
+
     steps:
     - uses: actions/checkout@v2
     - name: enable 32bit architecture
       run: sudo dpkg --add-architecture i386
       if: matrix.arch == 'x86-32'
+
     - name: dependencies-apt
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: sudo apt-get update && sudo apt-get install ${{ env.deps }} ${{ matrix.deps }} ${{ matrix.archdeps }}
     - name: dependencies-brew
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest' && matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: brew install libtool automake ronn OJFord/homebrew-formulae/kramdown ${{ matrix.archdeps }} ;
            brew install --HEAD anarchivist/espeak-ng/waywardgeek-sonic
     - name: autoconf
+      if: matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: ./autogen.sh ; chmod -x INSTALL m4/*.m4
     - name: configure
+      if: matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: ${{ matrix.configenv }}
            CFLAGS="${{ matrix.configflags }} ${{ matrix.archconfigflags }}"
            CXXFLAGS="${{ matrix.configflags }} ${{ matrix.archconfigflags }}"
            ./configure ${{ matrix.config }}
     - name: Store the config
-      if: ${{ failure() }}
+      if: ${{ failure() }} && matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       uses: actions/upload-artifact@v2
       with:
         name: config-${{ matrix.arch }}-${{ matrix.sanitizer }}.log
         path: config.log
     - name: make
+      if: matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: ${{ matrix.build_env }} make
     - name: make check
+      if: matrix.arch != 'arm-32' && matrix.arch != 'armel-32' && matrix.arch != 'arm-64'
       run: ${{ matrix.check_env }} make check
+
+    - uses: pguyot/arm-runner-action@v2
+      if: matrix.arch == 'arm-32' || matrix.arch == 'armel-32' || matrix.arch == 'arm-64'
+      with:
+        image_additional_mb: 4096
+        base_image: ${{ matrix.archimage }}
+        commands: |
+          apt-get update && apt-get install -y ${{ env.deps }} ${{ matrix.deps }} ${{ matrix.archdeps }}
+          ./autogen.sh ; chmod -x INSTALL m4/*.m4
+          CFLAGS="${{ matrix.configflags }} ${{ matrix.archconfigflags }}" CXXFLAGS="${{ matrix.configflags }} ${{ matrix.archconfigflags }}" ./configure ${{ matrix.config }}
+          ${{ matrix.build_env }} make
+          ${{ matrix.check_env }} make check
 
   reprotest:
 


### PR DESCRIPTION
This allows to cover
- another arch that x86, which is also very common
- an arch where char is unsigned
- a little-endian arch

This is running under qemu-user, so significantly slower and doesn't support ptrace thus no address sanitizer etc. but at least the undefined sanitizer works.