### PR TITLE
Revert IPA change to question marks

### DIFF
--- a/phsource/ph_german
+++ b/phsource/ph_german
@@ -208,6 +208,7 @@ endphoneme
 
 phoneme y
   vwl starttype #u endtype #u
+  ipa ʏ
   length 100
   IF nextPh(*) THEN
     length 110
@@ -363,7 +364,7 @@ endphoneme
 
 phoneme iR  // TEST "vier" = [f'iR] not successful
   vwl starttype #i endtype #@
-  ipa i?
+  ipa iɐ
   flag1
   length 240
   FMT(vdiph2/i@_3)
@@ -372,7 +373,7 @@ endphoneme
 
 phoneme UR
   vwl starttype #u endtype #@
-  ipa ??
+  ipa ʊɐ
   flag1
   length 180
   FMT(vwl_de/uu_@)


### PR DESCRIPTION
Fixes #890 #616 

essentially reverts this commit https://github.com/espeak-ng/espeak-ng/commit/e07002a1c9e517e0d6de8dc49f3192712b860996