### PR TITLE
Reland Chromium extension

### DIFF
--- a/chromium_extension/AudioStream.js
+++ b/chromium_extension/AudioStream.js
@@ -1,0 +1,251 @@
+class AudioStream {
+  constructor({
+    stdin,
+    recorder = false
+  }) {
+    if (!/^espeak-ng\s/.test(stdin)) {
+      throw new Error(`stdin should begin with "espeak-ng" command`);
+    }
+    // stdin: Command beginning with 'espeak-ng '
+    // Text or SSML with -m option passed
+    this.stdin = stdin;
+    console.log(stdin);
+    this.readOffset = 0;
+    this.duration = 0;
+    this.channelDataLength = 440;
+    this.sampleRate = 22050;
+    this.numberOfChannels = 1;
+    this.init = false;
+    this.id = '<id>';
+    this.ac = new AudioContext({
+      latencyHint: 0,
+    });
+    // this.ac.suspend();
+    this.msd = new MediaStreamAudioDestinationNode(this.ac, {
+      channelCount: this.numberOfChannels,
+    });
+    this.inputController = void 0;
+    this.inputStream = new ReadableStream({
+      start: (_) => {
+        return (this.inputController = _);
+      },
+    });
+    this.inputReader = this.inputStream.getReader();
+    const {
+      stream
+    } = this.msd;
+    this.stream = stream;
+    const [track] = stream.getAudioTracks();
+    this.track = track;
+    this.osc = new OscillatorNode(this.ac, {
+      frequency: 0
+    });
+    this.processor = new MediaStreamTrackProcessor({
+      track
+    });
+    this.generator = new MediaStreamTrackGenerator({
+      kind: 'audio'
+    });
+    const {
+      writable
+    } = this.generator;
+    this.writable = writable;
+    const {
+      readable: audioReadable
+    } = this.processor;
+    this.audioReadable = audioReadable;
+    this.audioWriter = this.writable.getWriter();
+    this.mediaStream = new MediaStream([this.generator]);
+    if (recorder) {
+      this.recorder = new MediaRecorder(this.mediaStream);
+      this.recorder.ondataavailable = ({
+        data
+      }) => {
+        this.data = data;
+      };
+    }
+    this.outputSource = new MediaStreamAudioSourceNode(this.ac, {
+      mediaStream: this.mediaStream,
+    });
+    this.outputSource.connect(this.ac.destination);
+    this.resolve = void 0;
+    this.promise = new Promise((_) => (this.resolve = _));
+    this.osc.connect(this.msd);
+    this.osc.start();
+    this.track.onmute = this.track.onunmute = this.track.onended = (e) => console.log(e);
+    this.abortable = new AbortController();
+    const {
+      signal
+    } = this.abortable;
+    this.signal = signal;
+    this.audioReadableAbortable = new AbortController();
+    const {
+      signal: audioReadableSignal
+    } = this.audioReadableAbortable;
+    this.audioReadableSignal = audioReadableSignal;
+    this.audioReadableSignal.onabort = (e) => console.log(e.type);
+    this.abortHandler = async (e) => {
+      try {
+        await this.disconnect(true);
+      } catch (err) {
+        console.warn(err.message);
+      }
+      console.log(`readOffset:${this.readOffset}, duration:${this.duration}, ac.currentTime:${this.ac.currentTime}`, `generator.readyState:${this.generator.readyState}, audioWriter.desiredSize:${this.audioWriter.desiredSize}`, `inputController.desiredSize:${this.inputController.desiredSize}, ac.state:${this.ac.state}`);
+      if (this.transferableWindow || document.body.querySelector(`iframe[src="${this.src}"]`)) {
+        document.body.removeChild(this.transferableWindow);
+      }
+      this.resolve('Stream aborted.');
+    };
+    this.signal.onabort = this.abortHandler;
+  }
+  async disconnect(abort = false) {
+    if (abort) {
+      this.audioReadableAbortable.abort('AudioStream aborted.');
+    }
+    this.msd.disconnect();
+    this.osc.disconnect();
+    this.outputSource.disconnect();
+    this.track.stop();
+    try {
+      await this.audioWriter.close();
+      await this.audioWriter.closed;
+      await this.inputReader.cancel();
+    } catch (err) {
+      throw err;
+    }
+    this.generator.stop();
+    if (this.recorder && this.recorder.state === 'recording') {
+      this.recorder.stop();
+    }
+    return this.ac.close();
+  }
+  async start() {
+    return this.nativeMessageStream();
+  }
+  async abort() {
+    this.abortable.abort();
+    return this.promise;
+  }
+  async nativeMessageStream() {
+    return new Promise((resolve) => {
+      this.port = chrome.runtime.connect(this.id);
+      const {
+        readable,
+        writable
+      } = new TransformStream();
+      this.stdout = readable;
+      this.writer = writable.getWriter();
+      this.port.onMessage.addListener(async ({
+        value,
+        done
+      }) => {
+        if (done) {
+          this.port.disconnect();
+          return await this.writer.close();
+        }
+        try {
+          await this.writer.ready;
+          await this.writer.write(new Uint8Array(value));
+        } catch (e) {
+          console.log(e.message);
+        } finally {
+          return true;
+        }
+      });
+      this.port.onDisconnect.addListener(this.portDisconnectedResolve);
+      this.port.postMessage(this.stdin);
+      resolve(this.audioStream());
+    }).catch((err) => {
+      throw err;
+    });
+  }
+  async audioStream() {
+    let channelData = [];
+    try {
+      if (this.ac.state === 'suspended') {
+        await this.ac.resume();
+      }
+      await this.ac.resume();
+      await this.audioWriter.ready;
+      await Promise.allSettled([this.stdout.pipeTo(new WritableStream({
+        write: async (value, c) => {
+          let i = 0;
+          if (!this.init) {
+            this.init = true;
+            i = 44;
+          }
+          for (; i < value.buffer.byteLength; i++,
+            this.readOffset++) {
+            if (channelData.length === this.channelDataLength) {
+              this.inputController.enqueue(new Uint8Array(channelData.splice(0, this.channelDataLength)));
+            }
+            channelData.push(value[i]);
+          }
+        },
+        abort(e) {
+          console.error(e.message);
+        },
+        close: async () => {
+          console.log('Done writing input stream.');
+          if (channelData.length) {
+            this.inputController.enqueue(new Uint8Array(channelData.splice(0, channelData.length)));
+          }
+          this.inputController.close();
+          this.source.postMessage('Done writing input stream.', '*');
+        },
+      }), {
+        signal: this.signal
+      }), this.audioReadable.pipeTo(new WritableStream({
+        write: async ({
+          timestamp
+        }) => {
+          const {
+            value,
+            done
+          } = await this.inputReader.read();
+          if (done) {
+            await this.inputReader.closed;
+            try {
+              await this.disconnect();
+            } catch (err) {
+              console.warn(err.message);
+            }
+            console.log(`readOffset:${this.readOffset}, duration:${this.duration}, ac.currentTime:${this.ac.currentTime}`, `generator.readyState:${this.generator.readyState}, audioWriter.desiredSize:${this.audioWriter.desiredSize}`);
+            return await Promise.all([new Promise((resolve) => (this.stream.oninactive = resolve)), new Promise((resolve) => (this.ac.onstatechange = resolve)), ]);
+          }
+          const frame = new AudioData({
+            format: 's16',
+            sampleRate: 22050,
+            numberOfChannels: 1,
+            numberOfFrames: value.length / 2,
+            timestamp,
+            data: value,
+          });
+          this.duration += frame.duration / 10 ** 6;
+          if (this.recorder && this.recorder.state === 'inactive') {
+            this.recorder.start();
+          }
+          await this.audioWriter.write(frame);
+          //gc();
+        },
+        abort(e) {
+          console.error(e.message);
+        },
+        close() {
+          console.log('Done reading input stream.');
+        },
+      }), {
+        signal: this.audioReadableSignal
+      }), ]);
+      this.resolve(this.recorder ? this.data && (await this.data.arrayBuffer()) : 'Done streaming.');
+      return this.promise;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  }
+}
+
+export {
+  AudioStream
+}

--- a/chromium_extension/README.md
+++ b/chromium_extension/README.md
@@ -1,0 +1,127 @@
+<h5>Motivation</h5>
+
+Web Speech API does not support SSML input to the speech synthesis engine https://github.com/WICG/speech-api/issues/10, or the ability to capture the output of `speechSynthesis.speak()` as a`MedaiStreamTrack` or raw audio https://lists.w3.org/Archives/Public/public-speech-api/2017Jun/0000.html.
+
+See [Issue 1115640: [FUGU] NativeTransferableStream](https://bugs.chromium.org/p/chromium/issues/detail?id=1115640).
+
+<h5>Synopsis</h5>
+
+[`"externally_connectable"`](https://developer.chrome.com/docs/extensions/mv3/manifest/externally_connectable/) => Native Messaging => eSpeak NG => `MediaStreamTrack`.
+
+Use local `espeak-ng` with `-m` option set in the browser. 
+
+Output speech sythesis audio as a live `MediaStreamTrack`.
+
+Use [Native Messaging](https://developer.chrome.com/extensions/nativeMessaging), Bash with GNU Core Utiltities to input text and [Speech Synthesis Markup Language](https://www.w3.org/TR/speech-synthesis11/) as STDIN to [`espeak-ng`](https://github.com/espeak-ng/espeak-ng), stream STDOUT in "real-time" as live `MediaStreamTrack`. 
+
+<h5>Install<h5>
+
+<h6>Dependencies</h6>
+
+eSpeak NG [Building eSpeak NG](https://github.com/espeak-ng/espeak-ng/blob/master/docs/building.md#building-espeak-ng).
+ 
+
+```
+git clone https://github.com/guest271314/native-messaging-espeak-ng.git
+cd native-messaging-espeak-ng
+chmod u+x nm_espeak_ng.sh
+ ```
+
+Navigate to `chrome://extensions`, set `Developer mode` to on, click `Load unpacked`, select downloaded git directory.
+
+Note the generated extension ID, substitute that value for `<id>` in `nm_epseakng.json` and `AudioStream.js`.
+
+Substitute full local path to `nm_espeakng.sh` for `/path/to` in `nm_espeakng.json`.
+  
+```
+"allowed_origins": [ "chrome-extension://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/" ]
+```
+
+Copy `nm_espeakng.json` to `NativeMessagingHosts` directory in Chromium or Chrome configuration folder, on Linux, i.e., `~/.config/chromium`; `~/.config/google-chrome-unstable`.
+
+`cp nm_espeakng.json ~/.config/chromium/NativeMessagingHosts`
+
+Reload extension.
+
+<h5>Usage</h5>
+
+On origins listed in `"matches"` array in [`"web_accessible_resources"`](https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/) and `"externally_connectable"` object in `manifest.json`, e.g., at `console`
+
+```
+let text = `So we need people to have weird new
+ideas ... we need more ideas to break it
+and make it better ...
+
+Use it. Break it. File bugs. Request features.
+
+- Soledad Penadés, Real time front-end alchemy, or: capturing, playing,
+  altering and encoding video and audio streams, without
+  servers or plugins!
+<br>  
+von Braun believed in testing. I cannot
+emphasize that term enough – test, test,
+test. Test to the point it breaks.
+
+- Ed Buckbee, NASA Public Affairs Officer, Chasing the Moon
+<br>
+Now watch. ..., this how science works.
+One researcher comes up with a result.
+And that is not the truth. No, no.
+A scientific emergent truth is not the
+result of one experiment. What has to
+happen is somebody else has to verify
+it. Preferably a competitor. Preferably
+someone who doesn't want you to be correct.
+
+- Neil deGrasse Tyson, May 3, 2017 at 92nd Street Y
+<br>
+It’s like they say, if the system fails you, you create your own system.
+
+- Michael K. Williams, Black Market
+<br>
+1. If a (logical or axiomatic formal) system is consistent, it cannot be complete.
+2. The consistency of axioms cannot be proved within their own system.
+
+- Kurt Gödel, Incompleteness Theorem, On Formally Undecidable Propositions of Principia Mathematica and Related Systems`;
+let {AudioStream} = await import('chrome-extension://<id>/AudioStream.js')
+let audioStream = new AudioStream({stdin: `espeak-ng -m --stdout "${text}"`});
+await audioStream.start();
+```
+  
+To record `MediaStreamTrack` pass `recorder: true` (set to `false` by default) to second parameter
+  
+```
+let audioStream = var audioStream = new AudioStream({
+   stdin: `espeak-ng -m --stdout '<voice name="Storm">Hello world.<br></voice>'`, 
+   recorder: true
+});
+let ab = await audioStream.start(); // ArrayBuffer
+let blobURL = URL.createObjectURL(new Blob([ab], {type: 'audio/wav'}));
+```
+  
+Abort the request and audio output.
+  
+```
+await audioStream.abort();
+```
+  
+<h5>References</h5>
+
+- [Include test for setting an SSML document at SpeechSynthesisUtterance .text property within speech-api](https://github.com/web-platform-tests/wpt/issues/8712)
+- [This is again recording from microphone, not from audiooutput device](https://github.com/guest271314/SpeechSynthesisRecorder/issues/14)
+- [Support SpeechSynthesis *to* a MediaStreamTrack](https://github.com/WICG/speech-api/issues/69)
+- [Clarify getUserMedia({audio:{deviceId:{exact:<audiooutput_device>}}}) in this specification mandates capability to capture of audio output device - not exclusively microphone input device](https://github.com/w3c/mediacapture-main/issues/650)
+- [How to modify existing code or build with -m option set for default SSML parsing?](https://github.com/pettarin/espeakng.js-cdn/issues/1)
+- [Issue 795371: Implement SSML parsing at SpeechSynthesisUtterance](https://bugs.chromium.org/p/chromium/issues/detail?id=795371)
+- [Implement SSML parsing at SpeechSynthesisUtterance](https://bugzilla.mozilla.org/show_bug.cgi?id=1425523)
+- [How is a complete SSML document expected to be parsed when set once at .text property of SpeechSynthesisUtterance instance?](https://github.com/WICG/speech-api/issues/10)
+- [How to programmatically send a unix socket command to a system server autospawned by browser or convert JavaScript to C++ souce code for Chromium?](https://stackoverflow.com/questions/48219981/how-to-programmatically-send-a-unix-socket-command-to-a-system-server-autospawne)
+- [<script type="shell"> to execute arbitrary shell commands, and import stdout or result written to local file as a JavaScript module](https://github.com/whatwg/html/issues/3443)
+- [Add execute() to FileSystemDirectoryHandle](https://github.com/WICG/native-file-system/issues/97)
+- [Issue 795371: Implement SSML parsing at SpeechSynthesisUtterance](https://bugs.chromium.org/p/chromium/issues/detail?id=795371)
+- [Implement SSML parsing at SpeechSynthesisUtterance](https://bugzilla.mozilla.org/show_bug.cgi?id=1425523)
+- [How is a complete SSML document expected to be parsed when set once at .text property of SpeechSynthesisUtterance instance?](https://github.com/WICG/speech-api/issues/10)
+- [How to programmatically send a unix socket command to a system server autospawned by browser or convert JavaScript to C++ souce code for Chromium?](https://stackoverflow.com/questions/48219981/how-to-programmatically-send-a-unix-socket-command-to-a-system-server-autospawne)
+- [<script type="shell"> to execute arbitrary shell commands, and import stdout or result written to local file as a JavaScript module](https://github.com/whatwg/html/issues/3443)
+- [Add execute() to FileSystemDirectoryHandle](https://github.com/WICG/native-file-system/issues/97)
+- [SpeechSynthesis *to* a MediaStreamTrack or: How to execute arbitrary shell commands using inotify-tools and DevTools Snippets](https://gist.github.com/guest271314/59406ad47a622d19b26f8a8c1e1bdfd5)

--- a/chromium_extension/background.js
+++ b/chromium_extension/background.js
@@ -1,0 +1,73 @@
+// https://stackoverflow.com/a/62364519
+function base64ToBytesArr(str) {
+  const abc = [
+    ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',
+  ]; // base64 alphabet
+  let result = [];
+
+  for (let i = 0; i < str.length / 4; i++) {
+    let chunk = [...str.slice(4 * i, 4 * i + 4)];
+    let bin = chunk
+      .map((x) => abc.indexOf(x).toString(2).padStart(6, 0))
+      .join('');
+    let bytes = bin.match(/.{1,8}/g).map((x) => +('0b' + x));
+    result.push(
+      ...bytes.slice(0, 3 - (str[4 * i + 2] == '=') - (str[4 * i + 3] == '='))
+    );
+  }
+  return result;
+}
+
+globalThis.name = chrome.runtime.getManifest().short_name;
+globalThis.externallyConnectablePort = null;
+globalThis.nativeMessagingPort = null;
+chrome.runtime.onConnectExternal.addListener((port) => {
+  globalThis.externallyConnectablePort = port;
+  globalThis.externallyConnectablePort.onMessage.addListener((message) => {
+    if (message === 'disconnect') {
+      globalThis.nativeMessagingPort.disconnect();
+      globalThis.externallyConnectablePort.disconnect();
+    }
+    if (!globalThis.nativeMessagingPort) {
+      globalThis.nativeMessagingPort = chrome.runtime.connectNative(globalThis.name);
+      globalThis.nativeMessagingPort.onMessage.addListener((nativeMessage) => {
+        const {
+          done,
+          value
+        } = nativeMessage;
+        if (!done) {
+          nativeMessage.value = base64ToBytesArr(nativeMessage.value);
+        }
+        globalThis.externallyConnectablePort.postMessage(nativeMessage)
+        if (done) {
+          globalThis.nativeMessagingPort.disconnect();
+        }
+      });
+      globalThis.nativeMessagingPort.postMessage(message);
+    }
+  });
+  globalThis.externallyConnectablePort.onDisconnect.addListener((_) => {
+    console.log('Disconnected');
+    globalThis.externallyConnectablePort = null;
+    globalThis.nativeMessagingPort = null;
+    if (chrome.runtime.lastError) {
+      console.warn(chrome.runtime.lastError);
+    }
+  });
+});
+
+// Log ID to console on click of extension icon
+chrome.action.onClicked.addListener(async (tab) => {
+  const manifest = chrome.runtime.getManifest();
+  console.log(tab, manifest.externally_connectable.matches);
+  await chrome.scripting.executeScript({
+    target: {
+      tabId: tab.id
+    },
+    world: 'MAIN',
+    args: [chrome.runtime.id],
+    func: (id) => {
+      console.log(id);
+    }
+  })
+});

--- a/chromium_extension/manifest.json
+++ b/chromium_extension/manifest.json
@@ -1,0 +1,41 @@
+{
+  "name": "Native Messaging espeak-ng",
+  "short_name": "nm_espeakng",
+  "description": "externally_connectable => Native Messaging => eSpeak NG => MediaStreamTrack",
+  "version": "2.0",
+  "manifest_version": 3,
+  "permissions": [
+    "nativeMessaging",
+    "activeTab",
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "*js"
+      ],
+      "matches": [
+        "https://github.com/*"
+      ],
+      "extensions": []
+    }
+  ],
+  "externally_connectable": {
+    "matches": [
+      "https://*.github.com/*"
+    ],
+    "ids": [
+      "*"
+    ]
+  },
+  "action": {},
+  "author": "guest271314",
+  "homepage_url": "https://github.com/guest271314/native-messaging-espeak-ng/"
+}

--- a/chromium_extension/nm_espeakng.json
+++ b/chromium_extension/nm_espeakng.json
@@ -1,0 +1,7 @@
+{
+  "name": "nm_espeakng",
+  "description": "eSpeak NG => MediaStreamTrack",
+  "path": "/path/to/nm_espeakng.sh",
+  "type": "stdio",
+  "allowed_origins": [ "chrome-extension://<id>/" ]
+}

--- a/chromium_extension/nm_espeakng.sh
+++ b/chromium_extension/nm_espeakng.sh
@@ -1,0 +1,54 @@
+#!/bin/env -S bash -b -o posix -o xtrace
+
+stream() {
+  eval "$1" | base64 -w 0 -
+}
+
+getMessage() {
+  # https://lists.gnu.org/archive/html/help-bash/2023-06/msg00057.html
+  length=$(head -q -z --bytes=4 -| od -An -td4 -)
+  message=$(head -q -z --bytes=$((length)) -)
+  # Remove leading, trailing double quotation marks
+  # command="${message:1:-1}"
+  # Remove escaping of double quotation marks around text parameter
+  command=$(echo "${message:1:-1}" | tr -d '\\') 
+  while IFS= read -r -n16384 line
+    do
+      data='{"value":'
+      data+=\"$line\"
+      data+=',"done": false}'
+      sendMessage "$data" # "${data}\"${value}\}" #+ \"$line\" + '}' #\""$(cat data.txt)\"" #message
+    done < <(stream "$command")
+  sendMessage '{"value":null,"done":true}'
+}
+
+# https://stackoverflow.com/a/24777120
+sendMessage() {
+  message="$*"
+  # Calculate the byte size of the string.
+  # NOTE: This assumes that byte length is identical to the string length!
+  # Do not use multibyte (unicode) characters, escape them instead, e.g.
+  # message='"Some unicode character:\u1234"'
+  messagelen=${#message}
+  # Convert to an integer in native byte order.
+  # If you see an error message in Chrome's stdout with
+  # "Native Messaging host tried sending a message that is ... bytes long.",
+  # then just swap the order, i.e. messagelen1 <-> messagelen4 and
+  # messagelen2 <-> messagelen3
+  messagelen1=$(((messagelen) & 0xFF))
+  messagelen2=$(((messagelen >> 8) & 0xFF))
+  messagelen3=$(((messagelen >> 16) & 0xFF))
+  messagelen4=$(((messagelen >> 24) & 0xFF))
+  # Print the message byte length followed by the actual message.
+  printf "$(printf '\\x%x\\x%x\\x%x\\x%x' \
+    $messagelen1 $messagelen2 $messagelen3 $messagelen4)%s" "$message"
+}
+
+main() {
+  # Loop forever, to deal with chrome.runtime.connectNative
+  while true; do
+    getMessage
+  done
+}
+
+main


### PR DESCRIPTION
The rationale for removing chromium_extension is here https://github.com/espeak-ng/espeak-ng/pull/1598

- It is not a part of eSpeak-NG, nor useful wrapper/adapter
- It is not properly documented and maintained
- It is unsafe (running PHP daemon with user privileges and [launch ANY](https://github.com/espeak-ng/espeak-ng/blob/6d7101c03c865c625d6c92b8dda15db0859fe3c2/chromium_extension/index.php#L8) received command via [passthru](https://www.php.net/manual/en/function.passthru.php) - seriously?)

and 

> @guest271314 you can avoid native code at all, by using WebAssembly code built with emscripten (that included in espeak codebase).


The updated code still uses Native Messaging to run a Bash script that streams `--stdout` to the browser.

The code has always been properly maintained and documented.

Again, this uses only Bash with GNU Core Utilities `tail` shipped by default in Debian and *buntu Linux distributions to achieve the requirement.

I'll emphasize here again that https://github.com/espeak-ng/espeak-ng/tree/master/emscripten is an incomplete compilation of eSpeak NG; SSML input is not supported. Further, the code uses the deprecated Web Audio API `ScriptProcessorNode`, so that code is not a solution to using eSpeak NG in Web pages.

The code in the PR uses `MediaStreamTrackProcessor` to create a live `MediaStreamTrack` from parsed WAV file output by `--stdout`.

If you want to advocate using https://github.com/espeak-ng/espeak-ng/tree/master/emscripten you need to update the code to support SSML input and remove use of deprecated Web Audio API `ScriptNodeProcessor`. It also looks like that code is not maintained anymore.