### PR TITLE
feat: add cmake options for cross compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,31 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(espeak-ng
-  VERSION 1.52.0
+  VERSION 1.52.0.1
   DESCRIPTION "open source speech synthesizer that supports more than hundred languages and accents"
   HOMEPAGE_URL "https://github.com/espeak-ng/espeak-ng"
 )
+
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(COMPILE_INTONATIONS "Intonation compilation" ON)
+option(ENABLE_TESTS "Intonation compilation" ON)
 
 include(CTest)
 
 include(cmake/deps.cmake)
 include(cmake/config.cmake)
 add_subdirectory(src)
-include(cmake/data.cmake)
+if (COMPILE_INTONATIONS AND NOT CMAKE_CROSSCOMPILING)
+  include(cmake/data.cmake)
+endif()
 include(cmake/docs.cmake)
 
 include(cmake/package.cmake)
 include(CPack)
 
-include(CTest)
-add_subdirectory(tests)
-
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+if(ENABLE_TESTS AND NOT CMAKE_CROSSCOMPILING)
+  add_subdirectory(tests)
+endif()
 
 message(STATUS "Configuration:")
 message(STATUS "  shared: ${BUILD_SHARED_LIBS}")


### PR DESCRIPTION
Add cmake options and fix cross compile. it's not possible to compile data when cross compile because the binaries are compiled into different architecture