### PR TITLE
Allow Direct Boot for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
     namespace "com.reecedunn.espeak"
 
     defaultConfig {
-        minSdk 19
+        minSdk 25
         targetSdk 33
         versionCode 22
         versionName "1.52-dev"


### PR DESCRIPTION
Updated minimum Android SDK to API 25, android 7.1. This will allow espeak to be used as a TTS during direct boot, i.e. before decryption of user data. This commit will provide accessibility to AOSP or other roms wishing to integrate TTS/screen reader capabilities without the need to license Google Services.