### PR TITLE
code cleanup: compilation options

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,8 +50,7 @@ EXTRA_DIST += ChangeLog
 
 all-local: \
 	espeak-ng-data/phontab \
-	dictionaries \
-	mbrola
+	dictionaries
 
 uninstall-hook:
 	rm -rf $(DESTDIR)$(DATADIR)
@@ -158,7 +157,6 @@ src_libespeak_ng_la_SOURCES = \
 	src/libespeak-ng/common.c \
 	src/libespeak-ng/compiledata.c \
 	src/libespeak-ng/compiledict.c \
-	src/libespeak-ng/compilembrola.c \
 	src/libespeak-ng/dictionary.c \
 	src/libespeak-ng/encoding.c \
 	src/libespeak-ng/error.c \
@@ -178,7 +176,6 @@ src_libespeak_ng_la_SOURCES = \
 	src/libespeak-ng/ssml.c \
 	src/libespeak-ng/synthdata.c \
 	src/libespeak-ng/synthesize.c \
-	src/libespeak-ng/synth_mbrola.c \
 	src/libespeak-ng/translate.c \
 	src/libespeak-ng/translateword.c \
 	src/libespeak-ng/tr_languages.c \
@@ -244,7 +241,10 @@ endif
 
 if OPT_MBROLA
 AM_CFLAGS  += -DUSE_MBROLA=1
-src_libespeak_ng_la_SOURCES += src/libespeak-ng/mbrowrap.c
+src_libespeak_ng_la_SOURCES += \
+	src/libespeak-ng/mbrowrap.c \
+	src/libespeak-ng/synth_mbrola.c \
+	src/libespeak-ng/compilembrola.c
 endif
 
 if OPT_ASYNC
@@ -956,6 +956,8 @@ dictsource/yue_emoji:
 
 ##### mbrola:
 
