### PR TITLE
Remove obsolete instructions regarding inclusion of phoneme files in …

### DIFF
--- a/docs/add_language.md
+++ b/docs/add_language.md
@@ -138,13 +138,6 @@ E.g. for French:
 
 Note, that you don't need to add `fr_extra` or `fr_emoji` reference in the last group, if your language doesn't have this file.
 
-Optionally, if you have [phoneme definition file](#phoneme-definition-file), following line also should be added:
-
-	phsource/phonemes.stamp: \
-	...
-	phsource/ph_french \
-	...
-
 ### Language File
 
 E.g. `espeak-ng-data/lang/roa/fr` is the language file for French.


### PR DESCRIPTION
Since https://github.com/espeak-ng/espeak-ng/commit/7954418b8874e0430d19eecec8d300eddddac169, phoneme files do not have to be exhaustively listed in `Makefile.am`. 

This removes the instructions to add them from the language addition tutorial.