### PR TITLE
pt_list: add dollar

### DIFF
--- a/dictsource/pt_list
+++ b/dictsource/pt_list
@@ -83,6 +83,7 @@ _#9	tab
 %	pors'eINtU	$max3
 &	_'e_
 @	ax'ob&
+$	d'olaR
 €	'eU*U
 £	l'ibR&
 ¥	j'eNy


### PR DESCRIPTION
Add the Portuguese pronunciation for the dollar. Currently it's pronounced "sifR'&U~" as per the rule at https://github.com/espeak-ng/espeak-ng/blob/cb62d93fd7b61d8593b9ae432e6e2a78e3711a77/dictsource/pt_rules#L1312 