### PR TITLE
Mark Truncating Casts as Intentional

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -2408,11 +2408,11 @@ int TransposeAlphabet(Translator *tr, char *text)
 
 			if (bits >= 8) {
 				bits -= 8;
-				*p2++ = (acc >> bits);
+				*p2++ = (char)((acc >> bits) & 0xff);
 			}
 		}
 		if (bits > 0)
-			*p2++ = (acc << (8-bits));
+			*p2++ = (char)((acc << (8-bits)) & 0xff);
 		*p2 = 0;
 		ix = p2 - buf;
 		memcpy(text, buf, ix);


### PR DESCRIPTION
We see false positives in run-time checks of truncating casts (`/RTCc` on MSVC). The loss of bits is intentional here and this commit marks it so.

The additional bitmasks are optimized away by every optimizing compiler, but they remove extra bits before the cast to `char` takes place so no implicit data loss occurs.