### PR TITLE
fix ucd library link

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(espeak-include INTERFACE)
 target_include_directories(espeak-include INTERFACE include include/compat)
+target_link_libraries(espeak-include INTERFACE ucd)
 
 add_subdirectory(ucd-tools)
 add_subdirectory(speechPlayer)


### PR DESCRIPTION
The `espeak-include` INTERFACE library was missing a dependency on the `ucd` library. This could lead to build failures when `espeak-ng` is consumed as a subdirectory in another CMake project.

**Steps to Reproduce:**

1.  Create a `CMakeLists.txt` file in a new project with the following content:
    ````cmake
    // filepath: CMakeLists.txt
    cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
    project(hello)

    add_subdirectory("${CMAKE_SOURCE_DIR}/espeak-ng") # Assuming espeak-ng is a subdirectory
    add_executable(${PROJECT_NAME} hello.cpp) # A simple hello.cpp that includes <iostream>

    target_link_libraries(${PROJECT_NAME} PRIVATE espeak-ng)
    ````
2.  Create a simple `hello.cpp` file:
    ````cpp
    // filepath: hello.cpp
    #include <iostream>

    int main() {
        std::cout << "Hello, world!" << std::endl;
        return 0;
    }
    ````
3.  Attempt to build the project:
    ````bash
    mkdir build && cd build
    cmake ..
    cmake --build .
    ````

**Error Encountered (before fix):**

```bash
...
[ 29%] Built target espeak-ng-bin
In file included from /usr/include/c++/13/cwchar:44,
                 from /usr/include/c++/13/bits/postypes.h:40,
                 from /usr/include/c++/13/iosfwd:42,
                 from /usr/include/c++/13/ios:40,
                 from /usr/include/c++/13/ostream:40,
                 from /usr/include/c++/13/iostream:41,
                 from /home/cychiu/test/hello.cpp:1:
/home/david/test/espeak-ng/src/include/compat/wchar.h:33:10: fatal error: ucd/ucd.h: No such file or directory
   33 | #include <ucd/ucd.h>
      |          ^~~~~~~~~~~
```
      
      