### PR TITLE
Fix dropping last byte of stdin input

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -762,8 +762,8 @@ int main(int argc, char **argv)
 				}
 			}
 			if (ix > 0) {
-				p_text[ix-1] = 0;
-				espeak_Synth(p_text, ix+1, 0, POS_CHARACTER, 0, synth_flags, NULL, NULL);
+				p_text[ix] = 0;
+				espeak_Synth(p_text, ix, 0, POS_CHARACTER, 0, synth_flags, NULL, NULL);
 			}
 		}
 


### PR DESCRIPTION
This got broken with eaa0c9aa08350ce8a1343aed4c0a87c1cc329b0e ("Fix truncated fgetc return value in main(espeak-ng.c). [Coverity]") which rightfully stopped adding a bogus EOF at the end of the input, which this line was probably dropping just by luck.

Fixes brailcom/speechd#978