### PR TITLE
cmake: default ESPEAK_COMPAT to ON

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -13,4 +13,4 @@ else()
   set(USE_ASYNC OFF)
 endif()
 
-option(ESPEAK_COMPAT "Install compat binary symlinks" OFF)
+option(ESPEAK_COMPAT "Install compat binary symlinks" ON)


### PR DESCRIPTION
So that we get the compatibility symlinks[1] like we had before the
cmake rewrite.

AFAICT, losing the symlinks was unintentional; it's not mentioned in
ChangeLog.md, and README.md still documents that

  The build creates symlinks of `espeak` to `espeak-ng`, and `speak` to `speak-ng`.

[1] `espeak` and `speak` pointing to `espeak-ng`. (There is no
`speak-ng` ELF anymore, only symlink.)

Fixes: c60a49d7118639396412c511221a85bdb3cda414 ("build: support building with cmake")
