### PR TITLE
translate: fix uppercase word split during alphabet change

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -1265,7 +1265,7 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 					} else {
 						if (iswlower(prev_in)) {
 							// lower case followed by upper case, possibly CamelCase
-							if (UpperCaseInWord(tr, &sbuf[ix], c) == 0) { // start a new word
+							if ((prev_out != ' ') && UpperCaseInWord(tr, &sbuf[ix], c) == 0) { // start a new word
 								c = ' ';
 								space_inserted = true;
 								prev_in_save = c;
@@ -1276,7 +1276,7 @@ void TranslateClause(Translator *tr, int *tone_out, char **voice_change)
 
 							if ((tr->translator_name == L('n', 'l')) && (letter_count == 2) && (c == 'j') && (prev_in == 'I')) {
 								// Dutch words may capitalise initial IJ, don't split
-							} else if (IsAlpha(next2_in)) {
+							} else if ((prev_out != ' ') && IsAlpha(next2_in)) {
 								// changing from upper to lower case, start new word at the last uppercase, if 3 or more letters
 								c = ' ';
 								space_inserted = true;


### PR DESCRIPTION
Reported by @kirill-jjj.

Before:
```
✗ espeak-ng -x -vru кошKa
k'oS(en)'eI(ru)
✗ espeak-ng -x -vru юMoney
'ju(en)w'0ni(ru)
✗ espeak-ng -x -vru ЮMoney                        
'ju(en)w'0ni(ru)
```

After:
```
✗ espeak-ng -x -vru кошKa 
k'oS(en)k'A:(ru)
✗ espeak-ng -x -vru юMoney
'ju(en)m'Vni(ru)
✗ espeak-ng -x -vru ЮMoney
'ju(en)m'Vni(ru)
```

I have not noticed any negative side-effects and tests are still passing.
But I think there should be a more precise testing, because translator code is very complex (and poorly organised, and not documented, and...)