### PR TITLE
Fixed missing function declaration that prevents build on modern C compilers

### DIFF
--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -669,6 +669,7 @@ void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
 
 int TranslateWord(Translator *tr, char *word1, WORD_TAB *wtab, char *word_out);
 void TranslateClause(Translator *tr, int *tone, char **voice_change);
+void TranslateClauseWithTerminator(Translator *tr, int *tone_out, char **voice_change, int *terminator_out);
 
 void SetVoiceStack(espeak_VOICE *v, const char *variant_name);
 


### PR DESCRIPTION
Without this function declaration, the build fails on modern C compilers (ISO C99). This affects e.g. builds on Apple Silicon. This fix is also needed in order to compile [rhasspy/piper](https://github.com/rhasspy/piper) on Apple Silicon.

Build error was:
```
/Users/leo/Development/piper/build/p/src/piper_phonemize_external-build/e/src/espeak_ng_external/src/libespeak-ng/speech.c:872:3: error: call to undeclared function 'TranslateClauseWithTerminator'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  TranslateClauseWithTerminator(translator, NULL, NULL, terminator);
  ^
1 error generated.
```