### PR TITLE
Spanish: fix pronunciation of "r" letter

### DIFF
--- a/dictsource/es_list
+++ b/dictsource/es_list
@@ -284,7 +284,7 @@ n	Ene
 ñ	En^e
 p	pe
 q	ku
-r	Ere
+r	ERRe
 ?2 r	ER2e
 s	Ese
 t	te


### PR DESCRIPTION
In Spanish the letter "r" in the alphabet is correctly pronounced as "ERRe", instead of "Ere".