### PR TITLE
wavegen: support higher speech rate in embedded commands

### DIFF
--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -119,7 +119,7 @@ int wcmdq_tail = 0;
 
 // pitch,speed,
 const int embedded_default[N_EMBEDDED_VALUES]    = { 0,     50, espeakRATE_NORMAL, 100, 50,  0,  0, 0, espeakRATE_NORMAL, 0, 0, 0, 0, 0, 0 };
-static const int embedded_max[N_EMBEDDED_VALUES] = { 0, 0x7fff, 750, 300, 99, 99, 99, 0, 750, 0, 0, 0, 0, 4, 0 };
+static const int embedded_max[N_EMBEDDED_VALUES] = { 0, 0x7fff, 2000, 300, 99, 99, 99, 0, 2000, 0, 0, 0, 0, 4, 0 };
 
 #if USE_LIBSONIC
 static sonicStream sonicSpeedupStream = NULL;


### PR DESCRIPTION
Fixes #1566 (ref https://github.com/espeak-ng/espeak-ng-ios-app/issues/35)