### PR TITLE
Fix pronunciation of Kamala

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -2333,6 +2333,7 @@ jumbalaya	dZVmb@l'aI|@
 kabaddi		$alt3
 kaboom		$alt3
 kalian		kalj'A:n
+kamala 'kA:m@l@ $only
 kaput		$alt3
 karaoke		karI'oUki
 karat		$alt2


### PR DESCRIPTION
Fix the pronunciation of Kamala, the name of the [vice president of the US](https://en.wikipedia.org/wiki/Kamala_Harris).