### PR TITLE
ci: fix i386

### DIFF
--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -43,7 +43,7 @@ jobs:
         sudo apt-get install ronn kramdown python3
     - name: apt-arch-deps
       if: matrix.os == 'ubuntu'
-      run: "sudo apt-get install libtool-bin valgrind g++-12-multilib linux-libc-dev:${{ matrix.arch }} libpcaudio-dev:${{ matrix.arch }} libsonic-dev:${{ matrix.arch }}"
+      run: "sudo apt-get install libtool-bin valgrind g++-12-multilib linux-libc-dev:${{ matrix.arch }} libpcaudio-dev:${{ matrix.arch }} libsonic-dev:${{ matrix.arch }} libgcc-s1:${{ matrix.arch }}"
     - name: apt-compile-clang
       if: matrix.os == 'ubuntu' && matrix.compiler == 'clang'
       run: sudo apt-get install clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         sudo apt-get install ronn kramdown python3
     - name: apt-arch-deps
       if: matrix.os == 'ubuntu' && matrix.cross == 'no'
-      run: "sudo apt-get install cmake valgrind g++-12-multilib linux-libc-dev:${{ matrix.arch }} libpcaudio-dev:${{ matrix.arch }} libsonic-dev:${{ matrix.arch }} libstdc++-12-dev:${{ matrix.arch }} libc6-dbg:${{ matrix.arch }}"
+      run: "sudo apt-get install cmake valgrind g++-12-multilib linux-libc-dev:${{ matrix.arch }} libpcaudio-dev:${{ matrix.arch }} libsonic-dev:${{ matrix.arch }} libc6-dbg:${{ matrix.arch }} libgcc-s1:${{ matrix.arch }}"
     - name: apt-cross-deps
       if: matrix.cross == 'yes'
       run: sudo apt-get install qemu-user g++-12-${{ matrix.arch }}-${{ matrix.sys }}

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -23,7 +23,7 @@ jobs:
 
         include:
           - arch: x86-32
-            archdeps: "gcc-multilib g++-multilib libpcaudio-dev:i386 libsonic-dev:i386 libc6-dbg:i386"
+            archdeps: "gcc-multilib g++-multilib libpcaudio-dev:i386 libsonic-dev:i386 libc6-dbg:i386 libgcc-s1:i386"
             archconfigflags: "-m32"
 
           - arch: x86-64


### PR DESCRIPTION
OK, now CI is green again. It is github-CI related issue, I think.

The root cause is that libgcc-s1:i386 fails to be installed as dependency (for unknown reason), so it is now installed explicitly.