### PR TITLE
Fix the replacement character in the input string

### DIFF
--- a/src/libespeak-ng/encoding.c
+++ b/src/libespeak-ng/encoding.c
@@ -562,8 +562,8 @@ string_decoder_getc_utf_8(espeak_ng_TEXT_DECODER *decoder)
 		ret = (ret << 6) + (c & 0x3F);
 		if (((c = *decoder->current++) & LEADING_2_BITS) != UTF8_TAIL_BITS) goto error;
 		ret = (ret << 6) + (c & 0x3F);
-		// avoid the "I umlaut a half" bug
-		if (ret == 0xFFFD) goto substitute;
+		// fix the "I umlaut a half" bug
+		if (ret == 0xFFFD) return 0x001A;
 		return ret;
 	// 4-byte UTF-8 sequence
 	case 0xF0:
@@ -577,9 +577,6 @@ string_decoder_getc_utf_8(espeak_ng_TEXT_DECODER *decoder)
 		ret = (ret << 6) + (c & 0x3F);
 		return (ret <= 0x10FFFF) ? ret : 0xFFFD;
 	}
-
-substitute:
-	return 0x001A;
 error:
 	--decoder->current;
 	return 0xFFFD;
@@ -618,10 +615,7 @@ string_decoder_getc_auto(espeak_ng_TEXT_DECODER *decoder)
 		decoder->get = string_decoder_getc_codepage;
 		decoder->current = ptr;
 		c = decoder->get(decoder);
-	} else if (c == 0x001A) {
-		return 0xFFFD;
 	}
-
 	return c;
 }
 

--- a/src/libespeak-ng/encoding.c
+++ b/src/libespeak-ng/encoding.c
@@ -562,6 +562,8 @@ string_decoder_getc_utf_8(espeak_ng_TEXT_DECODER *decoder)
 		ret = (ret << 6) + (c & 0x3F);
 		if (((c = *decoder->current++) & LEADING_2_BITS) != UTF8_TAIL_BITS) goto error;
 		ret = (ret << 6) + (c & 0x3F);
+		// avoid the "I umlaut a half" bug
+		if (ret == 0xFFFD) goto substitute;
 		return ret;
 	// 4-byte UTF-8 sequence
 	case 0xF0:
@@ -575,6 +577,9 @@ string_decoder_getc_utf_8(espeak_ng_TEXT_DECODER *decoder)
 		ret = (ret << 6) + (c & 0x3F);
 		return (ret <= 0x10FFFF) ? ret : 0xFFFD;
 	}
+
+substitute:
+	return 0x001A;
 error:
 	--decoder->current;
 	return 0xFFFD;
@@ -613,7 +618,10 @@ string_decoder_getc_auto(espeak_ng_TEXT_DECODER *decoder)
 		decoder->get = string_decoder_getc_codepage;
 		decoder->current = ptr;
 		c = decoder->get(decoder);
+	} else if (c == 0x001A) {
+		return 0xFFFD;
 	}
+
 	return c;
 }
 


### PR DESCRIPTION
Fixes #1904 

The correction uses [substitute character](https://en.wikipedia.org/wiki/Substitute_character) (0x001A) as a workaround. This control character is the "older brother" of the replacement character OxFFFD.

The workaround is necessary because the replacement character (0xFFFD) is used to flag to indicate an error or EOF. The substitute character (0x001A) was included as an alternative flag to indicate that the input character itself is a replacement character (0xFFFD).

The problem with the replacement character is well explained in this Wikipedia page: https://en.wikipedia.org/wiki/Specials_(Unicode_block)

> The replacement character � (often displayed as a black rhombus with a white question mark) is a symbol found in the Unicode standard at code point U+FFFD in the Specials table. It is used to indicate problems when a system is unable to render a stream of data to correct symbols.[6]
>
>As an example, a text file encoded in ISO 8859-1 containing the German word für contains the bytes 0x66 0xFC 0x72. If this file is opened with a text editor that assumes the input is UTF-8, the first and third bytes are valid UTF-8 encodings of ASCII, but the second byte (0xFC) is not valid in UTF-8. The text editor could replace this byte with the replacement character to produce a valid string of Unicode code points for display, so the user sees "f�r".
>
>A poorly implemented text editor might write out the replacement character when the user saves the file; the data in the file will then become 0x66 0xEF 0xBF 0xBD 0x72. If the file is re-opened using ISO 8859-1, it will display "fï¿½r" (this is called mojibake). Since the replacement is the same for all errors it is impossible to recover the original character. A design that is better (but harder to implement) is to preserve the original bytes, including any errors, and only convert to the replacement when displaying the text. This will allow the text editor to save the original byte sequence, while still showing an error indication to the user.
>
>At one time the replacement character was often used when there was no glyph available in a font for that character, as in font substitution. However, most modern text rendering systems instead use a font's .notdef character, which in most cases is an empty box, or "?" or "X" in a box[7] (this browser displays 􏿾), sometimes called a 'tofu'. There is no Unicode code point for this symbol.
>
>Thus the replacement character is now only seen for encoding errors. Some software programs translate invalid UTF-8 bytes to matching characters in Windows-1252 (since that is the most common source of these errors), so that the replacement character is never seen. 