### PR TITLE
ssml: support break time multiplier

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -77,6 +77,8 @@ static const char *help_text =
     "\t   Write speech to this WAV file, rather than speaking it directly\n"
     "-b\t   Input text encoding, 1=UTF8, 2=8 bit, 4=16 bit \n"
     "-m\t   Interpret SSML markup, and ignore other < > tags\n"
+    "--ssml-break=<percentage>\n"
+    "\t   Set SSML break time multiplier, default is 100\n"
     "-q\t   Quiet, don't produce any speech (may be useful with -x)\n"
     "-x\t   Write phoneme mnemonics to stdout\n"
     "-X\t   Write phonemes mnemonics and translation trace to stdout\n"
@@ -331,6 +333,7 @@ int main(int argc, char **argv)
 		{ "compile-intonations", no_argument, 0, 0x10f },
 		{ "compile-phonemes", optional_argument, 0, 0x110 },
 		{ "load",    no_argument,       0, 0x111 },
+		{ "ssml-break", required_argument, 0, 0x112 },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -361,6 +364,7 @@ int main(int argc, char **argv)
 	int phoneme_options = 0;
 	int option_linelength = 0;
 	int option_waveout = 0;
+	int ssml_break = -1;
 	bool deterministic = 0;
 	
 	espeak_VOICE voice_select;
@@ -586,6 +590,9 @@ int main(int argc, char **argv)
 		case 0x111: // --load
 			flag_load = 1;
 			break;
+		case 0x112: // --ssml-break
+			ssml_break = atoi(optarg2);
+			break;
 		default:
 			exit(0);
 		}
@@ -677,6 +684,8 @@ int main(int argc, char **argv)
 		espeak_SetParameter(espeakWORDGAP, wordgap, 0);
 	if (option_linelength > 0)
 		espeak_SetParameter(espeakLINELENGTH, option_linelength, 0);
+	if (ssml_break > 0)
+		espeak_SetParameter(espeakSSML_BREAK_MUL, ssml_break, 0);
 	if (option_punctuation == 2)
 		espeak_SetPunctuationList(option_punctlist);
 

--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -416,8 +416,8 @@ typedef enum {
   espeakWORDGAP=7,
   espeakOPTIONS=8,   // reserved for misc. options.  not yet used
   espeakINTONATION=9,
+  espeakSSML_BREAK_MUL=10,
 
-  espeakRESERVED1=10,
   espeakRESERVED2=11,
   espeakEMPHASIS,   /* internal use */
   espeakLINELENGTH, /* internal use */

--- a/src/libespeak-ng/CMakeLists.txt
+++ b/src/libespeak-ng/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(espeak-ng
   espeak_api.c
 )
 
+target_include_directories(espeak-ng BEFORE PRIVATE $<TARGET_PROPERTY:espeak-include,INTERFACE_INCLUDE_DIRECTORIES>)
+
 if (NOT MSVC)
   target_compile_options(espeak-ng PRIVATE
     "-fPIC"

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -336,6 +336,8 @@ espeak_ng_STATUS SetParameter(int parameter, int value, int relative)
 			translator->langopts.intonation_group = new_value & 0xff;
 		option_tone_flags = new_value;
 		break;
+  case espeakSSML_BREAK_MUL:
+    break;
 	default:
 		return EINVAL;
 	}

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -349,7 +349,7 @@ const int param_defaults[N_SPEECH_PARAM] = {
 	0,   // wordgap
 	0,   // options
 	0,   // intonation
-	0,
+	100, // ssml break mul
 	0,
 	0,   // emphasis
 	0,   // line length

--- a/src/libespeak-ng/ssml.c
+++ b/src/libespeak-ng/ssml.c
@@ -882,6 +882,8 @@ int ProcessSsmlTag(wchar_t *xml_buf, char *outbuf, int *outix, int n_outbuf, con
 		if ((attr2 = GetSsmlAttribute(px, "time")) != NULL) {
 			value2 = attrnumber(attr2, 0, 1);   // pause in mS
 
+			value2 = value2 * speech_parameters[espeakSSML_BREAK_MUL] / 100;
+
 			int wpm = speech_parameters[espeakRATE];
 			espeak_SetParameter(espeakRATE, wpm, 0);
 

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -8,10 +8,11 @@ test_ssml_audio() {
 	TEST_NAME=$1
 	EXPECTED=$2
 	TEST_TEXT=$3
+	OPTS=$4
 
 	echo "testing ${TEST_NAME}"
 	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
-		$VALGRIND src/espeak-ng --stdout -m "${TEST_TEXT}" \
+		$VALGRIND src/espeak-ng --stdout -m "${TEST_TEXT}" ${OPTS} \
 		> actual.txt || exit 1
 	< actual.txt $sha1sum | awk '{ print $1 }' > sum.txt
 	echo "${EXPECTED}" > expected.txt
@@ -56,3 +57,6 @@ test_ssml_audio "<prosody 200%><break 1000ms>" 64213dbaf593b139b0b21840ba938cf59
 ( test_ssml_audio "<prosody 260%><break 1000ms>" 4b4e30a2cfff1889972f013e514e81c1108283a4 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
 ( test_ssml_audio "<prosody 260%><break 1000ms>" 9849f0d27f5641db6da1a8aea82578e83656d323 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || \
 ( test_ssml_audio "<prosody 260%><break 1000ms>" 32a9c2887ec5b7d9d33d5503518ac0d384e43448 "<speak><prosody rate=\"260%\">Break<break time=\"1000ms\"/>test</prosody></speak>" ) || exit 1
+
+# Test break multiplier
+test_ssml_audio "<break 1000ms> mul=10" 9f3b0f34eb605fcecfc573fc215626f634b46756 "<speak>Break<break time=\"1000ms\"/>test</speak>" "--ssml-break=10"


### PR DESCRIPTION
Upstream implementation for feature request on iOS app: https://github.com/espeak-ng/espeak-ng-ios-app/issues/40