### PR TITLE
Fix pronunciation of banknote

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -1048,6 +1048,7 @@ banal		beIn@L
 banana		$alt3
 ?3 banana       ba#nan@
 banged		baNgd
+banknote b'aNknoUt
 banquet		baNkwI2t
 barbiturate	bA@b'ItSU@r@t
 barometer	b@r0mI2t3


### PR DESCRIPTION
Correct pronunciation of the word "banknote" ([Wiktionary](https://en.wiktionary.org/wiki/banknote)).