### PR TITLE
Fix non-SSML pauses with libsonic

### DIFF
--- a/src/libespeak-ng/ssml.c
+++ b/src/libespeak-ng/ssml.c
@@ -879,7 +879,16 @@ int ProcessSsmlTag(wchar_t *xml_buf, char *outbuf, int *outix, int n_outbuf, con
 		if ((attr2 = GetSsmlAttribute(px, "time")) != NULL) {
 			value2 = attrnumber(attr2, 0, 1);   // pause in mS
 
-			espeak_SetParameter(espeakRATE, speech_parameters[espeakRATE], 0);
+			int wpm = speech_parameters[espeakRATE];
+			espeak_SetParameter(espeakRATE, wpm, 0);
+
+			#if HAVE_SONIC_H
+			if (wpm >= espeakRATE_MAXIMUM) {
+				// Compensate speedup with libsonic, see function SetSpeed()
+				double sonic = ((double)wpm)/espeakRATE_NORMAL;
+				value2 = value2 * sonic;
+			}
+			#endif
 
 			// compensate for speaking speed to keep constant pause length, see function PauseLength()
 			// 'value' here is x 10mS

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -918,10 +918,6 @@ static int PlaySilence(int length, bool resume)
 	if (length == 0)
 		return 0;
 
-#if HAVE_SONIC_H
-	length = (int)(length * sonicSpeed);
-#endif
-
 	if (resume == false)
 		n_samples = length;
 

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -51,6 +51,6 @@ test_ssml_audio "<prosody  50%><break 1000ms>" bc47aac0142243b31dd1930e3462abe54
 test_ssml_audio "<prosody 100%><break 1000ms>" c7b3e92d90063761e9744b40b17bc9204fe7d25b "<speak><prosody rate=\"100%\">Break<break time=\"1000ms\"/>test</prosody></speak>"
 ( test_ssml_audio "<prosody 200%><break 1000ms>" 64213dbaf593b139b0b21840ba938cf597f7ad35 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
 ( test_ssml_audio "<prosody 200%><break 1000ms>" ff0837020dadeb8c5a20784d31624b8f0221d9a4 "<speak><prosody rate=\"200%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || exit 1
-( test_ssml_audio "<prosody 260%><break 1000ms>" 4eac3d4c5c893824dfa7434d0e66116d8ff18676 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
-( test_ssml_audio "<prosody 260%><break 1000ms>" 28b4ca77bd987d8a8a722d87f5daea70c2f7133a "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
+( test_ssml_audio "<prosody 260%><break 1000ms>" 4b4e30a2cfff1889972f013e514e81c1108283a4 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
+( test_ssml_audio "<prosody 260%><break 1000ms>" 9849f0d27f5641db6da1a8aea82578e83656d323 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
 ( test_ssml_audio "<prosody 260%><break 1000ms>" bb172a03c16e90ad537981467059c9e7d28d6aba "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || exit 1


### PR DESCRIPTION
Following #1512 

Ref: espeak-ng/espeak-ng-ios-app#34

I unfortunately have broken in-speech pauses by fixing ones that should be constant-time.
This reverts such change and adds a compensation to SSML code.