### PR TITLE
Allow build with CMake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 project(espeak-ng
   VERSION 1.52.0.1


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake.

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html