### PR TITLE
Fix pronunciation of Puyallup

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3052,6 +3052,7 @@ purport		$2
 purportedly	$2
 puree		pjU@reI
 ?3 puttin	pU?n
+puyallup pju:'al@p
 pyjama		p@dZA:m@
 pyrites		paIr'aIti:z
 pythagoras	paIT'ag@r@s


### PR DESCRIPTION
Fix pronunciation of Puyallup ([Wikipedia](https://en.wikipedia.org/wiki/Puyallup,_Washington), [YouTube](https://www.youtube.com/watch?v=RJySijoV5rI)).