### PR TITLE
Fix pronunciation of bateau

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -1065,6 +1065,7 @@ bass		$alt6 //beIs
 bassist		$alt6 //beIsIst
 baste		$alt6 //beIst
 bastion		basti@n
+bateau ba'toU
 batman		batman
 ?3 baton	$alt3
 battalion	$alt3


### PR DESCRIPTION
This PR fixes the pronunciation of "bateau" in English, per [Wiktionary](https://en.wiktionary.org/wiki/bateau).