### PR TITLE
Don't fetch libsonic if not present

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -17,19 +17,7 @@ endif(MBROLA_BIN)
 if (SONIC_LIB AND SONIC_INC)
   set(HAVE_LIBSONIC ON)
 else()
-  FetchContent_Declare(sonic-git
-    GIT_REPOSITORY https://github.com/waywardgeek/sonic.git
-    GIT_TAG fbf75c3d6d846bad3bb3d456cbc5d07d9fd8c104
-  )
-  FetchContent_MakeAvailable(sonic-git)
-  FetchContent_GetProperties(sonic-git)
-  add_library(sonic OBJECT ${sonic-git_SOURCE_DIR}/sonic.c)
-  # enable PIC in order to embed libsonic.a in a .so
-  set_property(TARGET sonic PROPERTY POSITION_INDEPENDENT_CODE ON)
-  target_include_directories(sonic PUBLIC ${sonic-git_SOURCE_DIR})
-  set(HAVE_LIBSONIC ON)
-  set(SONIC_LIB sonic)
-  set(SONIC_INC ${sonic-git_SOURCE_DIR})
+  set(HAVE_LIBSONIC OFF)
 endif()
 if (PCAUDIO_LIB AND PCAUDIO_INC)
   set(HAVE_LIBPCAUDIO ON)


### PR DESCRIPTION
The previous version used FetchContent to pull in the sonic library if it was not found.  This simply reports that it was not found because it is an optional dependency.