### PR TITLE
German: fixed the words balance, behilflich and garage

### DIFF
--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -651,7 +651,6 @@ bandagier	bandaZ'i:r
 beben	be:b@n
 bebung	b'e:bUN
 beere	be:r@
-behilflich	byh'Ilf-liC
 bestie	bEstI@
 best	bEst
 bestem	b'Est@m

--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -644,7 +644,7 @@ aventurin	avEntu:r'i:n
 ave	A:vE
 
 baguette	bag'Et
-balance	bal'aNz
+balance	bal'aNs
 balkan	$1
 balkon	$2
 bandagier	bandaZ'i:r

--- a/dictsource/de_list
+++ b/dictsource/de_list
@@ -644,12 +644,14 @@ aventurin	avEntu:r'i:n
 ave	A:vE
 
 baguette	bag'Et
+balance	bal'aNz
 balkan	$1
 balkon	$2
 bandagier	bandaZ'i:r
 beben	be:b@n
 bebung	b'e:bUN
 beere	be:r@
+behilflich	byh'Ilf-liC
 bestie	bEstI@
 best	bEst
 bestem	b'Est@m
@@ -736,6 +738,7 @@ friedvoll	fr'i:tfOl
 furchen	fUrC@n
 furie	$alt
 
+garage	gaR'AZ@
 geben	ge:b@n
 gebt	ge:bt
 gegenstand	$1

--- a/phsource/mbrola/de6
+++ b/phsource/mbrola/de6
@@ -1,6 +1,10 @@
 
 2  w  i:     0  v   // i:w  not allowed
 
+34 I  h     10  i: I  // fix stressed I sound by using 10% i:
+64 @  NULL   0  @     //default @
+2  @  b     40  e: @   //fix b@ sound.
+
 0  l/2 NULL 40  l
 0  l/ NULL   0  l
 0  r/ NULL   0  6

--- a/phsource/mbrola/de6
+++ b/phsource/mbrola/de6
@@ -1,9 +1,9 @@
 
 2  w  i:     0  v   // i:w  not allowed
 
-34 I  h     10  i: I  // fix stressed I sound by using 10% i:
-64 @  NULL   0  @     //default @
-2  @  b     40  e: @   //fix b@ sound.
+34 I  h     10  i: I  // fix stressed hI sound by using 10% i:
+64 @  NULL   0  @     //default @ for word endings
+2  @  b     40  e: @  //fix b@ sound.
 
 0  l/2 NULL 40  l
 0  l/ NULL   0  l


### PR DESCRIPTION
I did some major improvements to the words balance and garage and a minor improvement to the word behilflich.
This pull request supersedes the pull request https://github.com/espeak-ng/espeak-ng/pull/1875 as my pronunciation of the word garage sounds more natural.