### PR TITLE
Organize dictionaries in dicts subdirectory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,7 @@ if HAVE_GRADLE
 endif
 
 distclean-local:
-	rm -f espeak-ng-data/*_dict
+	rm -f espeak-ng-data/dicts/*_dict
 	rm -f espeak-ng-data/intonations
 	rm -f espeak-ng-data/phondata
 	rm -f espeak-ng-data/phondata-manifest
@@ -437,134 +437,135 @@ dictsource/%_extra:
 # The rm $@ stops espeak-ng trying to load the old dictionary when it is run
 # (at the cost of a spurious error message.)
 #
-# NOTE: keep in sync with 'espeak-ng-data/yue_dict' more specific rule.
-espeak-ng-data/%_dict: src/espeak-ng phsource/phonemes.stamp
+# NOTE: keep in sync with 'espeak-ng-data/dicts/yue_dict' more specific rule.
+espeak-ng-data/dicts/%_dict: src/espeak-ng phsource/phonemes.stamp
 	@echo "  DICT      $@"
+	@mkdir -p espeak-ng-data/dicts
 	rm -f $@
 	cd dictsource && ESPEAK_DATA_PATH=$(CURDIR) ../src/espeak-ng --compile="$(*F)"
 
 dictionaries: \
-	espeak-ng-data/af_dict \
-	espeak-ng-data/am_dict \
-	espeak-ng-data/an_dict \
-	espeak-ng-data/ar_dict \
-	espeak-ng-data/as_dict \
-	espeak-ng-data/az_dict \
-	espeak-ng-data/ba_dict \
-	espeak-ng-data/be_dict \
-	espeak-ng-data/bg_dict \
-	espeak-ng-data/bn_dict \
-	espeak-ng-data/bpy_dict \
-	espeak-ng-data/bs_dict \
-	espeak-ng-data/ca_dict \
-	espeak-ng-data/chr_dict \
-	espeak-ng-data/cmn_dict \
-        espeak-ng-data/crh_dict \
-	espeak-ng-data/cs_dict \
-	espeak-ng-data/cv_dict \
-	espeak-ng-data/cy_dict \
-	espeak-ng-data/da_dict \
-	espeak-ng-data/de_dict \
-	espeak-ng-data/el_dict \
-	espeak-ng-data/en_dict \
-	espeak-ng-data/eo_dict \
-	espeak-ng-data/es_dict \
-	espeak-ng-data/et_dict \
-	espeak-ng-data/eu_dict \
-	espeak-ng-data/fa_dict \
-	espeak-ng-data/fi_dict \
-	espeak-ng-data/fo_dict \
-	espeak-ng-data/fr_dict \
-	espeak-ng-data/ga_dict \
-	espeak-ng-data/gd_dict \
-	espeak-ng-data/gn_dict \
-	espeak-ng-data/grc_dict \
-	espeak-ng-data/gu_dict \
-	espeak-ng-data/hak_dict \
-	espeak-ng-data/haw_dict \
-	espeak-ng-data/he_dict \
-	espeak-ng-data/hi_dict \
-	espeak-ng-data/hr_dict \
-	espeak-ng-data/ht_dict \
-	espeak-ng-data/hu_dict \
-	espeak-ng-data/hy_dict \
-	espeak-ng-data/ia_dict \
-	espeak-ng-data/id_dict \
-	espeak-ng-data/io_dict \
-	espeak-ng-data/is_dict \
-	espeak-ng-data/it_dict \
-	espeak-ng-data/ja_dict \
-	espeak-ng-data/jbo_dict \
-	espeak-ng-data/ka_dict \
-	espeak-ng-data/kaa_dict \
-	espeak-ng-data/kk_dict \
-	espeak-ng-data/kl_dict \
-	espeak-ng-data/kn_dict \
-	espeak-ng-data/ko_dict \
-	espeak-ng-data/kok_dict \
-	espeak-ng-data/ku_dict \
-	espeak-ng-data/ky_dict \
-	espeak-ng-data/la_dict \
-	espeak-ng-data/lb_dict \
-	espeak-ng-data/lfn_dict \
-	espeak-ng-data/lt_dict \
-	espeak-ng-data/lv_dict \
-	espeak-ng-data/mi_dict \
-	espeak-ng-data/mk_dict \
-	espeak-ng-data/ml_dict \
-	espeak-ng-data/mn_dict \
-	espeak-ng-data/mr_dict \
-	espeak-ng-data/ms_dict \
-	espeak-ng-data/mt_dict \
-	espeak-ng-data/mto_dict \
-	espeak-ng-data/my_dict \
-	espeak-ng-data/nci_dict \
-	espeak-ng-data/ne_dict \
-	espeak-ng-data/nl_dict \
-	espeak-ng-data/no_dict \
-	espeak-ng-data/nog_dict \
-	espeak-ng-data/om_dict \
-	espeak-ng-data/or_dict \
-	espeak-ng-data/pa_dict \
-	espeak-ng-data/pap_dict \
-	espeak-ng-data/piqd_dict \
-	espeak-ng-data/pl_dict \
-	espeak-ng-data/ps_dict \
-	espeak-ng-data/pt_dict \
-	espeak-ng-data/py_dict \
-	espeak-ng-data/qdb_dict \
-	espeak-ng-data/qu_dict \
-	espeak-ng-data/quc_dict \
-	espeak-ng-data/qya_dict \
-	espeak-ng-data/ro_dict \
-	espeak-ng-data/ru_dict \
-        espeak-ng-data/rup_dict \
-	espeak-ng-data/sd_dict \
-	espeak-ng-data/shn_dict \
-	espeak-ng-data/si_dict \
-	espeak-ng-data/sjn_dict \
-	espeak-ng-data/sk_dict \
-	espeak-ng-data/sl_dict \
-	espeak-ng-data/smj_dict \
-	espeak-ng-data/sq_dict \
-	espeak-ng-data/sr_dict \
-	espeak-ng-data/sv_dict \
-	espeak-ng-data/sw_dict \
-	espeak-ng-data/ta_dict \
-	espeak-ng-data/te_dict \
-	espeak-ng-data/th_dict \
-	espeak-ng-data/ti_dict \
-	espeak-ng-data/tk_dict \
-	espeak-ng-data/tn_dict \
-	espeak-ng-data/tr_dict \
-	espeak-ng-data/tt_dict \
-	espeak-ng-data/uk_dict \
-	espeak-ng-data/ug_dict \
-	espeak-ng-data/ur_dict \
-	espeak-ng-data/uz_dict \
-	espeak-ng-data/vi_dict \
-	espeak-ng-data/xex_dict \
-	espeak-ng-data/yue_dict
+	espeak-ng-data/dicts/af_dict \
+	espeak-ng-data/dicts/am_dict \
+	espeak-ng-data/dicts/an_dict \
+	espeak-ng-data/dicts/ar_dict \
+	espeak-ng-data/dicts/as_dict \
+	espeak-ng-data/dicts/az_dict \
+	espeak-ng-data/dicts/ba_dict \
+	espeak-ng-data/dicts/be_dict \
+	espeak-ng-data/dicts/bg_dict \
+	espeak-ng-data/dicts/bn_dict \
+	espeak-ng-data/dicts/bpy_dict \
+	espeak-ng-data/dicts/bs_dict \
+	espeak-ng-data/dicts/ca_dict \
+	espeak-ng-data/dicts/chr_dict \
+	espeak-ng-data/dicts/cmn_dict \
+    espeak-ng-data/dicts/crh_dict \
+	espeak-ng-data/dicts/cs_dict \
+	espeak-ng-data/dicts/cv_dict \
+	espeak-ng-data/dicts/cy_dict \
+	espeak-ng-data/dicts/da_dict \
+	espeak-ng-data/dicts/de_dict \
+	espeak-ng-data/dicts/el_dict \
+	espeak-ng-data/dicts/en_dict \
+	espeak-ng-data/dicts/eo_dict \
+	espeak-ng-data/dicts/es_dict \
+	espeak-ng-data/dicts/et_dict \
+	espeak-ng-data/dicts/eu_dict \
+	espeak-ng-data/dicts/fa_dict \
+	espeak-ng-data/dicts/fi_dict \
+	espeak-ng-data/dicts/fo_dict \
+	espeak-ng-data/dicts/fr_dict \
+	espeak-ng-data/dicts/ga_dict \
+	espeak-ng-data/dicts/gd_dict \
+	espeak-ng-data/dicts/gn_dict \
+	espeak-ng-data/dicts/grc_dict \
+	espeak-ng-data/dicts/gu_dict \
+	espeak-ng-data/dicts/hak_dict \
+	espeak-ng-data/dicts/haw_dict \
+	espeak-ng-data/dicts/he_dict \
+	espeak-ng-data/dicts/hi_dict \
+	espeak-ng-data/dicts/hr_dict \
+	espeak-ng-data/dicts/ht_dict \
+	espeak-ng-data/dicts/hu_dict \
+	espeak-ng-data/dicts/hy_dict \
+	espeak-ng-data/dicts/ia_dict \
+	espeak-ng-data/dicts/id_dict \
+	espeak-ng-data/dicts/io_dict \
+	espeak-ng-data/dicts/is_dict \
+	espeak-ng-data/dicts/it_dict \
+	espeak-ng-data/dicts/ja_dict \
+	espeak-ng-data/dicts/jbo_dict \
+	espeak-ng-data/dicts/ka_dict \
+	espeak-ng-data/dicts/kaa_dict \
+	espeak-ng-data/dicts/kk_dict \
+	espeak-ng-data/dicts/kl_dict \
+	espeak-ng-data/dicts/kn_dict \
+	espeak-ng-data/dicts/ko_dict \
+	espeak-ng-data/dicts/kok_dict \
+	espeak-ng-data/dicts/ku_dict \
+	espeak-ng-data/dicts/ky_dict \
+	espeak-ng-data/dicts/la_dict \
+	espeak-ng-data/dicts/lb_dict \
+	espeak-ng-data/dicts/lfn_dict \
+	espeak-ng-data/dicts/lt_dict \
+	espeak-ng-data/dicts/lv_dict \
+	espeak-ng-data/dicts/mi_dict \
+	espeak-ng-data/dicts/mk_dict \
+	espeak-ng-data/dicts/ml_dict \
+	espeak-ng-data/dicts/mn_dict \
+	espeak-ng-data/dicts/mr_dict \
+	espeak-ng-data/dicts/ms_dict \
+	espeak-ng-data/dicts/mt_dict \
+	espeak-ng-data/dicts/mto_dict \
+	espeak-ng-data/dicts/my_dict \
+	espeak-ng-data/dicts/nci_dict \
+	espeak-ng-data/dicts/ne_dict \
+	espeak-ng-data/dicts/nl_dict \
+	espeak-ng-data/dicts/no_dict \
+	espeak-ng-data/dicts/nog_dict \
+	espeak-ng-data/dicts/om_dict \
+	espeak-ng-data/dicts/or_dict \
+	espeak-ng-data/dicts/pa_dict \
+	espeak-ng-data/dicts/pap_dict \
+	espeak-ng-data/dicts/piqd_dict \
+	espeak-ng-data/dicts/pl_dict \
+	espeak-ng-data/dicts/ps_dict \
+	espeak-ng-data/dicts/pt_dict \
+	espeak-ng-data/dicts/py_dict \
+	espeak-ng-data/dicts/qdb_dict \
+	espeak-ng-data/dicts/qu_dict \
+	espeak-ng-data/dicts/quc_dict \
+	espeak-ng-data/dicts/qya_dict \
+	espeak-ng-data/dicts/ro_dict \
+	espeak-ng-data/dicts/ru_dict \
+    espeak-ng-data/dicts/rup_dict \
+	espeak-ng-data/dicts/sd_dict \
+	espeak-ng-data/dicts/shn_dict \
+	espeak-ng-data/dicts/si_dict \
+	espeak-ng-data/dicts/sjn_dict \
+	espeak-ng-data/dicts/sk_dict \
+	espeak-ng-data/dicts/sl_dict \
+	espeak-ng-data/dicts/smj_dict \
+	espeak-ng-data/dicts/sq_dict \
+	espeak-ng-data/dicts/sr_dict \
+	espeak-ng-data/dicts/sv_dict \
+	espeak-ng-data/dicts/sw_dict \
+	espeak-ng-data/dicts/ta_dict \
+	espeak-ng-data/dicts/te_dict \
+	espeak-ng-data/dicts/th_dict \
+	espeak-ng-data/dicts/ti_dict \
+	espeak-ng-data/dicts/tk_dict \
+	espeak-ng-data/dicts/tn_dict \
+	espeak-ng-data/dicts/tr_dict \
+	espeak-ng-data/dicts/tt_dict \
+	espeak-ng-data/dicts/uk_dict \
+	espeak-ng-data/dicts/ug_dict \
+	espeak-ng-data/dicts/ur_dict \
+	espeak-ng-data/dicts/uz_dict \
+	espeak-ng-data/dicts/vi_dict \
+	espeak-ng-data/dicts/xex_dict \
+	espeak-ng-data/dicts/yue_dict
 
 DICTSOURCE = \
 	$(wildcard dictsource/*_emoji) \
@@ -582,317 +583,317 @@ DICTSOURCE = \
 
 EXTRA_DIST += $(DICTSOURCE)
 
-af: espeak-ng-data/af_dict
-espeak-ng-data/af_dict: dictsource/af_list dictsource/af_rules dictsource/af_extra dictsource/af_emoji
+af: espeak-ng-data/dicts/af_dict
+espeak-ng-data/dicts/af_dict: dictsource/af_list dictsource/af_rules dictsource/af_extra dictsource/af_emoji
 
-am: espeak-ng-data/am_dict
-espeak-ng-data/am_dict: dictsource/am_list dictsource/am_rules dictsource/am_extra dictsource/am_emoji
+am: espeak-ng-data/dicts/am_dict
+espeak-ng-data/dicts/am_dict: dictsource/am_list dictsource/am_rules dictsource/am_extra dictsource/am_emoji
 
-an: espeak-ng-data/an_dict
-espeak-ng-data/an_dict: dictsource/an_list dictsource/an_rules dictsource/an_extra
+an: espeak-ng-data/dicts/an_dict
+espeak-ng-data/dicts/an_dict: dictsource/an_list dictsource/an_rules dictsource/an_extra
 
-ar: espeak-ng-data/ar_dict
-espeak-ng-data/ar_dict: dictsource/ar_list dictsource/ar_listx dictsource/ar_rules dictsource/ar_extra dictsource/ar_emoji
+ar: espeak-ng-data/dicts/ar_dict
+espeak-ng-data/dicts/ar_dict: dictsource/ar_list dictsource/ar_listx dictsource/ar_rules dictsource/ar_extra dictsource/ar_emoji
 
-as: espeak-ng-data/as_dict
-espeak-ng-data/as_dict: dictsource/as_list dictsource/as_rules dictsource/as_extra
+as: espeak-ng-data/dicts/as_dict
+espeak-ng-data/dicts/as_dict: dictsource/as_list dictsource/as_rules dictsource/as_extra
 
-az: espeak-ng-data/az_dict
-espeak-ng-data/az_dict: dictsource/az_list dictsource/az_rules dictsource/az_extra dictsource/az_emoji
+az: espeak-ng-data/dicts/az_dict
+espeak-ng-data/dicts/az_dict: dictsource/az_list dictsource/az_rules dictsource/az_extra dictsource/az_emoji
 
-ba: espeak-ng-data/ba_dict
-espeak-ng-data/ba_dict: dictsource/ba_list dictsource/ba_rules
+ba: espeak-ng-data/dicts/ba_dict
+espeak-ng-data/dicts/ba_dict: dictsource/ba_list dictsource/ba_rules
 
-be: espeak-ng-data/be_dict
-espeak-ng-data/be_dict: dictsource/be_list dictsource/be_rules
+be: espeak-ng-data/dicts/be_dict
+espeak-ng-data/dicts/be_dict: dictsource/be_list dictsource/be_rules
 
-bg: espeak-ng-data/bg_dict
-espeak-ng-data/bg_dict: dictsource/bg_list dictsource/bg_listx dictsource/bg_rules dictsource/bg_extra dictsource/bg_emoji
+bg: espeak-ng-data/dicts/bg_dict
+espeak-ng-data/dicts/bg_dict: dictsource/bg_list dictsource/bg_listx dictsource/bg_rules dictsource/bg_extra dictsource/bg_emoji
 
-bn: espeak-ng-data/bn_dict
-espeak-ng-data/bn_dict: dictsource/bn_list dictsource/bn_rules dictsource/bn_extra dictsource/bn_emoji
+bn: espeak-ng-data/dicts/bn_dict
+espeak-ng-data/dicts/bn_dict: dictsource/bn_list dictsource/bn_rules dictsource/bn_extra dictsource/bn_emoji
 
-bpy: espeak-ng-data/bpy_dict
-espeak-ng-data/bpy_dict: dictsource/bpy_list dictsource/bpy_rules dictsource/bpy_extra
+bpy: espeak-ng-data/dicts/bpy_dict
+espeak-ng-data/dicts/bpy_dict: dictsource/bpy_list dictsource/bpy_rules dictsource/bpy_extra
 
-bs: espeak-ng-data/bs_dict
-espeak-ng-data/bs_dict: dictsource/bs_list dictsource/bs_rules dictsource/bs_extra dictsource/bs_emoji
+bs: espeak-ng-data/dicts/bs_dict
+espeak-ng-data/dicts/bs_dict: dictsource/bs_list dictsource/bs_rules dictsource/bs_extra dictsource/bs_emoji
 
-ca: espeak-ng-data/ca_dict
-espeak-ng-data/ca_dict: dictsource/ca_list dictsource/ca_rules dictsource/ca_extra dictsource/ca_emoji
+ca: espeak-ng-data/dicts/ca_dict
+espeak-ng-data/dicts/ca_dict: dictsource/ca_list dictsource/ca_rules dictsource/ca_extra dictsource/ca_emoji
 
-chr: espeak-ng-data/chr_dict
-espeak-ng-data/chr_dict: dictsource/chr_list dictsource/chr_rules
+chr: espeak-ng-data/dicts/chr_dict
+espeak-ng-data/dicts/chr_dict: dictsource/chr_list dictsource/chr_rules
 
-crh: espeak-ng-data/crh_dict
-espeak-ng-data/crh_dict: dictsource/crh_list dictsource/crh_rules dictsource/crh_extra dictsource/crh_emoji
+crh: espeak-ng-data/dicts/crh_dict
+espeak-ng-data/dicts/crh_dict: dictsource/crh_list dictsource/crh_rules dictsource/crh_extra dictsource/crh_emoji
 
-cs: espeak-ng-data/cs_dict
-espeak-ng-data/cs_dict: dictsource/cs_list dictsource/cs_rules dictsource/cs_extra dictsource/cs_emoji
+cs: espeak-ng-data/dicts/cs_dict
+espeak-ng-data/dicts/cs_dict: dictsource/cs_list dictsource/cs_rules dictsource/cs_extra dictsource/cs_emoji
 
-cv: espeak-ng-data/cv_dict
-espeak-ng-data/cv_dict: dictsource/cv_list dictsource/cv_rules dictsource/cv_extra
+cv: espeak-ng-data/dicts/cv_dict
+espeak-ng-data/dicts/cv_dict: dictsource/cv_list dictsource/cv_rules dictsource/cv_extra
 
-cy: espeak-ng-data/cy_dict
-espeak-ng-data/cy_dict: dictsource/cy_list dictsource/cy_rules dictsource/cy_extra dictsource/cy_emoji
+cy: espeak-ng-data/dicts/cy_dict
+espeak-ng-data/dicts/cy_dict: dictsource/cy_list dictsource/cy_rules dictsource/cy_extra dictsource/cy_emoji
 
-da: espeak-ng-data/da_dict
-espeak-ng-data/da_dict: dictsource/da_list dictsource/da_rules dictsource/da_extra dictsource/da_emoji
+da: espeak-ng-data/dicts/da_dict
+espeak-ng-data/dicts/da_dict: dictsource/da_list dictsource/da_rules dictsource/da_extra dictsource/da_emoji
 
-de: espeak-ng-data/de_dict
-espeak-ng-data/de_dict: dictsource/de_list dictsource/de_rules dictsource/de_extra dictsource/de_emoji
+de: espeak-ng-data/dicts/de_dict
+espeak-ng-data/dicts/de_dict: dictsource/de_list dictsource/de_rules dictsource/de_extra dictsource/de_emoji
 
-el: espeak-ng-data/el_dict
-espeak-ng-data/el_dict: dictsource/el_list dictsource/el_rules dictsource/el_extra dictsource/el_emoji
+el: espeak-ng-data/dicts/el_dict
+espeak-ng-data/dicts/el_dict: dictsource/el_list dictsource/el_rules dictsource/el_extra dictsource/el_emoji
 
-en: espeak-ng-data/en_dict
-espeak-ng-data/en_dict: dictsource/en_list dictsource/en_rules dictsource/en_extra dictsource/en_emoji
+en: espeak-ng-data/dicts/en_dict
+espeak-ng-data/dicts/en_dict: dictsource/en_list dictsource/en_rules dictsource/en_extra dictsource/en_emoji
 
-eo: espeak-ng-data/eo_dict
-espeak-ng-data/eo_dict: dictsource/eo_list dictsource/eo_rules dictsource/eo_extra
+eo: espeak-ng-data/dicts/eo_dict
+espeak-ng-data/dicts/eo_dict: dictsource/eo_list dictsource/eo_rules dictsource/eo_extra
 
-es: espeak-ng-data/es_dict
-espeak-ng-data/es_dict: dictsource/es_list dictsource/es_rules dictsource/es_extra dictsource/es_emoji
+es: espeak-ng-data/dicts/es_dict
+espeak-ng-data/dicts/es_dict: dictsource/es_list dictsource/es_rules dictsource/es_extra dictsource/es_emoji
 
-et: espeak-ng-data/et_dict
-espeak-ng-data/et_dict: dictsource/et_list dictsource/et_rules dictsource/et_extra dictsource/et_emoji
+et: espeak-ng-data/dicts/et_dict
+espeak-ng-data/dicts/et_dict: dictsource/et_list dictsource/et_rules dictsource/et_extra dictsource/et_emoji
 
-eu: espeak-ng-data/eu_dict
-espeak-ng-data/eu_dict: dictsource/eu_list dictsource/eu_rules dictsource/eu_extra dictsource/eu_emoji
+eu: espeak-ng-data/dicts/eu_dict
+espeak-ng-data/dicts/eu_dict: dictsource/eu_list dictsource/eu_rules dictsource/eu_extra dictsource/eu_emoji
 
-fa: espeak-ng-data/fa_dict
-espeak-ng-data/fa_dict: dictsource/fa_list dictsource/fa_rules dictsource/fa_extra dictsource/fa_emoji
+fa: espeak-ng-data/dicts/fa_dict
+espeak-ng-data/dicts/fa_dict: dictsource/fa_list dictsource/fa_rules dictsource/fa_extra dictsource/fa_emoji
 
-fi: espeak-ng-data/fi_dict
-espeak-ng-data/fi_dict: dictsource/fi_list dictsource/fi_rules dictsource/fi_extra dictsource/fi_emoji
+fi: espeak-ng-data/dicts/fi_dict
+espeak-ng-data/dicts/fi_dict: dictsource/fi_list dictsource/fi_rules dictsource/fi_extra dictsource/fi_emoji
 
-fo: espeak-ng-data/fo_dict
-espeak-ng-data/fo_dict: dictsource/fo_list dictsource/fo_rules dictsource/fo_extra dictsource/fo_emoji
+fo: espeak-ng-data/dicts/fo_dict
+espeak-ng-data/dicts/fo_dict: dictsource/fo_list dictsource/fo_rules dictsource/fo_extra dictsource/fo_emoji
 
-fr: espeak-ng-data/fr_dict
-espeak-ng-data/fr_dict: dictsource/fr_list dictsource/fr_rules dictsource/fr_extra dictsource/fr_emoji
+fr: espeak-ng-data/dicts/fr_dict
+espeak-ng-data/dicts/fr_dict: dictsource/fr_list dictsource/fr_rules dictsource/fr_extra dictsource/fr_emoji
 
-ga: espeak-ng-data/ga_dict
-espeak-ng-data/ga_dict: dictsource/ga_list dictsource/ga_rules dictsource/ga_extra dictsource/ga_emoji
+ga: espeak-ng-data/dicts/ga_dict
+espeak-ng-data/dicts/ga_dict: dictsource/ga_list dictsource/ga_rules dictsource/ga_extra dictsource/ga_emoji
 
-gd: espeak-ng-data/gd_dict
-espeak-ng-data/gd_dict: dictsource/gd_list dictsource/gd_rules dictsource/gd_extra dictsource/gd_emoji
+gd: espeak-ng-data/dicts/gd_dict
+espeak-ng-data/dicts/gd_dict: dictsource/gd_list dictsource/gd_rules dictsource/gd_extra dictsource/gd_emoji
 
-gn: espeak-ng-data/gn_dict
-espeak-ng-data/gn_dict: dictsource/gn_list dictsource/gn_rules dictsource/gn_extra
+gn: espeak-ng-data/dicts/gn_dict
+espeak-ng-data/dicts/gn_dict: dictsource/gn_list dictsource/gn_rules dictsource/gn_extra
 
-grc: espeak-ng-data/grc_dict
-espeak-ng-data/grc_dict: dictsource/grc_list dictsource/grc_rules dictsource/grc_extra
+grc: espeak-ng-data/dicts/grc_dict
+espeak-ng-data/dicts/grc_dict: dictsource/grc_list dictsource/grc_rules dictsource/grc_extra
 
-gu: espeak-ng-data/gu_dict
-espeak-ng-data/gu_dict: dictsource/gu_list dictsource/gu_rules dictsource/gu_extra dictsource/gu_emoji
+gu: espeak-ng-data/dicts/gu_dict
+espeak-ng-data/dicts/gu_dict: dictsource/gu_list dictsource/gu_rules dictsource/gu_extra dictsource/gu_emoji
 
-hak: espeak-ng-data/hak_dict
-espeak-ng-data/hak_dict: dictsource/hak_list dictsource/hak_rules dictsource/hak_extra
+hak: espeak-ng-data/dicts/hak_dict
+espeak-ng-data/dicts/hak_dict: dictsource/hak_list dictsource/hak_rules dictsource/hak_extra
 
-haw: espeak-ng-data/haw_dict
-espeak-ng-data/haw_dict: dictsource/haw_list dictsource/haw_rules dictsource/haw_extra
+haw: espeak-ng-data/dicts/haw_dict
+espeak-ng-data/dicts/haw_dict: dictsource/haw_list dictsource/haw_rules dictsource/haw_extra
 
-he: espeak-ng-data/he_dict
-espeak-ng-data/he_dict: dictsource/he_list dictsource/he_rules dictsource/he_extra
+he: espeak-ng-data/dicts/he_dict
+espeak-ng-data/dicts/he_dict: dictsource/he_list dictsource/he_rules dictsource/he_extra
 
-hi: espeak-ng-data/hi_dict
-espeak-ng-data/hi_dict: dictsource/hi_list dictsource/hi_rules dictsource/hi_extra dictsource/hi_emoji
+hi: espeak-ng-data/dicts/hi_dict
+espeak-ng-data/dicts/hi_dict: dictsource/hi_list dictsource/hi_rules dictsource/hi_extra dictsource/hi_emoji
 
-hr: espeak-ng-data/hr_dict
-espeak-ng-data/hr_dict: dictsource/hr_list dictsource/hr_rules dictsource/hr_extra dictsource/hr_emoji
+hr: espeak-ng-data/dicts/hr_dict
+espeak-ng-data/dicts/hr_dict: dictsource/hr_list dictsource/hr_rules dictsource/hr_extra dictsource/hr_emoji
 
-ht: espeak-ng-data/ht_dict
-espeak-ng-data/ht_dict: dictsource/ht_list dictsource/ht_rules dictsource/ht_extra
+ht: espeak-ng-data/dicts/ht_dict
+espeak-ng-data/dicts/ht_dict: dictsource/ht_list dictsource/ht_rules dictsource/ht_extra
 
-hu: espeak-ng-data/hu_dict
-espeak-ng-data/hu_dict: dictsource/hu_list dictsource/hu_rules dictsource/hu_extra dictsource/hu_emoji
+hu: espeak-ng-data/dicts/hu_dict
+espeak-ng-data/dicts/hu_dict: dictsource/hu_list dictsource/hu_rules dictsource/hu_extra dictsource/hu_emoji
 
-hy: espeak-ng-data/hy_dict
-espeak-ng-data/hy_dict: dictsource/hy_list dictsource/hy_rules dictsource/hy_extra dictsource/hy_emoji
+hy: espeak-ng-data/dicts/hy_dict
+espeak-ng-data/dicts/hy_dict: dictsource/hy_list dictsource/hy_rules dictsource/hy_extra dictsource/hy_emoji
 
-ia: espeak-ng-data/ia_dict
-espeak-ng-data/ia_dict: dictsource/ia_list dictsource/ia_listx dictsource/ia_rules dictsource/ia_extra
+ia: espeak-ng-data/dicts/ia_dict
+espeak-ng-data/dicts/ia_dict: dictsource/ia_list dictsource/ia_listx dictsource/ia_rules dictsource/ia_extra
 
-id: espeak-ng-data/id_dict
-espeak-ng-data/id_dict: dictsource/id_list dictsource/id_rules dictsource/id_extra dictsource/id_emoji
+id: espeak-ng-data/dicts/id_dict
+espeak-ng-data/dicts/id_dict: dictsource/id_list dictsource/id_rules dictsource/id_extra dictsource/id_emoji
 
-io: espeak-ng-data/io_dict
-espeak-ng-data/io_dict: dictsource/io_list dictsource/io_rules dictsource/io_extra
+io: espeak-ng-data/dicts/io_dict
+espeak-ng-data/dicts/io_dict: dictsource/io_list dictsource/io_rules dictsource/io_extra
 
-is: espeak-ng-data/is_dict
-espeak-ng-data/is_dict: dictsource/is_list dictsource/is_rules dictsource/is_extra dictsource/is_emoji
+is: espeak-ng-data/dicts/is_dict
+espeak-ng-data/dicts/is_dict: dictsource/is_list dictsource/is_rules dictsource/is_extra dictsource/is_emoji
 
-it: espeak-ng-data/it_dict
-espeak-ng-data/it_dict: dictsource/it_list dictsource/it_listx dictsource/it_rules dictsource/it_extra dictsource/it_emoji
+it: espeak-ng-data/dicts/it_dict
+espeak-ng-data/dicts/it_dict: dictsource/it_list dictsource/it_listx dictsource/it_rules dictsource/it_extra dictsource/it_emoji
 
-ja: espeak-ng-data/ja_dict
-espeak-ng-data/ja_dict: dictsource/ja_list dictsource/ja_rules dictsource/ja_extra dictsource/ja_emoji
+ja: espeak-ng-data/dicts/ja_dict
+espeak-ng-data/dicts/ja_dict: dictsource/ja_list dictsource/ja_rules dictsource/ja_extra dictsource/ja_emoji
 
-jbo: espeak-ng-data/jbo_dict
-espeak-ng-data/jbo_dict: dictsource/jbo_list dictsource/jbo_rules dictsource/jbo_extra
+jbo: espeak-ng-data/dicts/jbo_dict
+espeak-ng-data/dicts/jbo_dict: dictsource/jbo_list dictsource/jbo_rules dictsource/jbo_extra
 
-ka: espeak-ng-data/ka_dict
-espeak-ng-data/ka_dict: dictsource/ka_list dictsource/ka_rules dictsource/ka_extra dictsource/ka_emoji
+ka: espeak-ng-data/dicts/ka_dict
+espeak-ng-data/dicts/ka_dict: dictsource/ka_list dictsource/ka_rules dictsource/ka_extra dictsource/ka_emoji
 
-kaa: espeak-ng-data/kaa_dict
-espeak-ng-data/kaa_dict: dictsource/kaa_list dictsource/kaa_rules dictsource/kaa_extra dictsource/kaa_emoji
+kaa: espeak-ng-data/dicts/kaa_dict
+espeak-ng-data/dicts/kaa_dict: dictsource/kaa_list dictsource/kaa_rules dictsource/kaa_extra dictsource/kaa_emoji
 
-kk: espeak-ng-data/kk_dict
-espeak-ng-data/kk_dict: dictsource/kk_list dictsource/kk_rules dictsource/kk_extra dictsource/kk_emoji
+kk: espeak-ng-data/dicts/kk_dict
+espeak-ng-data/dicts/kk_dict: dictsource/kk_list dictsource/kk_rules dictsource/kk_extra dictsource/kk_emoji
 
-kl: espeak-ng-data/kl_dict
-espeak-ng-data/kl_dict: dictsource/kl_list dictsource/kl_rules dictsource/kl_extra
+kl: espeak-ng-data/dicts/kl_dict
+espeak-ng-data/dicts/kl_dict: dictsource/kl_list dictsource/kl_rules dictsource/kl_extra
 
-kn: espeak-ng-data/kn_dict
-espeak-ng-data/kn_dict: dictsource/kn_list dictsource/kn_rules dictsource/kn_extra dictsource/kn_emoji
+kn: espeak-ng-data/dicts/kn_dict
+espeak-ng-data/dicts/kn_dict: dictsource/kn_list dictsource/kn_rules dictsource/kn_extra dictsource/kn_emoji
 
-ko: espeak-ng-data/ko_dict
-espeak-ng-data/ko_dict: dictsource/ko_list dictsource/ko_rules dictsource/ko_extra dictsource/ko_emoji
+ko: espeak-ng-data/dicts/ko_dict
+espeak-ng-data/dicts/ko_dict: dictsource/ko_list dictsource/ko_rules dictsource/ko_extra dictsource/ko_emoji
 
-kok: espeak-ng-data/kok_dict
-espeak-ng-data/kok_dict: dictsource/kok_list dictsource/kok_rules dictsource/kok_extra
+kok: espeak-ng-data/dicts/kok_dict
+espeak-ng-data/dicts/kok_dict: dictsource/kok_list dictsource/kok_rules dictsource/kok_extra
 
-ku: espeak-ng-data/ku_dict
-espeak-ng-data/ku_dict: dictsource/ku_list dictsource/ku_rules dictsource/ku_extra
+ku: espeak-ng-data/dicts/ku_dict
+espeak-ng-data/dicts/ku_dict: dictsource/ku_list dictsource/ku_rules dictsource/ku_extra
 
-ky: espeak-ng-data/ky_dict
-espeak-ng-data/ky_dict: dictsource/ky_list dictsource/ky_rules dictsource/ky_extra dictsource/ky_emoji
+ky: espeak-ng-data/dicts/ky_dict
+espeak-ng-data/dicts/ky_dict: dictsource/ky_list dictsource/ky_rules dictsource/ky_extra dictsource/ky_emoji
 
-la: espeak-ng-data/la_dict
-espeak-ng-data/la_dict: dictsource/la_list dictsource/la_rules dictsource/la_extra
+la: espeak-ng-data/dicts/la_dict
+espeak-ng-data/dicts/la_dict: dictsource/la_list dictsource/la_rules dictsource/la_extra
 
-lb: espeak-ng-data/lb_dict
-espeak-ng-data/lb_dict: dictsource/lb_list dictsource/lb_rules dictsource/lb_emoji
+lb: espeak-ng-data/dicts/lb_dict
+espeak-ng-data/dicts/lb_dict: dictsource/lb_list dictsource/lb_rules dictsource/lb_emoji
 
-lfn: espeak-ng-data/lfn_dict
-espeak-ng-data/lfn_dict: dictsource/lfn_list dictsource/lfn_rules dictsource/lfn_extra
+lfn: espeak-ng-data/dicts/lfn_dict
+espeak-ng-data/dicts/lfn_dict: dictsource/lfn_list dictsource/lfn_rules dictsource/lfn_extra
 
-lt: espeak-ng-data/lt_dict
-espeak-ng-data/lt_dict: dictsource/lt_list dictsource/lt_rules dictsource/lt_extra dictsource/lt_emoji
+lt: espeak-ng-data/dicts/lt_dict
+espeak-ng-data/dicts/lt_dict: dictsource/lt_list dictsource/lt_rules dictsource/lt_extra dictsource/lt_emoji
 
-lv: espeak-ng-data/lv_dict
-espeak-ng-data/lv_dict: dictsource/lv_list dictsource/lv_rules dictsource/lv_extra dictsource/lv_emoji
+lv: espeak-ng-data/dicts/lv_dict
+espeak-ng-data/dicts/lv_dict: dictsource/lv_list dictsource/lv_rules dictsource/lv_extra dictsource/lv_emoji
 
-mi: espeak-ng-data/mi_dict
-espeak-ng-data/mi_dict: dictsource/mi_list dictsource/mi_rules dictsource/mi_extra
+mi: espeak-ng-data/dicts/mi_dict
+espeak-ng-data/dicts/mi_dict: dictsource/mi_list dictsource/mi_rules dictsource/mi_extra
 
-mk: espeak-ng-data/mk_dict
-espeak-ng-data/mk_dict: dictsource/mk_list dictsource/mk_rules dictsource/mk_extra dictsource/mk_emoji
+mk: espeak-ng-data/dicts/mk_dict
+espeak-ng-data/dicts/mk_dict: dictsource/mk_list dictsource/mk_rules dictsource/mk_extra dictsource/mk_emoji
 
-ml: espeak-ng-data/ml_dict
-espeak-ng-data/ml_dict: dictsource/ml_list dictsource/ml_rules dictsource/ml_extra dictsource/ml_emoji
+ml: espeak-ng-data/dicts/ml_dict
+espeak-ng-data/dicts/ml_dict: dictsource/ml_list dictsource/ml_rules dictsource/ml_extra dictsource/ml_emoji
 
-mn: espeak-ng-data/mn_dict
-espeak-ng-data/mn_dict: dictsource/mn_list dictsource/mn_rules dictsource/mn_extra dictsource/mn_emoji
+mn: espeak-ng-data/dicts/mn_dict
+espeak-ng-data/dicts/mn_dict: dictsource/mn_list dictsource/mn_rules dictsource/mn_extra dictsource/mn_emoji
 
-mr: espeak-ng-data/mr_dict
-espeak-ng-data/mr_dict: dictsource/mr_list dictsource/mr_rules dictsource/mr_extra dictsource/mr_emoji
+mr: espeak-ng-data/dicts/mr_dict
+espeak-ng-data/dicts/mr_dict: dictsource/mr_list dictsource/mr_rules dictsource/mr_extra dictsource/mr_emoji
 
-ms: espeak-ng-data/ms_dict
-espeak-ng-data/ms_dict: dictsource/ms_list dictsource/ms_rules dictsource/ms_extra dictsource/ms_emoji
+ms: espeak-ng-data/dicts/ms_dict
+espeak-ng-data/dicts/ms_dict: dictsource/ms_list dictsource/ms_rules dictsource/ms_extra dictsource/ms_emoji
 
-mt: espeak-ng-data/mt_dict
-espeak-ng-data/mt_dict: dictsource/mt_list dictsource/mt_rules dictsource/mt_extra
+mt: espeak-ng-data/dicts/mt_dict
+espeak-ng-data/dicts/mt_dict: dictsource/mt_list dictsource/mt_rules dictsource/mt_extra
 
-mto: espeak-ng-data/mto_dict
-espeak-ng-data/mto_dict: dictsource/mto_list dictsource/mto_rules
+mto: espeak-ng-data/dicts/mto_dict
+espeak-ng-data/dicts/mto_dict: dictsource/mto_list dictsource/mto_rules
 
-my: espeak-ng-data/my_dict
-espeak-ng-data/my_dict: dictsource/my_list dictsource/my_rules dictsource/my_extra dictsource/my_emoji
+my: espeak-ng-data/dicts/my_dict
+espeak-ng-data/dicts/my_dict: dictsource/my_list dictsource/my_rules dictsource/my_extra dictsource/my_emoji
 
-nci: espeak-ng-data/nci_dict
-espeak-ng-data/nci_dict: dictsource/nci_list dictsource/nci_rules dictsource/nci_extra
+nci: espeak-ng-data/dicts/nci_dict
+espeak-ng-data/dicts/nci_dict: dictsource/nci_list dictsource/nci_rules dictsource/nci_extra
 
-ne: espeak-ng-data/ne_dict
-espeak-ng-data/ne_dict: dictsource/ne_list dictsource/ne_rules dictsource/ne_extra dictsource/ne_emoji
+ne: espeak-ng-data/dicts/ne_dict
+espeak-ng-data/dicts/ne_dict: dictsource/ne_list dictsource/ne_rules dictsource/ne_extra dictsource/ne_emoji
 
-nl: espeak-ng-data/nl_dict
-espeak-ng-data/nl_dict: dictsource/nl_list dictsource/nl_rules dictsource/nl_extra dictsource/nl_emoji
+nl: espeak-ng-data/dicts/nl_dict
+espeak-ng-data/dicts/nl_dict: dictsource/nl_list dictsource/nl_rules dictsource/nl_extra dictsource/nl_emoji
 
-no: espeak-ng-data/no_dict
-espeak-ng-data/no_dict: dictsource/no_list dictsource/no_rules dictsource/no_extra
+no: espeak-ng-data/dicts/no_dict
+espeak-ng-data/dicts/no_dict: dictsource/no_list dictsource/no_rules dictsource/no_extra
 
-no: espeak-ng-data/nog_dict
-espeak-ng-data/nog_dict: dictsource/nog_list dictsource/nog_rules dictsource/nog_extra
+no: espeak-ng-data/dicts/nog_dict
+espeak-ng-data/dicts/nog_dict: dictsource/nog_list dictsource/nog_rules dictsource/nog_extra
 
-om: espeak-ng-data/om_dict
-espeak-ng-data/om_dict: dictsource/om_list dictsource/om_rules dictsource/om_extra
+om: espeak-ng-data/dicts/om_dict
+espeak-ng-data/dicts/om_dict: dictsource/om_list dictsource/om_rules dictsource/om_extra
 
-or: espeak-ng-data/or_dict
-espeak-ng-data/or_dict: dictsource/or_list dictsource/or_rules dictsource/or_extra dictsource/or_emoji
+or: espeak-ng-data/dicts/or_dict
+espeak-ng-data/dicts/or_dict: dictsource/or_list dictsource/or_rules dictsource/or_extra dictsource/or_emoji
 
-pa: espeak-ng-data/pa_dict
-espeak-ng-data/pa_dict: dictsource/pa_list dictsource/pa_rules dictsource/pa_extra dictsource/pa_emoji
+pa: espeak-ng-data/dicts/pa_dict
+espeak-ng-data/dicts/pa_dict: dictsource/pa_list dictsource/pa_rules dictsource/pa_extra dictsource/pa_emoji
 
-pap: espeak-ng-data/pap_dict
-espeak-ng-data/pap_dict: dictsource/pap_list dictsource/pap_rules dictsource/pap_extra
+pap: espeak-ng-data/dicts/pap_dict
+espeak-ng-data/dicts/pap_dict: dictsource/pap_list dictsource/pap_rules dictsource/pap_extra
 
-piqd: espeak-ng-data/piqd_dict
-espeak-ng-data/piqd_dict: dictsource/piqd_list dictsource/piqd_rules
+piqd: espeak-ng-data/dicts/piqd_dict
+espeak-ng-data/dicts/piqd_dict: dictsource/piqd_list dictsource/piqd_rules
 
-pl: espeak-ng-data/pl_dict
-espeak-ng-data/pl_dict: dictsource/pl_list dictsource/pl_rules dictsource/pl_extra dictsource/pl_emoji
+pl: espeak-ng-data/dicts/pl_dict
+espeak-ng-data/dicts/pl_dict: dictsource/pl_list dictsource/pl_rules dictsource/pl_extra dictsource/pl_emoji
 
-ps: espeak-ng-data/ps_dict
-espeak-ng-data/ps_dict: dictsource/ps_list dictsource/ps_rules dictsource/ps_extra dictsource/ps_emoji
+ps: espeak-ng-data/dicts/ps_dict
+espeak-ng-data/dicts/ps_dict: dictsource/ps_list dictsource/ps_rules dictsource/ps_extra dictsource/ps_emoji
 
-pt: espeak-ng-data/pt_dict
-espeak-ng-data/pt_dict: dictsource/pt_list dictsource/pt_rules dictsource/pt_extra dictsource/pt_emoji
+pt: espeak-ng-data/dicts/pt_dict
+espeak-ng-data/dicts/pt_dict: dictsource/pt_list dictsource/pt_rules dictsource/pt_extra dictsource/pt_emoji
 
-py: espeak-ng-data/py_dict
-espeak-ng-data/py_dict: dictsource/py_list dictsource/py_rules dictsource/py_extra
+py: espeak-ng-data/dicts/py_dict
+espeak-ng-data/dicts/py_dict: dictsource/py_list dictsource/py_rules dictsource/py_extra
 
-qdb: espeak-ng-data/qdb_dict
-espeak-ng-data/qdb_dict: dictsource/qdb_list dictsource/qdb_rules
+qdb: espeak-ng-data/dicts/qdb_dict
+espeak-ng-data/dicts/qdb_dict: dictsource/qdb_list dictsource/qdb_rules
 
-qu: espeak-ng-data/qu_dict
-espeak-ng-data/qu_dict: dictsource/qu_list dictsource/qu_rules dictsource/qu_extra
+qu: espeak-ng-data/dicts/qu_dict
+espeak-ng-data/dicts/qu_dict: dictsource/qu_list dictsource/qu_rules dictsource/qu_extra
 
-quc: espeak-ng-data/quc_dict
-espeak-ng-data/quc_dict: dictsource/quc_list dictsource/quc_rules dictsource/quc_extra dictsource/quc_emoji
+quc: espeak-ng-data/dicts/quc_dict
+espeak-ng-data/dicts/quc_dict: dictsource/quc_list dictsource/quc_rules dictsource/quc_extra dictsource/quc_emoji
 
-qya: espeak-ng-data/qya_dict
-espeak-ng-data/qya_dict: dictsource/qya_list dictsource/qya_rules
+qya: espeak-ng-data/dicts/qya_dict
+espeak-ng-data/dicts/qya_dict: dictsource/qya_list dictsource/qya_rules
 
-ro: espeak-ng-data/ro_dict
-espeak-ng-data/ro_dict: dictsource/ro_list dictsource/ro_rules dictsource/ro_extra dictsource/ro_emoji
+ro: espeak-ng-data/dicts/ro_dict
+espeak-ng-data/dicts/ro_dict: dictsource/ro_list dictsource/ro_rules dictsource/ro_extra dictsource/ro_emoji
 
-ru: espeak-ng-data/ru_dict
+ru: espeak-ng-data/dicts/ru_dict
 dictsource/ru_listx:
 	ln -svf extra/ru_listx dictsource/
 if HAVE_RU_EXTENDED_DICTIONARY
-espeak-ng-data/ru_dict: dictsource/ru_list dictsource/ru_rules dictsource/ru_extra dictsource/ru_listx dictsource/ru_emoji
+espeak-ng-data/dicts/ru_dict: dictsource/ru_list dictsource/ru_rules dictsource/ru_extra dictsource/ru_listx dictsource/ru_emoji
 else
-espeak-ng-data/ru_dict: dictsource/ru_list dictsource/ru_rules dictsource/ru_extra dictsource/ru_emoji
+espeak-ng-data/dicts/ru_dict: dictsource/ru_list dictsource/ru_rules dictsource/ru_extra dictsource/ru_emoji
 endif
 
-rup: espeak-ng-data/rup_dict
-espeak-ng-data/rup_dict: dictsource/rup_list dictsource/rup_rules dictsource/rup_extra
+rup: espeak-ng-data/dicts/rup_dict
+espeak-ng-data/dicts/rup_dict: dictsource/rup_list dictsource/rup_rules dictsource/rup_extra
 
-sd: espeak-ng-data/sd_dict
-espeak-ng-data/sd_dict: dictsource/sd_list dictsource/sd_rules dictsource/sd_extra dictsource/sd_emoji
+sd: espeak-ng-data/dicts/sd_dict
+espeak-ng-data/dicts/sd_dict: dictsource/sd_list dictsource/sd_rules dictsource/sd_extra dictsource/sd_emoji
 
-shn: espeak-ng-data/shn_dict
-espeak-ng-data/shn_dict: dictsource/shn_list dictsource/shn_rules dictsource/shn_extra
+shn: espeak-ng-data/dicts/shn_dict
+espeak-ng-data/dicts/shn_dict: dictsource/shn_list dictsource/shn_rules dictsource/shn_extra
 
-si: espeak-ng-data/si_dict
-espeak-ng-data/si_dict: dictsource/si_list dictsource/si_rules dictsource/si_extra dictsource/si_emoji
+si: espeak-ng-data/dicts/si_dict
+espeak-ng-data/dicts/si_dict: dictsource/si_list dictsource/si_rules dictsource/si_extra dictsource/si_emoji
 
-sjn: espeak-ng-data/sjn_dict
-espeak-ng-data/sjn_dict: dictsource/sjn_list dictsource/sjn_rules
+sjn: espeak-ng-data/dicts/sjn_dict
+espeak-ng-data/dicts/sjn_dict: dictsource/sjn_list dictsource/sjn_rules
 
-sk: espeak-ng-data/sk_dict
-espeak-ng-data/sk_dict: dictsource/sk_list dictsource/sk_rules dictsource/sk_extra dictsource/sk_emoji
+sk: espeak-ng-data/dicts/sk_dict
+espeak-ng-data/dicts/sk_dict: dictsource/sk_list dictsource/sk_rules dictsource/sk_extra dictsource/sk_emoji
 
-sl: espeak-ng-data/sl_dict
-espeak-ng-data/sl_dict: dictsource/sl_list dictsource/sl_rules dictsource/sl_extra dictsource/sl_emoji
+sl: espeak-ng-data/dicts/sl_dict
+espeak-ng-data/dicts/sl_dict: dictsource/sl_list dictsource/sl_rules dictsource/sl_extra dictsource/sl_emoji
 
-smj: espeak-ng-data/smj_dict
-espeak-ng-data/smj_dict: dictsource/smj_list dictsource/smj_rules
+smj: espeak-ng-data/dicts/smj_dict
+espeak-ng-data/dicts/smj_dict: dictsource/smj_list dictsource/smj_rules
 
-sq: espeak-ng-data/sq_dict
-espeak-ng-data/sq_dict: dictsource/sq_list dictsource/sq_rules dictsource/sq_extra dictsource/sq_emoji
+sq: espeak-ng-data/dicts/sq_dict
+espeak-ng-data/dicts/sq_dict: dictsource/sq_list dictsource/sq_rules dictsource/sq_extra dictsource/sq_emoji
 
 dictsource/sr_emoji:
 	@echo "  EMOJI     $@"
@@ -902,77 +903,78 @@ dictsource/sr_emoji:
 		tools/emoji dictsource/en_emoji sr_Latn ${CLDR_PATH} > $@ ; \
 	fi
 
-sr: espeak-ng-data/sr_dict
-espeak-ng-data/sr_dict: dictsource/sr_list dictsource/sr_rules dictsource/sr_extra dictsource/sr_emoji
+sr: espeak-ng-data/dicts/sr_dict
+espeak-ng-data/dicts/sr_dict: dictsource/sr_list dictsource/sr_rules dictsource/sr_extra dictsource/sr_emoji
 
-sv: espeak-ng-data/sv_dict
-espeak-ng-data/sv_dict: dictsource/sv_list dictsource/sv_rules dictsource/sv_extra dictsource/sv_emoji
+sv: espeak-ng-data/dicts/sv_dict
+espeak-ng-data/dicts/sv_dict: dictsource/sv_list dictsource/sv_rules dictsource/sv_extra dictsource/sv_emoji
 
-sw: espeak-ng-data/sw_dict
-espeak-ng-data/sw_dict: dictsource/sw_list dictsource/sw_rules dictsource/sw_extra dictsource/sw_emoji
+sw: espeak-ng-data/dicts/sw_dict
+espeak-ng-data/dicts/sw_dict: dictsource/sw_list dictsource/sw_rules dictsource/sw_extra dictsource/sw_emoji
 
-ta: espeak-ng-data/ta_dict
-espeak-ng-data/ta_dict: dictsource/ta_list dictsource/ta_rules dictsource/ta_extra dictsource/ta_emoji
+ta: espeak-ng-data/dicts/ta_dict
+espeak-ng-data/dicts/ta_dict: dictsource/ta_list dictsource/ta_rules dictsource/ta_extra dictsource/ta_emoji
 
-te: espeak-ng-data/te_dict
-espeak-ng-data/te_dict: dictsource/te_list dictsource/te_rules dictsource/te_extra dictsource/te_emoji
+te: espeak-ng-data/dicts/te_dict
+espeak-ng-data/dicts/te_dict: dictsource/te_list dictsource/te_rules dictsource/te_extra dictsource/te_emoji
 
-ti: espeak-ng-data/ti_dict
-espeak-ng-data/ti_dict: dictsource/ti_list dictsource/ti_rules dictsource/ti_extra dictsource/ti_emoji
+ti: espeak-ng-data/dicts/ti_dict
+espeak-ng-data/dicts/ti_dict: dictsource/ti_list dictsource/ti_rules dictsource/ti_extra dictsource/ti_emoji
 
-th: espeak-ng-data/th_dict
-espeak-ng-data/th_dict: dictsource/th_list dictsource/th_rules dictsource/th_extra
+th: espeak-ng-data/dicts/th_dict
+espeak-ng-data/dicts/th_dict: dictsource/th_list dictsource/th_rules dictsource/th_extra
 
-tk: espeak-ng-data/tk_dict
-espeak-ng-data/tk_dict: dictsource/tk_list dictsource/tk_listx dictsource/tk_rules dictsource/tk_extra
+tk: espeak-ng-data/dicts/tk_dict
+espeak-ng-data/dicts/tk_dict: dictsource/tk_list dictsource/tk_listx dictsource/tk_rules dictsource/tk_extra
 
-tn: espeak-ng-data/tn_dict
-espeak-ng-data/tn_dict: dictsource/tn_list dictsource/tn_rules dictsource/tn_extra
+tn: espeak-ng-data/dicts/tn_dict
+espeak-ng-data/dicts/tn_dict: dictsource/tn_list dictsource/tn_rules dictsource/tn_extra
 
-tr: espeak-ng-data/tr_dict
-espeak-ng-data/tr_dict: dictsource/tr_list dictsource/tr_rules dictsource/tr_extra dictsource/tr_emoji
+tr: espeak-ng-data/dicts/tr_dict
+espeak-ng-data/dicts/tr_dict: dictsource/tr_list dictsource/tr_rules dictsource/tr_extra dictsource/tr_emoji
 
-tt: espeak-ng-data/tt_dict
-espeak-ng-data/tt_dict: dictsource/tt_list dictsource/tt_rules dictsource/tt_extra
+tt: espeak-ng-data/dicts/tt_dict
+espeak-ng-data/dicts/tt_dict: dictsource/tt_list dictsource/tt_rules dictsource/tt_extra
 
-ug: espeak-ng-data/ug_dict
-espeak-ng-data/ug_dict: dictsource/ug_list dictsource/ug_rules dictsource/ug_extra
+ug: espeak-ng-data/dicts/ug_dict
+espeak-ng-data/dicts/ug_dict: dictsource/ug_list dictsource/ug_rules dictsource/ug_extra
 
-uk: espeak-ng-data/uk_dict
-espeak-ng-data/uk_dict: dictsource/uk_list dictsource/uk_rules dictsource/uk_extra
+uk: espeak-ng-data/dicts/uk_dict
+espeak-ng-data/dicts/uk_dict: dictsource/uk_list dictsource/uk_rules dictsource/uk_extra
 
-ur: espeak-ng-data/ur_dict
-espeak-ng-data/ur_dict: dictsource/ur_list dictsource/ur_rules dictsource/ur_extra dictsource/ur_emoji
+ur: espeak-ng-data/dicts/ur_dict
+espeak-ng-data/dicts/ur_dict: dictsource/ur_list dictsource/ur_rules dictsource/ur_extra dictsource/ur_emoji
 
-uz: espeak-ng-data/uz_dict
-espeak-ng-data/uz_dict: dictsource/uz_list dictsource/uz_rules dictsource/uz_extra
+uz: espeak-ng-data/dicts/uz_dict
+espeak-ng-data/dicts/uz_dict: dictsource/uz_list dictsource/uz_rules dictsource/uz_extra
 
-vi: espeak-ng-data/vi_dict
-espeak-ng-data/vi_dict: dictsource/vi_list dictsource/vi_rules dictsource/vi_extra dictsource/vi_emoji
+vi: espeak-ng-data/dicts/vi_dict
+espeak-ng-data/dicts/vi_dict: dictsource/vi_list dictsource/vi_rules dictsource/vi_extra dictsource/vi_emoji
 
-xex: espeak-ng-data/xex_dict
-espeak-ng-data/xex_dict: dictsource/xex_list dictsource/xex_rules
+xex: espeak-ng-data/dicts/xex_dict
+espeak-ng-data/dicts/xex_dict: dictsource/xex_list dictsource/xex_rules
 
-cmn: espeak-ng-data/cmn_dict
+cmn: espeak-ng-data/dicts/cmn_dict
 dictsource/cmn_listx:
 	ln -svf extra/cmn_listx dictsource/
 if HAVE_CMN_EXTENDED_DICTIONARY
-espeak-ng-data/cmn_dict: dictsource/cmn_list dictsource/cmn_rules dictsource/cmn_listx dictsource/cmn_extra dictsource/cmn_emoji
+espeak-ng-data/dicts/cmn_dict: dictsource/cmn_list dictsource/cmn_rules dictsource/cmn_listx dictsource/cmn_extra dictsource/cmn_emoji
 else
-espeak-ng-data/cmn_dict: dictsource/cmn_list dictsource/cmn_rules dictsource/cmn_extra dictsource/cmn_emoji
+espeak-ng-data/dicts/cmn_dict: dictsource/cmn_list dictsource/cmn_rules dictsource/cmn_extra dictsource/cmn_emoji
 endif
 
-yue: espeak-ng-data/yue_dict
+yue: espeak-ng-data/dicts/yue_dict
 dictsource/yue_listx:
 	ln -svf extra/yue_listx dictsource/
 
 # NOTE: keep in sync with espeak-ng-data/%_dict more generic rule.
 if HAVE_YUE_EXTENDED_DICTIONARY
-espeak-ng-data/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_listx dictsource/yue_emoji
+espeak-ng-data/dicts/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_listx dictsource/yue_emoji
 else
-espeak-ng-data/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_emoji
+espeak-ng-data/dicts/yue_dict: src/espeak-ng phsource/phonemes.stamp dictsource/yue_list dictsource/yue_rules dictsource/yue_extra dictsource/yue_emoji
 endif
 	@echo "  DICT      $@"
+	@mkdir -p espeak-ng-data/dicts
 	rm -f $@
 	cd dictsource && ESPEAK_DATA_PATH=$(CURDIR) LD_LIBRARY_PATH=../src:${LD_LIBRARY_PATH} ../src/espeak-ng --compile=yue && cd ..
 


### PR DESCRIPTION
  - Compile dictionaries into espeak-ng-data/dicts/ subdirectory
  - Read from dicts/ first, fallback to flat structure for compatibility