### PR TITLE
Disable use of libsonic with msan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             deps: "clang"
             configenv: "CC=clang CXX=clang++"
             configflags: "-fsanitize=memory -fsanitize-memory-track-origins=2 -g -Og -fno-omit-frame-pointer"
-            config: "--without-pcaudiolib"
+            config: "--without-pcaudiolib --without-sonic"
             build_env: "MSAN_OPTIONS=exitcode=42"
             check_env: "MSAN_OPTIONS=exitcode=42"
 

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -39,7 +39,8 @@ test_ssml() {
 for i in `ls tests/ssml/*.ssml` ; do test_ssml $i; done
 for i in `ls tests/ssml/*.ssml2` ; do test_ssml $i punct; done
 
-test_ssml_audio "<prosody>" 88fccb35536158f25f4ae44a03fb005fef95c99b "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>"
+( test_ssml_audio "<prosody>" 88fccb35536158f25f4ae44a03fb005fef95c99b "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>" ) || \
+( test_ssml_audio "<prosody>" 32c9f870117bce5852fd53af93e967187fa8ca40 "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>" ) || exit 1
 # #410 is a bug in SSML. Sentence termination causes prosody stack to misfunction. 
 # Hash 8d3bace is the buggy version and should fail:
 test_ssml_audio "<prosody> bug #410" 8d3bace9548ae73c4770a73c88c6f65e848b45cf "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low. </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>"
@@ -48,6 +49,7 @@ test_ssml_audio "<audio>" 5134c1db757b2d6b8d1f3f2416124462e401b4c6 "<speak>ha: <
 # Test SSML breaks inside prosody (#1512)
 test_ssml_audio "<prosody  50%><break 1000ms>" bc47aac0142243b31dd1930e3462abe541c1d9ff "<speak><prosody rate=\"50%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
 test_ssml_audio "<prosody 100%><break 1000ms>" c7b3e92d90063761e9744b40b17bc9204fe7d25b "<speak><prosody rate=\"100%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
-test_ssml_audio "<prosody 200%><break 1000ms>" 64213dbaf593b139b0b21840ba938cf597f7ad35 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
+( test_ssml_audio "<prosody 200%><break 1000ms>" 64213dbaf593b139b0b21840ba938cf597f7ad35 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
+( test_ssml_audio "<prosody 200%><break 1000ms>" ff0837020dadeb8c5a20784d31624b8f0221d9a4 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || exit 1
 # test_ssml_audio "<prosody 260%><break 1000ms>" 28b4ca77bd987d8a8a722d87f5daea70c2f7133a "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
 # libsonic that available in official repositories have a bug and last test is fails on CI


### PR DESCRIPTION
msan requires that we build all code with msan to avoid false positives.