### PR TITLE
Add espeak_TextToPhonemesWithTerminator

### DIFF
--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -544,6 +544,12 @@ ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode,
 #ifdef __cplusplus
 extern "C"
 #endif
+ESPEAK_API const char *espeak_TextToPhonemesWithTerminator(const void **textptr, int textmode, int phonememode, int *terminator);
+/* Version of espeak_TextToPhonemes that also returns the clause terminator (e.g., CLAUSE_INTONATION_FULL_STOP) */
+
+#ifdef __cplusplus
+extern "C"
+#endif
 ESPEAK_API void espeak_CompileDictionary(const char *path, FILE *log, int flags);
 /* Compile pronunciation dictionary for a language which corresponds to the currently
    selected voice.  The required voice should be selected before calling this function.

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -850,7 +850,7 @@ ESPEAK_API void espeak_SetPhonemeTrace(int phonememode, FILE *stream)
 		f_trans = stderr;
 }
 
-ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode, int phonememode)
+ESPEAK_API const char* espeak_TextToPhonemesWithTerminator(const void** textptr, int textmode, int phonememode, int* terminator)
 {
 	/* phoneme_mode
 	    bit 1:   0=eSpeak's ascii phoneme names, 1= International Phonetic Alphabet (as UTF-8 characters).
@@ -864,10 +864,15 @@ ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode,
 	if (text_decoder_decode_string_multibyte(p_decoder, *textptr, translator->encoding, textmode) != ENS_OK)
 		return NULL;
 
-	TranslateClause(translator, NULL, NULL);
+	TranslateClauseWithTerminator(translator, NULL, NULL, terminator);
 	*textptr = text_decoder_get_buffer(p_decoder);
 
 	return GetTranslatedPhonemeString(phonememode);
+}
+
+ESPEAK_API const char *espeak_TextToPhonemes(const void **textptr, int textmode, int phonememode)
+{
+	return espeak_TextToPhonemesWithTerminator(textptr, textmode, phonememode, NULL);
 }
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Cancel(void)


### PR DESCRIPTION
This variant of espeak_TextToPhonemes also returns the clause terminator for the text. It is used by [piper-phonemize](https://github.com/rhasspy/piper-phonemize/), and rather than submit this themselves they appear happier to maintain their own fork with this added. See some discussion at [#30](https://github.com/rhasspy/piper-phonemize/issues/30).

I would like the Debian version of espeak to have this function available rather than requiring a separate patched variant for a single function. To me the change seems minimal and a logical extension of the interface, so I'm hoping it is acceptable to upstream.