### PR TITLE
Android: Set a default English voice

### DIFF
--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2024 Bill Dengler
  * Copyright (C) 2022 Beka Gozalishvili
  * Copyright (C) 2012-2015 Reece H. Dunn
  * Copyright (C) 2011 Google Inc.
@@ -175,6 +176,11 @@ public class TtsService extends TextToSpeechService {
         final Pair<Voice, Integer> match = findVoice(language, country, variant);
         switch (match.second) {
             case TextToSpeech.LANG_AVAILABLE:
+                // Some language codes don't map exactly to eSpeak voices.
+                // Set a sensible default country.
+                if (language.equals("en") || language.equals("eng")) {
+                    return new Pair<>(findVoice(language, "GBR", "").first, match.second);
+                }
                 if (language.equals("fr") || language.equals("fra")) {
                     return new Pair<>(findVoice(language, "FRA", "").first, match.second);
                 }
@@ -188,6 +194,7 @@ public class TtsService extends TextToSpeechService {
                 }
                 return new Pair<>(findVoice(language, country, "").first, match.second);
             default:
+//cactus
                 return match;
         }
     }


### PR DESCRIPTION
The language code "en" doesn't map onto an eSpeak voice, but Android clients/the system often use "eng". This causes erratic behaviour: in some cases, the RP voice is used. In others, the US voice is used. Since the standard UK English voice is eSpeak's original English voice, maps onto "en" when using the command line implementation, and is (in my opinion) eSpeak's highest quality voice by far, this PR explicitly makes GBR the default country for English when none is specified.

This doesn't solve the problem in any other languages where it might exist. I tried a more generalized approach in #1885, but there are problems when reading web content with inline variant changes within a language. A more general approach should be considered, but in the meantime, this should be merged soon as it provides significant quality of life improvements in eSpeak's primary language.

Closes #970.