### PR TITLE
Following Spanish adverb exceptions for espeak-ng

### DIFF
--- a/dictsource/es_list
+++ b/dictsource/es_list
@@ -355,8 +355,9 @@ grismente gr'ism'ente
 ali $u $stem
 argu $u $stem
 ator $u $stem
-condi $u $stem
 comple $u $stem
+condi $u $stem
+contraargu $u $stem
 cumpli $u $stem
 depri $u $stem
 desfrag $u $stem


### PR DESCRIPTION
We collected this new exception list according to our recent upcoming feature to support proper adverb stress in our own g2p.

However, it would be OK to have this advantage in espeak-ng too - Some LLM-based and neural TTS systems are currently using this as a phonemizer backend.

Cheers.