### PR TITLE
GitHub Actions: macOS runner.arch is `X64` or `ARM64`

### DIFF
--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -25,17 +25,17 @@ jobs:
           - arch: i386
             archcflags: "-m32 -msse2 -mfpmath=sse"
           - os: macos
-            osver: macos-13  # runner.arch is X64
+            osver: 13  # runner.arch is X64
             compiler: gcc
           - os: macos
-            osver: macos-13
+            osver: 13
             compiler: clang
           - os: macos
-            osver: macos-latest  # runner.arch is ARM64
+            osver: latest  # runner.arch is ARM64
             compiler: gcc
           - os: macos
+            osver: latest
             compiler: clang
-            osver: macos-latest
 
     steps:
 

--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}-${{ matrix.osver }}
 
-    name: "${{ matrix.os }} ${{ matrix.arch }}: ${{ matrix.compiler }}"
+    name: "${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
     strategy:
       fail-fast: false
       matrix:
@@ -40,25 +40,25 @@ jobs:
     steps:
 
     # Linux - dependencies
-    - name: "apt-build-deps ${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
-      if: matrix.os == 'ubuntu'
+    - name: apt-build-deps
+      if: runner.os == 'Linux'
       run: |
         sudo dpkg --add-architecture ${{ matrix.arch }}
         sudo apt-get update
         sudo apt-get install ronn kramdown python3
     - name: apt-arch-deps
-      if: matrix.os == 'ubuntu'
+      if: runner.os == 'Linux'
       run: "sudo apt-get install libtool-bin valgrind g++-12-multilib linux-libc-dev:${{ matrix.arch }} libpcaudio-dev:${{ matrix.arch }} libsonic-dev:${{ matrix.arch }} libgcc-s1:${{ matrix.arch }}"
     - name: apt-compile-clang
-      if: matrix.os == 'ubuntu' && matrix.compiler == 'clang'
+      if: runner.os == 'Linux' && matrix.compiler == 'clang'
       run: sudo apt-get install clang
 
     # MacOS - dependencies
-    - name: "brew-deps ${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
-      if: matrix.os == 'macos'
+    - name: brew-deps
+      if: runner.os == 'macOS'
       run: brew install libtool automake ronn OJFord/homebrew-formulae/kramdown
     - name: brew-compile-deps
-      if: matrix.os == 'macos' && matrix.compiler == 'gcc'
+      if: runner.os == 'macOS' && matrix.compiler == 'gcc'
       run: brew install gcc@12
 
     # Checkout code

--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}-${{ matrix.osver }}
 
-    name: "${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
+    name: "${{ matrix.os }} ${{ matrix.arch }}: ${{ matrix.compiler }}"
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,8 @@ jobs:
             compiler: clang
 
     steps:
-
+    - name: "${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
+      run: echo "${{ runner.os }} ${{ runner.arch }} ${{ matrix.compiler }}"
     # Linux - dependencies
     - name: apt-build-deps
       if: runner.os == 'Linux'
@@ -81,7 +82,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
-        name: config-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.compiler }}.log
+        name: config-${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}.log
         path: config.log
 
     # Build and test

--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -15,27 +15,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu]
         arch: [amd64, i386]
         compiler: [gcc, clang]
 
         include:
           - os: ubuntu
             osver: ubuntu-latest
-          - os: macos
-            osver: macos-latest
-
           - arch: i386
             archcflags: "-m32 -msse2 -mfpmath=sse"
-
-        exclude:
           - os: macos
-            arch: i386
+            osver: macos-13  # runner.arch is X64
+            compiler: gcc
+          - os: macos
+            osver: macos-13
+            compiler: clang
+          - os: macos
+            osver: macos-latest  # runner.arch is ARM64
+            compiler: gcc
+          - os: macos
+            compiler: clang
+            osver: macos-latest
 
     steps:
 
     # Linux - dependencies
-    - name: apt-build-deps
+    - name: "apt-build-deps ${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
       if: matrix.os == 'ubuntu'
       run: |
         sudo dpkg --add-architecture ${{ matrix.arch }}
@@ -49,7 +54,7 @@ jobs:
       run: sudo apt-get install clang
 
     # MacOS - dependencies
-    - name: brew-deps
+    - name: "brew-deps ${{ runner.os }} ${{ runner.arch }}: ${{ matrix.compiler }}"
       if: matrix.os == 'macos'
       run: brew install libtool automake ronn OJFord/homebrew-formulae/kramdown
     - name: brew-compile-deps
@@ -57,7 +62,7 @@ jobs:
       run: brew install gcc@12
 
     # Checkout code
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Configure
     - name: configure


### PR DESCRIPTION
These test names do not make sense:
![image](https://github.com/user-attachments/assets/2465322d-9c53-405f-a191-509018979a68)
The tests were run on `arm64`, not `amd64`.

GitHub Actions: macOS `runner.arch` is `X64` (Intel) or `ARM64` (Apple Silicon).
* `macos-12` is now deprecated.
    * See annotations https://github.com/espeak-ng/espeak-ng/actions/runs/12223530383/job/34095193619?pr=2030 
* `macos-13` has a `runner.arch` of `X64` (Intel).
* `macos-14` (aka `macos-latest`) has a `runner.arch` of `ARM64` (Apple Silicon).
* `macos-15` has a `runner.arch` of `ARM64` (Apple Silicon).

GitHub Actions docs for [detecting the operating system](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system).