### PR TITLE
Add Windows MSBuild pipeline

### DIFF
--- a/.github/workflows/windows-msbuild.yml
+++ b/.github/workflows/windows-msbuild.yml
@@ -1,0 +1,43 @@
+name: windows-msbuild
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    name: "build: ${{ matrix.config }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, Release]
+
+    steps:
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Install Windows 8.1 SDK
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
+          Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
+      - name: Install WiX
+        run: dotnet tool install --global wix
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Checkout pcaudiolib
+        uses: actions/checkout@v4
+        with:
+          repository: "espeak-ng/pcaudiolib"
+          path: "src/pcaudiolib"
+      - name: Do build
+        working-directory: "src/windows"
+        run: msbuild espeak-ng.sln /p:Configuration=${{ matrix.config }} /p:Platform=x64
+      - name: Upload MSI installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-${{ matrix.config }}-msi
+          path: "src/windows/installer/bin/x64/${{ matrix.config }}/espeak-ng.msi"

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -75,7 +75,7 @@ extern "C"
 
 // will look for espeak_data directory here, and also in user's home directory
 #ifndef PATH_ESPEAK_DATA
-   #define PATH_ESPEAK_DATA  "/usr/share/espeak-ng-data"
+   #define PATH_ESPEAK_DATA ("%cespeak-ng-data", PATHSEP)
 #endif
 
 void cancel_audio(void);

--- a/src/windows/data.vcxproj
+++ b/src/windows/data.vcxproj
@@ -92,9 +92,6 @@
   <Target Name="an" Inputs="$(ProjectDir)..\..\dictsource\an_rules;$(ProjectDir)..\..\dictsource\an_list" Outputs="$(ProjectDir)..\..\espeak-ng-data\an_dict" DependsOnTargets="Phonemes">
     <Exec Command="cd $(ProjectDir)..\..\dictsource &amp;&amp; $(TargetDir)espeak-ng.exe --path=$(ProjectDir)..\.. --compile=an" />
   </Target>
-  <Target Name="ar" Inputs="$(ProjectDir)..\..\dictsource\ar_rules;$(ProjectDir)..\..\dictsource\ar_list;$(ProjectDir)..\..\dictsource\ar_listx" Outputs="$(ProjectDir)..\..\espeak-ng-data\ar_dict" DependsOnTargets="Phonemes">
-    <Exec Command="cd $(ProjectDir)..\..\dictsource &amp;&amp; $(TargetDir)espeak-ng.exe --path=$(ProjectDir)..\.. --compile=ar" />
-  </Target>
   <Target Name="as" Inputs="$(ProjectDir)..\..\dictsource\as_rules;$(ProjectDir)..\..\dictsource\as_list" Outputs="$(ProjectDir)..\..\espeak-ng-data\as_dict" DependsOnTargets="Phonemes">
     <Exec Command="cd $(ProjectDir)..\..\dictsource &amp;&amp; $(TargetDir)espeak-ng.exe --path=$(ProjectDir)..\.. --compile=as" />
   </Target>
@@ -428,6 +425,6 @@
   <Target Name="yue" Inputs="$(ProjectDir)..\..\dictsource\yue_rules;$(ProjectDir)..\..\dictsource\yue_list;$(ProjectDir)..\..\dictsource\yue_listx" Outputs="$(ProjectDir)..\..\espeak-ng-data\yue_dict" DependsOnTargets="Phonemes;Extdict">
     <Exec Command="cd $(ProjectDir)..\..\dictsource &amp;&amp; $(TargetDir)espeak-ng.exe --path=$(ProjectDir)..\.. --compile=yue" />
   </Target>
-  <Target Name="Dictionaries" DependsOnTargets="af;am;an;ar;as;az;ba;be;bg;bn;bpy;bs;ca;chr;cmn;cs;cv;cy;da;de;el;en;eo;es;et;eu;fa;fi;fr;ga;gd;gn;grc;gu;hak;haw;he;hi;hr;ht;hu;hy;ia;id;io;is;it;ja;jbo;ka;kk;kl;kn;ko;kok;ku;ky;la;lb;lfn;lt;lv;mi;mk;ml;mr;ms;mt;my;nci;ne;nl;no;nog;om;or;pa;pap;piqd;pl;pt;py;qdb;quc;qu;qya;ro;ru;sd;shn;si;sjn;sk;sl;smj;sq;sr;sv;sw;ta;te;th;tk;tn;tr;tt;ug;uk;ur;uz;vi;xex;yue" />
+  <Target Name="Dictionaries" DependsOnTargets="af;am;an;as;az;ba;be;bg;bn;bpy;bs;ca;chr;cmn;cs;cv;cy;da;de;el;en;eo;es;et;eu;fa;fi;fr;ga;gd;gn;grc;gu;hak;haw;he;hi;hr;ht;hu;hy;ia;id;io;is;it;ja;jbo;ka;kk;kl;kn;ko;kok;ku;ky;la;lb;lfn;lt;lv;mi;mk;ml;mr;ms;mt;my;nci;ne;nl;no;nog;om;or;pa;pap;piqd;pl;pt;py;qdb;quc;qu;qya;ro;ru;sd;shn;si;sjn;sk;sl;smj;sq;sr;sv;sw;ta;te;th;tk;tn;tr;tt;ug;uk;ur;uz;vi;xex;yue" />
 
 </Project>

