### PR TITLE
Fixing Belarusian

### DIFF
--- a/dictsource/be_list
+++ b/dictsource/be_list
@@ -2,38 +2,39 @@
 // Spelling-to-phoneme words for Belarusian
 
 // Letter names
-а       a $u
-б       b $u
-в       vE $u
-г       QE $u
-д       dE $u
-е       jE $u
-ё       jO $u
-ж       z. $u
-з       z $u
-і       i $u
-й       i $u
-к       ka $u
-л       El  $u
-м       Em $u
-н       En $u
-о       O   $u
-п       pE  $u
-р       Er  $u
-с       Es  $u
-т       tE  $u
-у       u $u
-ў       w $u
-ф       Ef $u
-х       xa $u
-ц       tsE $u
-ч       ts.E $u
-ш       s.a $u
-ы       i" $u
+а       a 
+б       be
+в       vE
+г       QE
+д       dE
+е       jE
+ё       jO
+ж       z.E
+з       zE
+і       i
+й       in;Esklad'OvajE
+к       ka
+л       El
+м       Em 
+н       En
+о       O
+п       pE
+р       Er
+с       Es
+т       tE
+у       u
+ў       w
+ф       Ef
+х       xa
+ц       tsE
+ч       ts.E
+ш       s.a
+ы       i"
 ь       m;'ak;:i||znak
-э       E $u
-ю       ju $u
-я       ja $u
+э       E
+ю       ju
+я       ja
+
 
 // Numbers
 _0     n'ul;

--- a/phsource/ph_belarusian
+++ b/phsource/ph_belarusian
@@ -17,7 +17,7 @@ phoneme i"
 endphoneme
 
 phoneme Q
-  import_phoneme base1/Q"
+  import_phoneme base1/Q
   ipa ɣ
 endphoneme
 
@@ -27,19 +27,13 @@ phoneme ts
   ipa t͡s
 endphoneme
 
-phoneme ts;
-  CALL base1/tS;
-  voicingswitch dz;
-  ipa t͡sʲ
-endphoneme
-
 phoneme ts.
   vls pla afr sib
   ipa ʈ͡ʂ
   lengthmod 2
   voicingswitch dz.
   Vowelin f1=0  f2=2300 200 400  f3=-100 80
-  WAV(ustop/tsh_sr, 50)
+  WAV(ustop/ts_rfx)
 endphoneme
 
 phoneme dz
@@ -48,20 +42,14 @@ phoneme dz
   ipa d͡z
 endphoneme
 
-phoneme dz;
-  import_phoneme pl/dz;
-  CALL base1/dZ;
-  voicingswitch ts;
-  ipa d͡zʲ
-endphoneme
-
 phoneme dz.
   vcd pla afr sib
   ipa ɖ͡ʐ
   lengthmod 5
-  voicingswitch ts.
-  Vowelin f1=2  f2=2300 200 400  f3=100 80
-  Vowelout f1=2  f2=2300 250 300  f3=100 80 brk
+  voicingswitch tS
+  Vowelin f1=2  f2=1900 100 300  f3=100 80
+  Vowelout f1=2  f2=1900 100 300  f3=100 80 brk
+  FMT(dzh/dzh2) addWav(ustop/tsh2, 80)
 endphoneme
 
 phoneme r
@@ -73,17 +61,61 @@ phoneme r
 endphoneme
 
 phoneme s;
-  import_phoneme base1/s;
-  ipa sʲ
+  vls pal frc sib pzd
+  ipa ʂ
+  voicingswitch z;
+  lengthmod 3
+  Vowelin  f1=1  f2=2700 400 600  f3=200 70 rate len=70
+  Vowelout f1=1  f2=2700 400 600  f3=200 70 rate len=70
+
+  IF nextPh(isPause) THEN
+    WAV(ufric/s_pzd_)
+  ENDIF
+  WAV(ufric/s_pzd)
 endphoneme
 
 phoneme z;
-  import_phoneme base1/z;
-  ipa zʲ
+  vcd alp sib frc
+  ipa ʑ
+  voicingswitch s;
+  lengthmod 6
+  Vowelin  f1=2  f2=2700 400 600  f3=300 80 rate len=70
+  Vowelout f1=2  f2=2300 250 300  f3=-300 80 brk
+
+  IF nextPh(isPause2) THEN
+    FMT(voc/z_pzd_) addWav(ufric/s_pzd_, 80)
+  ENDIF
+  FMT(voc/z_pzd) addWav(ufric/s_pzd, 80)
 endphoneme
 
-phoneme ;
+phoneme ;     // linking j, used between (i) vowels and a following vowel
+              // also to palatalize consonants
   liquid pzd
   lengthmod 0
-  ipa ʲ
+
+  IF prevPh(#i) THEN
+    ipa NULL   // linking after i vowel, don't show in ipa
+  ENDIF
+
+  IF nextPh(isNotVowel) THEN
+    ChangePhoneme(NULL)   // this is to ignore this phoneme if not before a vowel
+  ENDIF
+
+  NextVowelStarts
+    VowelStart(j2/j2@)
+    VowelStart(j2/j2a)
+    VowelStart(j2/j2e)
+    VowelStart(j2/j2i)
+    VowelStart(j2/j2o)
+    VowelStart(j2/j2u)
+  EndSwitch
+
+  IF prevPh(#i) THEN
+    VowelEnding(j2/xj2, -40)
+  ENDIF
+
+  IF prevPh(isPause) THEN
+    FMT(j2/_j2)
+  ENDIF
 endphoneme
+


### PR DESCRIPTION
Fixing Belarusian for:
-unable to have unstressed letters from thihs alphabet
-fixing phonemes pronunciation (because is not sounding pronounciations like a Belarusian)