### PR TITLE
Fix new line conversion on windows

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -222,7 +222,7 @@ static int OpenWavFile(char *path, int rate)
 	f_wavfile = NULL;
 	if (path[0] != 0) {
 		if (strcmp(path, "stdout") == 0) {
-#if PLATFORM_WINDOWS
+#ifdef _WIN32
 			// prevent Windows adding 0x0d before 0x0a bytes
 			_setmode(_fileno(stdout), _O_BINARY);
 #endif


### PR DESCRIPTION
`#if PLATFORM_WINDOWS` doesn't work for some reason.

Fix suggested by @beqabeqa473