### PR TITLE
Fix use-of-uninitialized-value

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -1607,6 +1607,7 @@ void TranslateClauseWithTerminator(Translator *tr, int *tone_out, char **voice_c
 			if (dict_flags & FLAG_SPELLWORD) {
 				// redo the word, speaking single letters
 				for (pw = word; *pw != ' ';) {
+					memset(number_buf, 0, sizeof(number_buf));
 					memset(number_buf, ' ', 9);
 					nx = utf8_in(&c_temp, pw);
 					memcpy(&number_buf[2], pw, nx);


### PR DESCRIPTION
84e967c0a2ac ("Update translate.c") (sic) dropped the initialization of number_buf, breaking the CI on ubuntu amd64 clang+msan, ubuntu amd64/i386 gcc/clang+valgrind,

While this probably deserves cleaning up, we'd rather not break the CI, to be able to properly track regressions.