### PR TITLE
adding just one real word for testing errors on previous pull request

### DIFF
--- a/dictsource/fa_list
+++ b/dictsource/fa_list
@@ -13287,3 +13287,4 @@ U+20	fAsele_
 یگانه	jegAne:
 یگانۀ	jegAneje
 ییلاق	jejlAq1
+پاتختی	pAtaxti


### PR DESCRIPTION
We opened another pull request that added 50 words to the exception list in Farsi and got errors  and creating another one with just one word to find out the issue.
this word is one of the exception words and is ok to be added to the list.
Previous pull request:
https://github.com/espeak-ng/espeak-ng/pull/1991
We are aligned with @shadyar  and @ehsan-e
