### PR TITLE
prevent data loss when converting intptr_t to int

### DIFF
--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -1343,7 +1343,7 @@ static int WavegenFill2(void)
 #endif
 		case WCMD_MARKER:
 			marker_type = q[0] >> 8;
-			MarkerEvent(marker_type, q[1], q[2], q[3], out_ptr);
+			MarkerEvent(marker_type, q[1], * (int *) & q[2], * ((int *) & q[2] + 1), out_ptr);
 			break;
 		case WCMD_AMPLITUDE:
 			SetAmplitude(length, (unsigned char *)q[2], q[3]);


### PR DESCRIPTION
q[2] and q[3] are of type intptr_t, i.e. typically 64-bit, but MarkerEvent expects 32-bit ints instead, so that the 4 upper bytes are lost in the conversion. In the case of WCMD_MARKER, these four discarded bytes could contain phoneme codes. This case is somewhat rare on little-endian systems, where "upper" means 'last', but usual on big-endian systems, where "upper" means 'first' (we noticed the bug when testing on a s390x processor). The fix works on 64-bit (where all 8 phoneme bytes are in q[2]) as well as on 32-bit (where the 8 phoneme bytes are distributed over q[2] and q[3]).

fixes #1970