### PR TITLE
Fix pause duration for SSML and Sonic

### DIFF
--- a/src/libespeak-ng/ssml.c
+++ b/src/libespeak-ng/ssml.c
@@ -872,6 +872,8 @@ int ProcessSsmlTag(wchar_t *xml_buf, char *outbuf, int *outix, int n_outbuf, con
 		if ((attr2 = GetSsmlAttribute(px, "time")) != NULL) {
 			value2 = attrnumber(attr2, 0, 1);   // pause in mS
 
+			espeak_SetParameter(espeakRATE, speech_parameters[espeakRATE], 0);
+
 			// compensate for speaking speed to keep constant pause length, see function PauseLength()
 			// 'value' here is x 10mS
 			value = (value2 * 256) / (speed.clause_pause_factor * 10);

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -918,6 +918,10 @@ static int PlaySilence(int length, bool resume)
 	if (length == 0)
 		return 0;
 
+#if HAVE_SONIC_H
+	length = (int)(length * sonicSpeed);
+#endif
+
 	if (resume == false)
 		n_samples = length;
 

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -44,3 +44,10 @@ test_ssml_audio "<prosody>" 88fccb35536158f25f4ae44a03fb005fef95c99b "<speak><pr
 # Hash 8d3bace is the buggy version and should fail:
 test_ssml_audio "<prosody> bug #410" 8d3bace9548ae73c4770a73c88c6f65e848b45cf "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low. </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>"
 test_ssml_audio "<audio>" 5134c1db757b2d6b8d1f3f2416124462e401b4c6 "<speak>ha: <audio src=\"$PWD/phsource/h/ha.wav\"></audio></speak>"
+
+# Test SSML breaks inside prosody (#1512)
+test_ssml_audio "<prosody  50%><break 1000ms>" bc47aac0142243b31dd1930e3462abe541c1d9ff "<speak><prosody rate=\"50%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
+test_ssml_audio "<prosody 100%><break 1000ms>" c7b3e92d90063761e9744b40b17bc9204fe7d25b "<speak><prosody rate=\"100%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
+test_ssml_audio "<prosody 200%><break 1000ms>" 64213dbaf593b139b0b21840ba938cf597f7ad35 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
+# test_ssml_audio "<prosody 260%><break 1000ms>" 28b4ca77bd987d8a8a722d87f5daea70c2f7133a "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
+# libsonic that available in official repositories have a bug and last test is fails on CI


### PR DESCRIPTION
Fixes #1512

There was a two bugs.
The first is SSML duration compensation was calculated wrong because rate was not sync to internal global state.
The second causes pauses shorten when sonic compresses it, so I back compensated it in wavegen.