### PR TITLE
Enable PIC to sonic deps

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -24,6 +24,8 @@ else()
   FetchContent_MakeAvailable(sonic-git)
   FetchContent_GetProperties(sonic-git)
   add_library(sonic OBJECT ${sonic-git_SOURCE_DIR}/sonic.c)
+  # enable PIC in order to embed libsonic.a in a .so
+  set_property(TARGET sonic PROPERTY POSITION_INDEPENDENT_CODE ON)
   target_include_directories(sonic PUBLIC ${sonic-git_SOURCE_DIR})
   set(HAVE_LIBSONIC ON)
   set(SONIC_LIB sonic)


### PR DESCRIPTION
fix espeak-ng shared library build

```
[ 24%] Linking CXX shared library libespeak-ng.so
/usr/bin/ld: ../../CMakeFiles/sonic.dir/_deps/sonic-git-src/sonic.c.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
```