--- a/src/windows/installer/Product.wxs
+++ b/src/windows/installer/Product.wxs
@@ -69,9 +69,6 @@
                 <Component Id="an_dict" Guid="398D043F-2306-4465-AF86-0E71B8919E82">
                     <File Id="an_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\an_dict" />
                 </Component>
-                <Component Id="ar_dict" Guid="DA018A76-E180-413D-A4FC-DC42822EE9DC">
-                    <File Id="ar_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\ar_dict" />
-                </Component>
                 <Component Id="as_dict" Guid="F414CBF2-A37F-4B20-8568-E02F0005E5AC">
                     <File Id="as_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\as_dict" />
                 </Component>
@@ -143,9 +140,6 @@
                 </Component>
                 <Component Id="fi_dict" Guid="A940BAEF-840D-4A76-AF8E-1971E88F9057">
                     <File Id="fi_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\fi_dict" />
-                </Component>
-                <Component Id="fo_dict" Guid="68CBDAF4-8D0E-44CC-8523-3E0CF5343024">
-                    <File Id="fo_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\fo_dict" />
                 </Component>
                 <Component Id="fr_dict" Guid="437EC744-1AF9-49CF-8058-BEBDE579EF79">
                     <File Id="fr_dict" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\fr_dict" />
@@ -535,9 +529,6 @@
                         <Component Id="da" Guid="F2056D5A-95BE-4141-9884-BDECCD20911F">
                             <File Id="da" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\gmq\da" />
                         </Component>
-                        <Component Id="fo" Guid="0786F902-D75C-4A41-956B-A6D2F25180A2">
-                            <File Id="fo" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\gmq\fo" />
-                        </Component>
                         <Component Id="is" Guid="D77DC66C-17BA-425C-A1E4-18D9CAC03284">
                             <File Id="is" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\gmq\is" />
                         </Component>
@@ -742,9 +733,6 @@
                     <Directory Id="sem" Name="sem">
                         <Component Id="am" Guid="6DC9AEC3-4C3F-4C46-B10A-765AEDFD95BE">
                             <File Id="am" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\sem\am" />
-                        </Component>
-                        <Component Id="ar" Guid="B7B2CAC1-7B02-4F3D-BA32-D278439278A1">
-                            <File Id="ar" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\sem\ar" />
                         </Component>
                         <Component Id="he" Guid="40CD0730-60BE-4B57-89B7-AFCF1215D717">
                             <File Id="he" KeyPath="yes" Source="$(var.ProjectDir)\..\..\..\espeak-ng-data\lang\sem\he" />
@@ -1471,7 +1459,6 @@
       <ComponentRef Id="af_dict" />
       <ComponentRef Id="am_dict" />
       <ComponentRef Id="an_dict" />
-      <ComponentRef Id="ar_dict" />
       <ComponentRef Id="as_dict" />
       <ComponentRef Id="az_dict" />
       <ComponentRef Id="ba_dict" />
@@ -1496,7 +1483,6 @@
       <ComponentRef Id="eu_dict" />
       <ComponentRef Id="fa_dict" />
       <ComponentRef Id="fi_dict" />
-      <ComponentRef Id="fo_dict" />
       <ComponentRef Id="fr_dict" />
       <ComponentRef Id="ga_dict" />
       <ComponentRef Id="gd_dict" />
@@ -1678,7 +1664,6 @@
       <ComponentRef Id="ro" />
       <ComponentRef Id="gn" />
       <ComponentRef Id="am" />
-      <ComponentRef Id="ar" />
       <ComponentRef Id="he" />
       <ComponentRef Id="mt" />
       <ComponentRef Id="cmn" />
@@ -1702,7 +1687,6 @@
       <ComponentRef Id="uz" />
       <ComponentRef Id="et" />
       <ComponentRef Id="fi" />
-      <ComponentRef Id="fo" />
       <ComponentRef Id="hu" />
       <ComponentRef Id="smj" />
       <ComponentRef Id="be" />


### PR DESCRIPTION
This PR adds, in addition to the existing windows CMake pipeline, a Github Action to build release and debug installers for Windows. It includes the espeak-ng-data path fix from https://github.com/espeak-ng/espeak-ng/issues/1705. Unfortunately, in order to build successfully, it removes Arabic and Faroese from the Windows installer for the reasons listed in https://github.com/espeak-ng/espeak-ng/issues/1774 (which incidentally, I think, demonstrates the value of having this as a separate CI pipeline)