### PR TITLE
Small fixes for Polish

### DIFF
--- a/dictsource/pl_rules
+++ b/dictsource/pl_rules
@@ -646,7 +646,6 @@ _salce) son (_++   =sOn
         skj (A     S
 
 .group sc
-        sch        S
     pa) sch (a     sx
         sch (abA_  sx
         sch (ab_   sx
@@ -796,7 +795,6 @@ _anasta) si (L03_  sj
 .group	 th
     _e) th (anak   t
      _) the (_     dE
-        th         s
         th (ie_    s;
      _) th         t
      _) thank      fENk


### PR DESCRIPTION
This PR removes two unnecessary rules in Polish. They both make sense for English (probably someone just copied them from the English file), but make pronunciation of several Polish words incorrect.