### PR TITLE
Increase sonic activation threshold

### DIFF
--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -163,7 +163,7 @@ void SetSpeed(int control)
 
 	if (control & 2)
 		DoSonicSpeed(1 * 1024);
-	if ((wpm_value >= espeakRATE_MAXIMUM) || ((wpm_value > speed.fast_settings) && (wpm > 350))) {
+	if ((wpm_value > espeakRATE_MAXIMUM) || ((wpm_value > speed.fast_settings) && (wpm > 350))) {
 		int wpm2;
 		wpm2 = wpm;
 		wpm = espeakRATE_NORMAL;


### PR DESCRIPTION
The threshold value for the activation of Sonic was changed in 065a0e8f03bfac5677e1503a1c5ea0c6093ec023 without an obvious reason.

Related issues: #131, #1461.
