### PR TITLE
TranslateClauseWithTerminator: fix overflowing number_buf

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -1591,7 +1591,7 @@ void TranslateClauseWithTerminator(Translator *tr, int *tone_out, char **voice_c
 			for (pw = &number_buf[3]; pw < pn && nw < N_CLAUSE_WORDS;) {
 				// keep wflags for each part, for FLAG_HYPHEN_AFTER
 				dict_flags = TranslateWord2(tr, pw, &num_wtab[nw++], words[ix].pre_pause);
-				while (*pw++ != ' ')
+				while (pw < pn && *pw++ != ' ')
 					;
 				words[ix].pre_pause = 0;
 			}


### PR DESCRIPTION
The pw loop is not supposed to iterate beyond what was produced by the pn loop above, and not beyond pn (as already tested in the for stanza)

Most often numbers are somehow followed by a space some time so checking for space is most often enough, but if there is text without space after this, we start iterating inside pn (which we are not supposed to), and may never stop before overflowing (if the following text doesn't contain space).