### PR TITLE
mbrola_is_idle: Make /proc checks work with Solaris /proc

### DIFF
--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -219,7 +219,11 @@ static int start_mbrola(const char *voice_path)
 		_exit(1);
 	}
 
+#if defined(__sun) && defined(__SVR4)
+	snprintf(charbuf, sizeof(charbuf), "/proc/%d/psinfo", mbr_pid);
+#else
 	snprintf(charbuf, sizeof(charbuf), "/proc/%d/stat", mbr_pid);
+#endif
 	mbr_proc_stat = open(charbuf, O_RDONLY);
 	if (mbr_proc_stat == -1) {
 		error = errno;
@@ -413,6 +417,19 @@ static int send_to_mbrola(const char *cmd)
 	return result;
 }
 
+#if defined(__sun) && defined(__SVR4) /* Solaris */
+#include <procfs.h>
+static int mbrola_is_idle(void)
+{
+	psinfo_t ps;
+
+	// look in /proc to determine if mbrola is still running or sleeping
+	if (pread(mbr_proc_stat, &ps, sizeof(ps), 0) != sizeof(ps))
+		return 0;
+
+	return strcmp(ps.pr_fname, "mbrola") == 0 && ps.pr_lwp.pr_sname == 'S';
+}
+#else
 static int mbrola_is_idle(void)
 {
 	char *p;
@@ -428,6 +445,7 @@ static int mbrola_is_idle(void)
 		return 0;
 	return p[1] == ' ' && p[2] == 'S';
 }
+#endif
 
 static ssize_t receive_from_mbrola(void *buffer, size_t bufsize)
 {


### PR DESCRIPTION
Upstreaming a patch for handling the difference between Linux & Solaris /proc that we've been carrying in the Solaris packages for 2 years now: 
https://github.com/oracle/solaris-userland/blob/master/components/desktop/espeak-ng/patches/03-procfs.patch

This gets rid of the warning message:
```
mbrowrap error: /proc is unaccessible: No such file or directory
```