### PR TITLE
IsLetterGroup: Also handle case when *word is already \0

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -737,6 +737,8 @@ static int IsLetterGroup(Translator *tr, char *word, int group, int pre)
 		if (pre) {
 			len = strlen(p);
 			w = word;
+			if (*w == 0)
+				goto skip;
 			for (i = 0; i < len-1; i++)
 			{
 				w--;


### PR DESCRIPTION
Othersize the for loop below decrements w before any checking for \0