### PR TITLE
Fixes English

### DIFF
--- a/dictsource/en_list
+++ b/dictsource/en_list
@@ -420,7 +420,7 @@ U+303	tIld@_
 U+304	makr0n_
 U+306	brEv_
 U+308	daI3ri:sI2s
-U+30a	rINg_
+U+30a	rIN_
 U+31e	a#pr'0ksIm@nt_
 U+325	vOIsl@s_  // ring below
 U+32a	dEnt@L_

--- a/dictsource/en_rules
+++ b/dictsource/en_rules
@@ -117,8 +117,8 @@
      r) a (ciA     eI
      w) a (d       0
     ow) a (d       @
-        ae         i:
-     @) aea        'i@
+        ae         eI
+     @) aea        'eI@
      @) aed (_S2   d
         ae (l      eI
         aeg (er    eIg


### PR DESCRIPTION
Fixing English for following features:

- Fixing group letter "a" for "ae" which was incorrect;
- Fixing pronouncing "ring" capital letter which was still incorrect.