### PR TITLE
Russian and Czech update

### DIFF
--- a/dictsource/be_list
+++ b/dictsource/be_list
@@ -75,7 +75,7 @@ _6C    s.Es;ts;s'Ot
 _7C    s;Ems'Ot
 _8C    v,Os;Ems'Ot
 _9C    dz;Ev;ats;s'Ot
-_0MB1  t'i"s;ats.a
+_1MA1  t'i"s;ats.a
 _0MA1  t'i"s;ats.i"
 _0M1   t'i"s;ats.      // NOTE: in 10k > appends `_!`
 

--- a/dictsource/ru_list
+++ b/dictsource/ru_list
@@ -41,34 +41,34 @@ _6C     S,E#s;t;s'ot
 _7C     s;,Ims'ot
 _8C     vOs;Ims'ot
 _9C     dev;Vts'ot
-_0MB1   t'ys;itS;V     // keep '1' before thousand
+_1MA1   t'ys;itS;V     // keep '1' before thousand
 _0MA1   t'ys;itS;i
 _0M1    t'ys;itS;
-_0MB2   m;,Il;I;'on
+_1MA2   m;,Il;I;'on
 _0MA2   m;,IlI;'ona
 _0M2    m;,IlI;'onV#f
-_0MB3   m;,IlI;'art
+_1MA3   m;,IlI;'art
 _0M3    m;,IlI;'ardV#f
 _0MA3   m;,IlI;'arda
-_0MB4   tr;,IlI;'on
+_1MA4   tr;,IlI;'on
 _0M4   tr;,IlI;'onV#f
 _0MA4   tr;,IlI;'ona
-_0MB5           kvVd@-r;il;i'on
+_1MA5           kvVd@-r;il;i'on
 _0M5           kvVd@-r;il;i'onV#f
 _0MA5           kvVd@-r;il;i'ona
-_0MB6          kv;int;il;i'on
+_1MA6          kv;int;il;i'on
 _0M6          kv;int;il;i'onV#f
 _0MA6          kv;int;il;i'ona
-_0MB7           s;iks;t;il;i'on
+_1MA7           s;iks;t;il;i'on
 _0M7           s;iks;t;il;i'onV#f
 _0MA7           s;iks;t;il;i'ona
-_0MB8           s;ipt;il;i'on
+_1MA8           s;ipt;il;i'on
 _0M8           s;ipt;il;i'onV#f
 _0MA8           s;ipt;il;i'ona
-_0MB9        Vkt;il;i'on
+_1MA9        Vkt;il;i'on
 _0M9        Vkt;il;i'onV#f
 _0MA9        Vkt;il;i'ona
-_0MB10        nVn;il;i'on
+_1MA10        nVn;il;i'on
 _0M10        nVn;il;i'onV#f
 _0MA10        nVn;il;i'ona
 _dpt    _:'i_:        // start of decimal fraction

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -885,7 +885,7 @@ static const char *M_Variant(int value)
 	case NUM2_THOUSANDS_VAR1: // lang=ru
 		if (teens == false) {
 			if ((value % 10) == 1)
-				return "0MB";
+				return "1MA";
 			if (((value % 10) >= 2) && ((value % 10) <= 4))
 				return "0MA";
 		}

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -1360,7 +1360,7 @@ Translator *SelectTranslator(const char *name)
 		tr->langopts.decimal_sep = ',';
 
 		if (name2 == L('c', 's'))
-			tr->langopts.numbers2 = NUM2_THOUSANDPLEX_VAR_MILLIARDS | NUM2_THOUSANDS_VAR4;
+			tr->langopts.numbers2 = NUM2_THOUSANDPLEX_VAR_MILLIARDS | NUM2_THOUSANDS_VAR2;
 
 		SetLetterVowel(tr, 'y');
 		SetLetterVowel(tr, 'r');


### PR DESCRIPTION
I really wonder why the code comment says.
	case NUM2_THOUSANDS_VAR2: // lang=cs,sk
and option 4 was used for Czech, and this is not the case when this option fits the language, just the opposite.
it reads 10000000 as 10000, 11000000, as 11000, and so on
almost the same problem was in the Russian language, only it consisted in the fact that the var_1 itself was not made correctly. And here the variant is commented on as the one that is used in the Czech language, but it is not used there. And the worst thing is that everyone does not pay attention to it, well, it reads the wrong number, well, okay.