### PR TITLE
Android: Remove compatibility fallback

### DIFF
--- a/src/include/compat/wctype.h
+++ b/src/include/compat/wctype.h
@@ -44,7 +44,5 @@
 #define iswspace  ucd_isspace
 #define iswupper  ucd_isupper
 #define iswxdigit ucd_isxdigit
-#define tolower ucd_tolower
-#define toupper udc_toupper
 
 #endif


### PR DESCRIPTION
When trying to compile Espeak integration with Android NDK >= 27 an error is thrown stating `udc_toupper` has no matching function:

```error: no matching function for call to 'udc_toupper'```

Since Android NDK 28 is adviced in order add [support for 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes), I want to suggest to remove this old workaround. This will soon become a requirement to publish apps for Android 15 and above. The example project uses NDK 26, but can still be compiled without issues after these changes. Check out the old commit here:

https://github.com/espeak-ng/espeak-ng/commit/e3487d0cf803a5b8202ef170daedf23f82c565cd