+if OPT_MBROLA
+
 PHSOURCE_MBROLA = \
 	$(wildcard phsource/mbrola/*)
 
@@ -967,3 +969,7 @@ espeak-ng-data/mbrola_ph/%_phtrans: phsource/mbrola/% src/espeak-ng
 	ESPEAK_DATA_PATH=$(CURDIR) src/espeak-ng --compile-mbrola=phsource/mbrola/$*
 
 EXTRA_DIST += $(PHSOURCE_MBROLA)
+
+all-local: mbrola
+
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -227,12 +227,12 @@ noinst_HEADERS = \
 	src/ucd-tools/src/include/ucd/ucd.h
 
 if OPT_KLATT
-src_libespeak_ng_la_CFLAGS  += -DINCLUDE_KLATT
+AM_CFLAGS  += -DUSE_KLATT=1
 src_libespeak_ng_la_SOURCES += src/libespeak-ng/klatt.c
 endif
 
 if OPT_SPEECHPLAYER
-src_libespeak_ng_la_CFLAGS  += -DINCLUDE_SPEECHPLAYER
+AM_CFLAGS  += -DUSE_SPEECHPLAYER=1
 src_libespeak_ng_la_SOURCES += src/libespeak-ng/sPlayer.c
 src_libespeak_ng_la_SOURCES += src/speechPlayer/src/frame.cpp
 src_libespeak_ng_la_SOURCES += src/speechPlayer/src/speechPlayer.cpp
@@ -243,12 +243,12 @@ src_speak_ng_SOURCES = src/speak-ng.c
 endif
 
 if OPT_MBROLA
-src_libespeak_ng_la_CFLAGS  += -DINCLUDE_MBROLA
+AM_CFLAGS  += -DUSE_MBROLA=1
 src_libespeak_ng_la_SOURCES += src/libespeak-ng/mbrowrap.c
 endif
 
 if OPT_ASYNC
-src_libespeak_ng_la_CFLAGS  += -DUSE_ASYNC
+AM_CFLAGS  += -DUSE_ASYNC=1
 src_libespeak_ng_la_SOURCES += \
 	src/libespeak-ng/espeak_command.c \
 	src/libespeak-ng/event.c \
@@ -289,14 +289,6 @@ src_libespeak_ng_test_la_CFLAGS  = \
 	-fPIC -pedantic -fno-exceptions -DPATH_ESPEAK_DATA=\"$(DATADIR)\" -DLIBESPEAK_NG_EXPORT \
 	${PCAUDIOLIB_CFLAGS} ${AM_CFLAGS}
 src_libespeak_ng_test_la_SOURCES = $(src_libespeak_ng_la_SOURCES)
-
-if OPT_KLATT
-src_libespeak_ng_test_la_CFLAGS  += -DINCLUDE_KLATT
-endif
-
-if OPT_SPEECHPLAYER
-src_libespeak_ng_test_la_CFLAGS  += -DINCLUDE_SPEECHPLAYER
-endif
 
 check_PROGRAMS += tests/encoding.test
 

--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -218,7 +218,7 @@ static int OpenWavFile(char *path, int rate)
 	f_wavfile = NULL;
 	if (path[0] != 0) {
 		if (strcmp(path, "stdout") == 0) {
-#ifdef PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS
 			// prevent Windows adding 0x0d before 0x0a bytes
 			_setmode(_fileno(stdout), _O_BINARY);
 #endif

--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -89,8 +89,10 @@ static const char *help_text =
     "\t   Compile pronunciation rules and dictionary from the current\n"
     "\t   directory, including line numbers for use with -X.\n"
     "\t   <voice name> specifies the language\n"
+#if USE_MBROLA
     "--compile-mbrola=<voice name>\n"
     "\t   Compile an MBROLA voice\n"
+#endif
     "--compile-intonations\n"
     "\t   Compile the intonation data\n"
     "--compile-phonemes=<phsource-dir>\n"
@@ -323,7 +325,9 @@ int main(int argc, char **argv)
 		{ "version", no_argument,       0, 0x10b },
 		{ "sep",     optional_argument, 0, 0x10c },
 		{ "tie",     optional_argument, 0, 0x10d },
+#if USE_MBROLA
 		{ "compile-mbrola", optional_argument, 0, 0x10e },
+#endif
 		{ "compile-intonations", no_argument, 0, 0x10f },
 		{ "compile-phonemes", optional_argument, 0, 0x110 },
 		{ "load",    no_argument,       0, 0x111 },
@@ -536,6 +540,7 @@ int main(int argc, char **argv)
 			if (phonemes_separator == 'z')
 				phonemes_separator = 0x200d; // ZWJ
 			break;
+#if USE_MBROLA
 		case 0x10e: // --compile-mbrola
 		{
 			espeak_ng_InitializePath(data_path);
@@ -548,6 +553,7 @@ int main(int argc, char **argv)
 			}
 			return EXIT_SUCCESS;
 		}
+#endif
 		case 0x10f: // --compile-intonations
 		{
 			espeak_ng_InitializePath(data_path);

--- a/src/include/compat/endian.h
+++ b/src/include/compat/endian.h
@@ -20,10 +20,10 @@
 #define ENDIAN_H_COMPAT_SHIM
 #pragma once
 
-#if defined(HAVE_ENDIAN_H)
+#if __has_include_next(<endian.h>)
 #	pragma GCC system_header // Silence "warning: #include_next is a GCC extension"
 #	include_next <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
+#elif __has_include(<sys/endian.h>)
 #	include <sys/endian.h>
 #	if !defined(be16toh)
 #		define be16toh(x) betoh16(x)

--- a/src/include/compat/getopt.h
+++ b/src/include/compat/getopt.h
@@ -21,7 +21,7 @@
 #ifndef GETOPT_H_COMPAT_SHIM
 #define GETOPT_H_COMPAT_SHIM
 
-#if defined(HAVE_GETOPT_H)
+#if __has_include_next(<getopt.h>)
 #pragma GCC system_header // Silence "warning: #include_next is a GCC extension"
 #include_next <getopt.h>
 #else

--- a/src/include/compat/stdint.h
+++ b/src/include/compat/stdint.h
@@ -45,7 +45,7 @@
 
 #pragma GCC system_header // Silence "warning: #include_next is a GCC extension"
 
-#if defined(HAVE_STDINT_H) || !defined(HAVE_INTTYPES_H)
+#if __has_include(<stdint.h>) || !__has_include(<inttypes.h>)
 #include_next <stdint.h>
 #else
 #include_next <inttypes.h>

--- a/src/include/compat/unistd.h
+++ b/src/include/compat/unistd.h
@@ -19,7 +19,7 @@
 #ifndef UNISTD_H_COMPAT_SHIM
 #define UNISTD_H_COMPAT_SHIM
 
-#if defined(HAVE_UNISTD_H)
+#if __has_include_next(<unistd.h>)
 #pragma GCC system_header // Silence "warning: #include_next is a GCC extension"
 #include_next <unistd.h>
 #endif

--- a/src/libespeak-ng/espeak_command.c
+++ b/src/libespeak-ng/espeak_command.c
@@ -27,7 +27,7 @@
 
 #include "espeak_command.h"
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 
 static unsigned int my_current_text_id = 0;
 

--- a/src/libespeak-ng/event.c
+++ b/src/libespeak-ng/event.c
@@ -46,7 +46,7 @@ static bool my_stop_is_acknowledged = false;
 static bool my_terminate_is_required = 0;
 // my_thread: polls the audio duration and compares it to the duration of the first event.
 static pthread_t my_thread;
-static bool thread_inited;
+static bool thread_inited = false;
 
 static t_espeak_callback *my_callback = NULL;
 static bool my_event_is_running = false;

--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -38,7 +38,7 @@
 #include "fifo.h"
 #include "event.h"
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 
 // my_mutex: protects my_thread_is_talking,
 // my_stop_is_required, and the command fifo

--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -63,6 +63,7 @@ static espeak_ng_STATUS push(t_espeak_command *the_command);
 static t_espeak_command *pop(void);
 static void init(int process_parameters);
 static int node_counter = 0;
+static bool thread_inited = false;
 
 enum {
 	MAX_NODE_COUNTER = 400,
@@ -89,6 +90,7 @@ void fifo_init()
 	                      (void *)NULL)) {
 		assert(0);
 	}
+	thread_inited = true;
 
 	pthread_attr_destroy(&a_attrib);
 
@@ -131,6 +133,9 @@ espeak_ng_STATUS fifo_add_command(t_espeak_command *the_command)
 espeak_ng_STATUS fifo_add_commands(t_espeak_command *command1, t_espeak_command *command2)
 {
 	espeak_ng_STATUS status;
+	if (!thread_inited) {
+		return ENS_NOT_INITIALIZED;
+	}
 	if ((status = pthread_mutex_lock(&my_mutex)) != ENS_OK)
 		return status;
 
@@ -166,6 +171,7 @@ espeak_ng_STATUS fifo_add_commands(t_espeak_command *command1, t_espeak_command 
 
 espeak_ng_STATUS fifo_stop()
 {
+	if (!thread_inited) return ENS_OK;
 	espeak_ng_STATUS status;
 	if ((status = pthread_mutex_lock(&my_mutex)) != ENS_OK)
 		return status;
@@ -193,7 +199,11 @@ espeak_ng_STATUS fifo_stop()
 
 int fifo_is_busy()
 {
-	return my_command_is_running;
+	if (!thread_inited) return false;
+	pthread_mutex_lock(&my_mutex);
+	bool running = my_command_is_running;
+	pthread_mutex_unlock(&my_mutex);
+	return running;
 }
 
 static int sleep_until_start_request_or_inactivity()
@@ -438,12 +448,15 @@ static void init(int process_parameters)
 
 void fifo_terminate()
 {
+	if (!thread_inited) return;
+
 	pthread_mutex_lock(&my_mutex);
 	my_terminate_is_required = true;
 	pthread_mutex_unlock(&my_mutex);
 	pthread_cond_signal(&my_cond_start_is_required);
 	pthread_join(my_thread, NULL);
 	my_terminate_is_required = false;
+	thread_inited = false;
 
 	pthread_mutex_destroy(&my_mutex);
 	pthread_cond_destroy(&my_cond_start_is_required);

--- a/src/libespeak-ng/klatt.c
+++ b/src/libespeak-ng/klatt.c
@@ -38,7 +38,7 @@
 #include "common.h"      // for espeak_rand
 #include "synthesize.h"  // for frame_t, WGEN_DATA, STEPSIZE, N_KLATTP, echo...
 #include "voice.h"       // for voice_t, N_PEAKS
-#ifdef INCLUDE_SPEECHPLAYER
+#if USE_SPEECHPLAYER
 #include "sPlayer.h"
 #endif
 
@@ -433,7 +433,7 @@ void KlattReset(int control)
 {
 	int r_ix;
 
-#ifdef INCLUDE_SPEECHPLAYER
+#if USE_SPEECHPLAYER
 	KlattResetSP();
 #endif
 
@@ -466,7 +466,7 @@ void KlattReset(int control)
 
 void KlattFini(void)
 {
-#ifdef INCLUDE_SPEECHPLAYER
+#if USE_SPEECHPLAYER
 	KlattFiniSP();
 #endif
 }
@@ -859,7 +859,7 @@ static double klattp_inc[N_KLATTP];
 
 int Wavegen_Klatt(int length, int resume, frame_t *fr1, frame_t *fr2, WGEN_DATA *wdata, voice_t *wvoice)
 {
-#ifdef INCLUDE_SPEECHPLAYER
+#if USE_SPEECHPLAYER
 	if(wvoice->klattv[0] == 6)
 	return Wavegen_KlattSP(wdata, wvoice, length, resume, fr1, fr2);
 #endif
@@ -1078,7 +1078,7 @@ void KlattInit()
 
 	int ix;
 
-#ifdef INCLUDE_SPEECHPLAYER
+#if USE_SPEECHPLAYER
 	KlattInitSP();
 #endif
 

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -38,7 +38,6 @@
 
 #include "readclause.h"
 #include "common.h"               // for GetFileLength, strncpy0
-#include "config.h"               // for HAVE_MKSTEMP
 #include "dictionary.h"           // for LookupDictList, DecodePhonemes, Set...
 #include "error.h"                // for create_file_error_context
 #include "phoneme.h"              // for phonSWITCH

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -157,7 +157,7 @@ void SetSpeed(int control)
 
 	speed.min_pause = 5;
 
-	#if HAVE_SONIC_H
+	#if USE_LIBSONIC
 	int wpm_value = wpm;
 
 	if (voice->speed_percent > 0)

--- a/src/libespeak-ng/soundicon.c
+++ b/src/libespeak-ng/soundicon.c
@@ -88,7 +88,7 @@ static espeak_ng_STATUS LoadSoundFile(const char *fname, int index, espeak_ng_ER
 			fclose(f);
 			f = NULL;
 
-#ifdef HAVE_MKSTEMP
+#if HAVE_MKSTEMP
 			strcpy(fname_temp, "/tmp/espeakXXXXXX");
 			int fd_temp;
 			if ((fd_temp = mkstemp(fname_temp)) >= 0)

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -273,6 +273,9 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_InitializeOutput(espeak_ng_OUTPUT_MODE 
 		my_audio = create_audio_device_object(device, "eSpeak", "Text-to-Speech");
 #endif
 
+#if USE_ASYNC
+	if ((my_mode & ENOUTPUT_MODE_SYNCHRONOUS) == 0) fifo_init();
+#endif
 
 	// Don't allow buffer be smaller than safe minimum
 	if (buffer_length < min_buffer_length)
@@ -392,10 +395,6 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Initialize(espeak_ng_ERROR_CONTEXT *con
 	SetParameter(espeakCAPITALS, option_capitals, 0);
 	SetParameter(espeakPUNCTUATION, option_punctuation, 0);
 	SetParameter(espeakWORDGAP, 0, 0);
-
-#if USE_ASYNC
-	fifo_init();
-#endif
 
 	option_phonemes = 0;
 	option_phoneme_events = 0;

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -123,9 +123,6 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 					// sound was previously open with a different sample rate
 					audio_object_close(my_audio);
 					out_samplerate = 0;
-#ifdef HAVE_SLEEP
-					sleep(1);
-#endif
 				}
 #endif
 #if USE_LIBPCAUDIO

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -523,6 +523,10 @@ void MarkerEvent(int type, unsigned int char_position, int value, int value2, un
 	ep->text_position = char_position & 0xffffff;
 	ep->length = char_position >> 24;
 
+#if !USE_MBROLA
+	static const int mbrola_delay = 0;
+#endif
+
 	time = ((double)(count_samples + mbrola_delay + (out_ptr - out_start)/2)*1000.0)/samplerate;
 	ep->audio_position = (int)time;
 	ep->sample = (count_samples + mbrola_delay + (out_ptr - out_start)/2);

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -33,7 +33,7 @@
 #include <unistd.h>
 #include <wchar.h>
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 #include <pcaudiolib/audio.h>
 #endif
 
@@ -71,7 +71,7 @@ espeak_EVENT *event_list = NULL;
 static int event_list_ix = 0;
 static int n_event_list;
 static long count_samples;
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 static struct audio_object *my_audio = NULL;
 #endif
 
@@ -90,7 +90,7 @@ extern int saved_parameters[N_SPEECH_PARAM]; // Parameters saved on synthesis st
 
 void cancel_audio(void)
 {
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO) {
 		audio_object_flush(my_audio);
 	}
@@ -100,7 +100,7 @@ void cancel_audio(void)
 static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 {
 	int a_wave_can_be_played = 1;
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	if ((my_mode & ENOUTPUT_MODE_SYNCHRONOUS) == 0)
 		a_wave_can_be_played = fifo_is_command_enabled();
 #endif
@@ -118,7 +118,7 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 			voice_samplerate = event->id.number;
 
 			if (out_samplerate != voice_samplerate) {
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 				if (out_samplerate != 0) {
 					// sound was previously open with a different sample rate
 					audio_object_close(my_audio);
@@ -128,7 +128,7 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 #endif
 				}
 #endif
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 				int error = audio_object_open(my_audio, AUDIO_OBJECT_FORMAT_S16LE, voice_samplerate, 1);
 				if (error != 0) {
 					fprintf(stderr, "error: %s\n", audio_object_strerror(my_audio, error));
@@ -137,14 +137,14 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 				}
 #endif
 				out_samplerate = voice_samplerate;
-#ifdef USE_ASYNC
+#if USE_ASYNC
 				if ((my_mode & ENOUTPUT_MODE_SYNCHRONOUS) == 0)
 					event_init();
 #endif
 			}
 		}
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 		if (out_samplerate == 0) {
 			int error = audio_object_open(my_audio, AUDIO_OBJECT_FORMAT_S16LE, voice_samplerate, 1);
 			if (error != 0) {
@@ -156,7 +156,7 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 		}
 #endif
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 		if (outbuf && length && a_wave_can_be_played) {
 			int error = audio_object_write(my_audio, (char *)outbuf, 2*length);
 			if (error != 0)
@@ -164,7 +164,7 @@ static int dispatch_audio(short *outbuf, int length, espeak_EVENT *event)
 		}
 #endif
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 		while (event && a_wave_can_be_played) {
 			// TBD: some event are filtered here but some insight might be given
 			// TBD: in synthesise.cpp for avoiding to create WORDs with size=0.
@@ -218,7 +218,7 @@ static int create_events(short *outbuf, int length, espeak_EVENT *event_list)
 	return finished;
 }
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 
 int sync_espeak_terminated_msg(uint32_t unique_identifier, void *user_data)
 {
@@ -266,12 +266,12 @@ static int check_data_path(const char *path, int allow_directory)
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_InitializeOutput(espeak_ng_OUTPUT_MODE output_mode, int buffer_length, const char *device)
 {
-	(void)device; // unused if HAVE_PCAUDIOLIB_AUDIO_H is not defined
+	(void)device; // unused if  USE_LIBPCAUDIO is not defined
 
 	my_mode = output_mode;
 	out_samplerate = 0;
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 	if (((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO) && (my_audio == NULL))
 		my_audio = create_audio_device_object(device, "eSpeak", "Text-to-Speech");
 #endif
@@ -308,7 +308,7 @@ ESPEAK_NG_API void espeak_ng_InitializePath(const char *path)
 	if (check_data_path(path, 1))
 		return;
 
-#ifdef PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS
 	HKEY RegKey;
 	unsigned long size;
 	unsigned long var_type;
@@ -396,7 +396,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Initialize(espeak_ng_ERROR_CONTEXT *con
 	SetParameter(espeakPUNCTUATION, option_punctuation, 0);
 	SetParameter(espeakWORDGAP, 0, 0);
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	fifo_init();
 #endif
 
@@ -571,7 +571,7 @@ espeak_ng_STATUS sync_espeak_Synth(unsigned int unique_identifier, const void *t
 	end_character_position = end_position;
 
 	espeak_ng_STATUS aStatus = Synthesize(unique_identifier, text, flags);
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO) {
 		int error = (aStatus == ENS_SPEECH_STOPPED)
 		          ? audio_object_flush(my_audio)
@@ -647,7 +647,7 @@ void sync_espeak_SetPunctuationList(const wchar_t *punctlist)
 ESPEAK_API void espeak_SetSynthCallback(t_espeak_callback *SynthCallback)
 {
 	synth_callback = SynthCallback;
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	event_set_callback(synth_callback);
 #endif
 }
@@ -670,7 +670,7 @@ espeak_ng_Synthesize(const void *text, size_t size,
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS)
 		return sync_espeak_Synth(0, text, position, position_type, end_position, flags, user_data);
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	// Create the text command
 	t_espeak_command *c1 = create_espeak_text(text, size, position, position_type, end_position, flags, user_data);
 	if (c1) {
@@ -719,7 +719,7 @@ espeak_ng_SynthesizeMark(const void *text,
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS)
 		return sync_espeak_Synth_Mark(0, text, index_mark, end_position, flags, user_data);
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	// Create the mark command
 	t_espeak_command *c1 = create_espeak_mark(text, size, index_mark, end_position,
 	                                          flags, user_data);
@@ -756,7 +756,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SpeakKeyName(const char *key_name)
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS)
 		return sync_espeak_Key(key_name);
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	t_espeak_command *c = create_espeak_key(key_name, NULL);
 	espeak_ng_STATUS status = fifo_add_command(c);
 	if (status != ENS_OK)
@@ -771,7 +771,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SpeakCharacter(wchar_t character)
 {
 	// is there a system resource of character names per language?
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS)
 		return sync_espeak_Char(character);
 
@@ -795,7 +795,7 @@ ESPEAK_API int espeak_GetParameter(espeak_PARAMETER parameter, int current)
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SetParameter(espeak_PARAMETER parameter, int value, int relative)
 {
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS)
 		return SetParameter(parameter, value, relative);
 
@@ -814,7 +814,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_SetPunctuationList(const wchar_t *punct
 {
 	// Set the list of punctuation which are spoken for "some".
 
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	if (my_mode & ENOUTPUT_MODE_SYNCHRONOUS) {
 		sync_espeak_SetPunctuationList(punctlist);
 		return ENS_OK;
@@ -874,12 +874,12 @@ ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode,
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Cancel(void)
 {
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	fifo_stop();
 	event_clear_all();
 #endif
 
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO)
 		audio_object_flush(my_audio);
 #endif
@@ -893,7 +893,7 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Cancel(void)
 
 ESPEAK_API int espeak_IsPlaying(void)
 {
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	return fifo_is_busy();
 #else
 	return 0;
@@ -903,7 +903,7 @@ ESPEAK_API int espeak_IsPlaying(void)
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Synchronize(void)
 {
 	espeak_ng_STATUS berr = err;
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	while (espeak_IsPlaying())
 		usleep(20000);
 #endif
@@ -913,14 +913,14 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Synchronize(void)
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Terminate(void)
 {
-#ifdef USE_ASYNC
+#if USE_ASYNC
 	fifo_stop();
 	fifo_terminate();
 	event_terminate();
 #endif
 
 	if ((my_mode & ENOUTPUT_MODE_SPEAK_AUDIO) == ENOUTPUT_MODE_SPEAK_AUDIO) {
-#ifdef HAVE_PCAUDIOLIB_AUDIO_H
+#if USE_LIBPCAUDIO
 		audio_object_close(my_audio);
 		audio_object_destroy(my_audio);
 		my_audio = NULL;

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -54,14 +54,14 @@ extern "C"
 
 #if defined(_WIN32) || defined(_WIN64) // Windows
 
-#define PLATFORM_WINDOWS
+#define PLATFORM_WINDOWS 1
 #define PATHSEP '\\'
 #define N_PATH_HOME_DEF  230
 #define NO_VARIADIC_MACROS
 
 #else
 
-#define PLATFORM_POSIX
+#define PLATFORM_POSIX 1
 #define PATHSEP  '/'
 #define N_PATH_HOME_DEF  160
 #define USE_NANOSLEEP

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -31,7 +31,7 @@
 #endif
 
 #ifndef MAKE_MEM_UNDEFINED
-#  ifdef HAVE_VALGRIND_MEMCHECK_H
+#  if __has_include(<valgrind/memcheck.h>)
 #    include <valgrind/memcheck.h>
 #    define MAKE_MEM_UNDEFINED(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
 #  else

--- a/src/libespeak-ng/ssml.c
+++ b/src/libespeak-ng/ssml.c
@@ -884,7 +884,7 @@ int ProcessSsmlTag(wchar_t *xml_buf, char *outbuf, int *outix, int n_outbuf, con
 			int wpm = speech_parameters[espeakRATE];
 			espeak_SetParameter(espeakRATE, wpm, 0);
 
-			#if HAVE_SONIC_H
+			#if USE_LIBSONIC
 			if (wpm >= espeakRATE_MAXIMUM) {
 				// Compensate speedup with libsonic, see function SetSpeed()
 				double sonic = ((double)wpm)/espeakRATE_NORMAL;

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -50,7 +50,7 @@
 int mbrola_delay;
 char mbrola_name[20];
 
-#ifdef INCLUDE_MBROLA
+#if USE_MBROLA
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
@@ -86,7 +86,7 @@ espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans, 
 		return ENS_MBROLA_NOT_FOUND;
 
 	sprintf(path, "%s/mbrola/%s", path_home, mbrola_voice);
-#ifdef PLATFORM_POSIX
+#if PLATFORM_POSIX
 	// if not found, then also look in
 	//   usr/share/mbrola/xx, /usr/share/mbrola/xx/xx, /usr/share/mbrola/voices/xx
 	if (GetFileLength(path) <= 0) {

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -639,10 +639,14 @@ static bool InterpretCondition(Translator *tr, int control, PHONEME_LIST *plist,
 		{
 		case 1: // PreVoicing
 			return control & 1;
+#if USE_KLATT
 		case 2: // KlattSynth
 			return voice->klattv[0] != 0;
+#endif
+#if USE_MBROLA
 		case 3: // MbrolaSynth
 			return mbrola_name[0] != 0;
+#endif
 		}
 	}
 	return false;

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -1148,8 +1148,10 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 	if (option_phoneme_events & espeakINITIALIZE_PHONEME_IPA)
 		use_ipa = 1;
 
+#if USE_MBROLA
 	if (mbrola_name[0] != 0)
 		return MbrolaGenerate(phoneme_list, n_ph, resume);
+#endif
 
 	if (resume == false) {
 		ix = 1;

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -1040,7 +1040,7 @@ void DoPhonemeMarker(int type, int char_posn, int length, char *name)
 	}
 }
 
-#if HAVE_SONIC_H
+#if USE_LIBSONIC
 void DoSonicSpeed(int value)
 {
 	// value, multiplier * 1024

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -439,7 +439,7 @@ int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsig
 
 void Write4Bytes(FILE *f, int value);
 
-#if HAVE_SONIC_H
+#if USE_LIBSONIC
 void DoSonicSpeed(int value);
 #endif
 

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1176,7 +1176,7 @@ static void GetVoices(const char *path, int len_path_voices, int is_language_fil
 {
 	char fname[sizeof(path_home)+100];
 
-#ifdef PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS
 	WIN32_FIND_DATAA FindFileData;
 	HANDLE hFind = INVALID_HANDLE_VALUE;
 

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -305,7 +305,9 @@ void VoiceReset(int tone_only)
 
 	if (tone_only == 0) {
 		n_replace_phonemes = 0;
+#if USE_MBROLA
 		LoadMbrolaTable(NULL, NULL, 0);
+#endif
 	}
 
 // probably unnecessary, but removing this would break tests
@@ -649,6 +651,7 @@ voice_t *LoadVoice(const char *vname, int control)
                 sscanf(p, "%d", &voice->speed_percent);
                 SetSpeed(3);
                 break;
+#if USE_MBROLA
             case V_MBROLA:
             {
                 int srate = 16000;
@@ -665,11 +668,14 @@ voice_t *LoadVoice(const char *vname, int control)
                     voice->samplerate = srate;
             }
                 break;
+#endif
+#if USE_KLATT
             case V_KLATT:
                 voice->klattv[0] = 1; // default source: IMPULSIVE
                 Read8Numbers(p, voice->klattv);
                 voice->klattv[KLATT_Kopen] -= 40;
                 break;
+#endif
             case V_FAST:
                 sscanf(p, "%d", &speed.fast_settings);
                 SetSpeed(3);

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -832,10 +832,6 @@ static int Wavegen(int length, int modulation, bool resume, frame_t *fr1, frame_
 		}
 
 		// apply main peaks, formants 0 to 5
-#ifdef USE_ASSEMBLER_1
-		// use an optimised routine for this loop, if available
-		total += AddSineWaves(waveph, h_switch_sign, maxh, harmspect);  // call an assembler code routine
-#else
 		theta = waveph;
 
 		for (h = 1; h <= h_switch_sign; h++) {
@@ -847,7 +843,6 @@ static int Wavegen(int length, int modulation, bool resume, frame_t *fr1, frame_
 			theta += waveph;
 			h++;
 		}
-#endif
 
 		if (voicing != 64)
 			total = (total >> 6) * voicing;

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -246,8 +246,10 @@ void WcmdqStop()
 	}
 #endif
 
+#if USE_MBROLA
 	if (mbrola_name[0] != 0)
 		MbrolaReset();
+#endif
 }
 
 int WcmdqFree()

--- a/tests/api.c
+++ b/tests/api.c
@@ -88,9 +88,11 @@ test_espeak_synth()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -118,7 +120,12 @@ test_espeak_synth_no_voices(const char *path)
 	assert(p_decoder == NULL);
 
 	const char *test = "One two three.";
-	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_NOT_FOUND);
+	int res = espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL);
+#if USE_ASYNC
+	assert(res == EE_OK);
+#else
+	assert(res == EE_NOT_FOUND);
+#endif
 	assert(translator == NULL);
 	assert(p_decoder == NULL);
 
@@ -151,9 +158,11 @@ test_espeak_ng_synthesize()
 
 	const char *test = "One two three.";
 	assert(espeak_ng_Synthesize(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == ENS_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -181,11 +190,16 @@ test_espeak_ng_synthesize_no_voices(const char *path)
 	assert(p_decoder == NULL);
 
 	const char *test = "One two three.";
-	assert(espeak_ng_Synthesize(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == ENS_VOICE_NOT_FOUND);
+	int res = espeak_ng_Synthesize(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL);
+#if USE_ASYNC
+	assert(res == EE_OK);
+#else
+	assert(res == ENS_VOICE_NOT_FOUND);
+#endif
 	assert(translator == NULL);
 	assert(p_decoder == NULL);
 
-	assert(espeak_Synchronize() == EE_OK);
+	assert(espeak_ng_Synchronize() == ENS_OK);
 	assert(translator == NULL);
 	assert(p_decoder == NULL);
 
@@ -218,9 +232,11 @@ test_espeak_set_voice_by_name_null_voice()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -253,9 +269,11 @@ test_espeak_set_voice_by_name_blank_voice()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -289,9 +307,11 @@ test_espeak_set_voice_by_name_valid_voice()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "de") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -324,9 +344,11 @@ test_espeak_set_voice_by_name_invalid_voice()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -360,9 +382,11 @@ test_espeak_set_voice_by_name_language_variant_intonation_parameter()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -402,9 +426,11 @@ test_espeak_set_voice_by_properties_empty()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -442,9 +468,11 @@ test_espeak_set_voice_by_properties_blank_language()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -482,9 +510,11 @@ test_espeak_set_voice_by_properties_with_valid_language()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "mk") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -521,9 +551,11 @@ test_espeak_set_voice_by_properties_with_invalid_language()
 
 	const char *test = "One two three.";
 	assert(espeak_Synth(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == EE_OK);
+#if !USE_ASYNC
 	assert(translator != NULL);
 	assert(strcmp(translator->dictionary_name, "en") == 0);
 	assert(p_decoder != NULL);
+#endif
 
 	assert(espeak_Synchronize() == EE_OK);
 	assert(translator != NULL);
@@ -564,7 +596,7 @@ test_espeak_ng_phoneme_events(int enabled, int ipa) {
 	espeak_ng_InitializePath(NULL);
 	espeak_ng_ERROR_CONTEXT context = NULL;
 	assert(espeak_ng_Initialize(&context) == ENS_OK);
-	assert(espeak_ng_InitializeOutput(ENOUTPUT_MODE_SYNCHRONOUS, 0, NULL) == ENS_OK);
+	assert(espeak_ng_InitializeOutput(0, 0, NULL) == ENS_OK);
 	espeak_SetSynthCallback(_test_espeak_ng_phoneme_events_cb);
 	assert(espeak_ng_SetPhonemeEvents(enabled, ipa) == ENS_OK);
 


### PR DESCRIPTION
Fixes: #1549

A bunch of `#ifdef` stuff cleanups, including:

- Check header presence with `__has_include` instead of autoconf's `HAVE_XXX` macro
- Standartization of defines: consistent naming, define to 1 and check with `#if` instead of `#ifdef`
- Compile MBROLA-related code only if configured `--with-mbrola`
- Compile tests with flags that match configuration (including async, klatt, speechplayer, mbrola)
- Fix for API test when compiled with async