### PR TITLE
Fix pronunciation of name "Shea"

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -3368,6 +3368,7 @@ shaoni	SaI'oUni
 shareable	Se@@b@L
 sharpie		$alt2
 shazam		$alt3
+shea S'eI $only
 shebang		SI#baN
 sheepherder	$alt4
 shenanigan	SI#nanIg@n


### PR DESCRIPTION
This PR fixes pronunciation of the name "Shea" (pronounced like "Shay").