### PR TITLE
remove some unnecessary conversions from 'c' to 'k' in Polish

### DIFF
--- a/dictsource/pl_rules
+++ b/dictsource/pl_rules
@@ -77,25 +77,10 @@
    _ar) c (adią_   k
    _ar) c (adię_   k
      _) c (alend   k
-        cal (l     kO
-        cal (lA    ka
-        c (alv     k
         caly (ps   kali
-     _) ca (m      kE
-     _) c (amembert ka
-     _) c (an      k
   cose) c (ans     k
-     _) c (app     k
-     _) c (aps_    k
-     _) c (apslo   k
-     _) c (arav    k
-     _) c (arl     k
-     _) c (arp     k
-     _) c (art     k
      _) c (arv     k
         casc       kask
-        c (at_     k
-        c (ata_    k
         c (atami_  k
         c (atem_   k
         c (ato_    k


### PR DESCRIPTION
Next PR removing rules which ,make sense for English, but should not be present in the Polish language files.