### PR TITLE
Fix PATH_ESPEAK_DATA macro type

### DIFF
--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -80,7 +80,11 @@ extern "C"
 
 // will look for espeak_data directory here, and also in user's home directory
 #ifndef PATH_ESPEAK_DATA
-   #define PATH_ESPEAK_DATA ("%cespeak-ng-data", PATHSEP)
+#  if defined(_WIN32) || defined(_WIN64)
+#    define PATH_ESPEAK_DATA "\\espeak-ng-data"
+#  else
+#    define PATH_ESPEAK_DATA "/espeak-ng-data"
+#  endif
 #endif
 
 void cancel_audio(void);


### PR DESCRIPTION
While building a project using espeak-ng via Swift Package Manager with Swift 6.2, compilation fails with:

```
error: incompatible integer to pointer conversion passing 'int' to parameter of type 'const char *' [-Wint-conversion]
strcpy(path_home, PATH_ESPEAK_DATA);
```

The `PATH_ESPEAK_DATA` macro is defined as a comma expression `("%cespeak-ng-data", PATHSEP)` which evaluates to `PATHSEP` (an int), not a string. Newer compilers with strict settings treat this as an error.

This fixes the macro to return a proper string literal based on platform.