### PR TITLE
espeakEVENT_SAMPLERATE: Do not mark as internal

### DIFF
--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -94,7 +94,7 @@ typedef enum {
   espeakEVENT_END = 5,             // End of sentence or clause
   espeakEVENT_MSG_TERMINATED = 6,  // End of message
   espeakEVENT_PHONEME = 7,         // Phoneme, if enabled in espeak_Initialize()
-  espeakEVENT_SAMPLERATE = 8       // internal use, set sample rate
+  espeakEVENT_SAMPLERATE = 8       // Set sample rate
 } espeak_EVENT_TYPE;
 
 


### PR DESCRIPTION
When e.g. using mbrola voices, the sample rate may change. When the application plays audio itself, it needs to know it, and espeak_ng_GetSampleRate does not report that.