### PR TITLE
Fixes Belarusian

### DIFF
--- a/dictsource/be_list
+++ b/dictsource/be_list
@@ -3,7 +3,7 @@
 
 // Letter names
 а       a $u
-б       b $u
+б       bE $u
 в       vE $u
 г       QE $u
 д       dE $u
@@ -34,32 +34,33 @@
 э       E $u
 ю       ju $u
 я       ja $u
+'       ap'Ostraf
 
 // Numbers
-_0     n'ul;
+_0     n'ul;I^
 _1     adz;'in
 _1f    adna
 _2     dv'a
 _2f    dz;v;'E
 _3     tr'i"
 _4     ts.at'i"ri"
-_5     p;'ats;
-_6     s.'Es;ts;
+_5     p;'ats;I^
+_6     s.'Es;ts;I^
 _7     s;'Em
 _8     v'Os;Em
-_9     dz;'Ev;ats;
-_10    dz;'Es;ats;
-_11    adz;'inats:ats;
-_12    dvan'ats:ats;
-_13    tri"n'ats:ats;
-_14    ts.at'i"rnats:ats;
-_15    p;atn'ats:ats;
-_16    s.asn'ats:ats;
-_17    s;amn'ats:ats;
-_18    vas;amn'ats:ats;
-_19    dz;Ev;atn'ats:ats;
-_2X    dv'ats:ats;||
-_3X    tr'i"ts:ats;||
+_9     dz;'Ev;ats;I^
+_10    dz;'Es;ats;I^
+_11    adz;'inats:ats;I^
+_12    dvan'ats:ats;I^
+_13    tri"n'ats:ats;I^
+_14    ts.at'i"rnats:ats;I^
+_15    p;atn'ats:ats;I^
+_16    s.asn'ats:ats;I^
+_17    s;amn'ats:ats;I^
+_18    vas;amn'ats:ats;I^
+_19    dz;Ev;atn'ats:ats;I^
+_2X    dv'ats:ats;I^||
+_3X    tr'i"ts:ats;I^||
 _4X    s'Orak||
 _5X    p;adz;:Es;'at||
 _6X    s.Ezdz;:Es;'at||
@@ -79,6 +80,6 @@ _1MA1  t'i"s;ats.a
 _0MA1  t'i"s;ats.i"
 _0M1   t'i"s;ats.      // NOTE: in 10k > appends `_!`
 
-# exceptions
+// exceptions
 дождж d'Os.ts.
 відзскі v;'itsk;i

--- a/dictsource/be_rules
+++ b/dictsource/be_rules
@@ -32,11 +32,13 @@
 
 .group б
        б       b
+	   б (L04 b;
        б (_    p
        б (L02  p
 
 .group в
        в       v
+	   в (L04  v;
 
 .group г
        г       Q     // ɣ
@@ -48,6 +50,7 @@
        д (_    t
        д (L02  t
        дз      dz
+	   дз (L04 dz;
        дз (_   ts
        дж      dz.
        дж (_   ts.
@@ -93,12 +96,15 @@
 
 .group л
        л       l
+	   л (L04  l;
 
 .group м
        м       m
+	   м (L04  m;
 
 .group н
        н       n
+	   н (L04  n;
 
 .group о
        о       'O
@@ -106,6 +112,7 @@
 .group п
        п       p
        п (L03  b
+	   п (L04  p;
 
 .group р
        р       r
@@ -139,6 +146,7 @@
        ц       ts    // t͡s
        цц      ts:
        ц (L03  dz
+	   ц (ь    ts;
 
 .group ч
        ч       ts.   // ʈ͡ʂ
@@ -155,6 +163,7 @@
 
 .group ь
        ь       ;     // ʲ
+	   ь (_    I^
 
 .group э
        э       E     // ɛ

--- a/phsource/ph_belarusian
+++ b/phsource/ph_belarusian
@@ -119,7 +119,6 @@ phoneme k;
   vls vel stp pzd
   ipa kʲ
   lengthmod 2
-  voicingswitch g;
 
   Vowelin f1=0  f2=2700 400 600  f3=300 80 rate len=70
   Vowelout f1=1  f2=2700 400 600  f3=200 70 len=50 colr=1
@@ -214,7 +213,6 @@ phoneme v;
   vcd lbd frc pzd
   ipa vʲ
   lengthmod 6
-  voicingswitch f;
 
   Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80
   Vowelout f1=2 f2=2700 400 600  f3=200 80 rate len=100 colr=1

--- a/phsource/ph_belarusian
+++ b/phsource/ph_belarusian
@@ -3,10 +3,17 @@
 //====================================================
 
 phoneme a
-  vwl   starttype #a  endtype #a
+  vwl starttype #a  endtype #a
   ipa a
   length 180
-  FMT(vowel/a)
+  FMT(vwl_ru/a)
+endphoneme
+
+phoneme E
+  vwl starttype #e endtype #e
+  ipa ɛ
+  length 180
+  FMT(vwl_ru/e)
 endphoneme
 
 phoneme i"
@@ -16,9 +23,11 @@ phoneme i"
   FMT(vowel/ii#_2)
 endphoneme
 
+
+// Consonants
+
 phoneme Q
   import_phoneme base1/Q"
-  ipa ɣ
 endphoneme
 
 phoneme ts
@@ -28,9 +37,29 @@ phoneme ts
 endphoneme
 
 phoneme ts;
-  CALL base1/tS;
-  voicingswitch dz;
+  vls alv afr sib
   ipa t͡sʲ
+  lengthmod 2
+  CALL base2/ts
+  Vowelout f1=0 f2=1700 -300 250  f3=-100 80  rms=20 colr=1
+endphoneme
+
+phoneme dz;
+  vcd alv afr pzd
+   ipa d͡zʲ
+  voicingswitch ts
+  lengthmod 5
+  Vowelin f1=1  f2=1700 -300 300  f3=-100 80 len=50
+  Vowelout f1=2 f2=1700 -300 300  f3=-100 80
+
+  IF PreVoicing THEN
+    FMT(d/xd)
+  ENDIF
+
+  IF nextPh(isPause2) THEN
+    FMT(voc/z_) addWav(ustop/ts_, 60)
+  ENDIF
+  FMT(d/xdz) addWav(ustop/ts, 140)
 endphoneme
 
 phoneme ts.
@@ -38,8 +67,9 @@ phoneme ts.
   ipa ʈ͡ʂ
   lengthmod 2
   voicingswitch dz.
-  Vowelin f1=0  f2=2300 200 400  f3=-100 80
-  WAV(ustop/tsh_sr, 50)
+  Vowelin  f1=0  f2=1800 -100 300  f3=-300 80
+  Vowelout f1=0  f2=1800 -100 300  f3=-300 80
+   WAV(ustop/ts_rfx_unasp)
 endphoneme
 
 phoneme dz
@@ -48,20 +78,120 @@ phoneme dz
   ipa d͡z
 endphoneme
 
-phoneme dz;
-  import_phoneme pl/dz;
-  CALL base1/dZ;
-  voicingswitch ts;
-  ipa d͡zʲ
-endphoneme
-
 phoneme dz.
   vcd pla afr sib
   ipa ɖ͡ʐ
   lengthmod 5
-  voicingswitch ts.
-  Vowelin f1=2  f2=2300 200 400  f3=100 80
-  Vowelout f1=2  f2=2300 250 300  f3=100 80 brk
+  voicingswitch tS
+  Vowelin f1=2  f2=1900 100 300  f3=100 80
+  Vowelout f1=2  f2=1900 100 300  f3=100 80 brk
+
+  IF PreVoicing THEN
+    FMT(dzh/xdzh)
+  ENDIF
+
+  IF nextPh(isPause2) THEN
+    FMT(dzh/dzh_) addWav(ustop/tsh2, 50)
+  ENDIF
+  FMT(dzh/dzh2) addWav(ustop/tsh2, 80)
+endphoneme
+
+phoneme b;
+  vcd blb stp pzd 
+  ipa bʲ
+  lengthmod 5
+  voicingswitch p;
+
+  Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80
+  Vowelout f1=2 f2=2700 400 600  f3=200 80 rate len=100 colr=1
+
+  IF PreVoicing THEN
+    FMT(b/xb)
+  ENDIF
+  IF nextPh(isPause2) THEN
+    FMT(b/b_) addWav(x/b_)
+  ELSE
+    FMT(b/b) addWav(x/b)
+  ENDIF
+endphoneme
+
+phoneme k;
+  vls vel stp pzd
+  ipa kʲ
+  lengthmod 2
+  voicingswitch g;
+
+  Vowelin f1=0  f2=2700 400 600  f3=300 80 rate len=70
+  Vowelout f1=1  f2=2700 400 600  f3=200 70 len=50 colr=1
+  
+  IF nextPh(isPause2) THEN
+    WAV(ustop/k_)
+  ELSE
+    WAV(ustop/ki)
+  ENDIF
+endphoneme
+
+phoneme l;
+  liquid pzd
+  ipa lʲ
+  lengthmod 7
+
+  Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80
+  Vowelout f1=2 f2=2700 400 600  f3=200 80 rate len=70 colr=1
+
+  FMT(l/l)
+endphoneme
+
+phoneme m;
+  vcd blb nas
+  Vowelout f1=2  f2=1000 -500 -350  f3=-200 80 brk
+  lengthmod 4
+
+  IF KlattSynth THEN
+    Vowelin  f1=0  f2=1000 -50 -200  f3=-200 80
+    IF nextPh(isPause2) THEN
+      FMT(klatt/m_)
+    ENDIF
+    FMT(klatt/m)
+  ENDIF
+
+  VowelStart(m/mi)
+
+  FMT(m/mj)
+endphoneme
+
+phoneme n;
+  vcd alv nas pzd
+  ipa nʲ 
+  voicingswitch t;
+  lengthmod 3
+  length 100
+  Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80
+  Vowelout f1=2 f2=2700 400 600  f3=200 80 rate len=70 colr=1
+
+  IF prevPh(isPause) THEN
+    FMT(n^/_n^)
+  ELIF nextPh(isNotVowel) THEN
+    FMT(n^/n^_)
+  ELSE
+    FMT(n^/n^_)
+  ENDIF
+endphoneme
+
+phoneme p;
+  vls blb stp pzd 
+  ipa pʲ
+  lengthmod 2
+  voicingswitch b;
+
+  Vowelin f1=0  f2=2700 400 600  f3=300 80 rate len=70
+  Vowelout f1=1  f2=2700 400 600  f3=200 70 len=50 colr=1
+
+  IF nextPh(isPause2) THEN
+    WAV(ustop/p_)
+  ELSE
+    WAV(ustop/p)
+  ENDIF
 endphoneme
 
 phoneme r
@@ -74,16 +204,71 @@ endphoneme
 
 phoneme s;
   import_phoneme base1/s;
-  ipa sʲ
 endphoneme
 
 phoneme z;
   import_phoneme base1/z;
-  ipa zʲ
 endphoneme
 
-phoneme ;
+phoneme v;
+  vcd lbd frc pzd
+  ipa vʲ
+  lengthmod 6
+  voicingswitch f;
+
+  Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80
+  Vowelout f1=2 f2=2700 400 600  f3=200 80 rate len=100 colr=1
+
+  IF nextPh(isPause2) THEN
+    FMT(voc/v_) addWav(vocw/v)
+  ELSE
+    FMT(voc/v) addWav(vocw/v)
+  ENDIF
+endphoneme
+
+
+// Palatalized versions of consonants
+
+phoneme I^ // "silent i", palatilizes the preceding consonant
+  vwl starttype #i endtype #i
+  unstressed nsy
+  length 70
+  IF nextPh(isVowel) THEN
+    ChangePhoneme(;)
+  ENDIF
+  IF prevPh(m;) THEN
+    FMT(vwl_ro/mi)
+  ENDIF
+  FMT(vwl_ru/ii-)
+endphoneme
+
+phoneme ;     // linking j, used between (i) vowels and a following vowel
+              // also to palatalize consonants
   liquid pzd
   lengthmod 0
-  ipa ʲ
+
+  IF prevPh(#i) THEN
+    ipa NULL   // linking after i vowel, don't show in ipa
+  ENDIF
+
+  IF nextPh(isNotVowel) THEN
+    ChangePhoneme(NULL)   // this is to ignore this phoneme if not before a vowel
+  ENDIF
+
+  NextVowelStarts
+    VowelStart(j2/j2@)
+    VowelStart(j2/j2a)
+    VowelStart(j2/j2e)
+    VowelStart(j2/j2i)
+    VowelStart(j2/j2o)
+    VowelStart(j2/j2u)
+  EndSwitch
+
+  IF prevPh(#i) THEN
+    VowelEnding(j2/xj2, -40)
+  ENDIF
+
+  IF prevPh(isPause) THEN
+    FMT(j2/_j2)
+  ENDIF
 endphoneme

--- a/phsource/ph_belarusian
+++ b/phsource/ph_belarusian
@@ -161,8 +161,7 @@ endphoneme
 
 phoneme n;
   vcd alv nas pzd
-  ipa nʲ 
-  voicingswitch t;
+  ipa nʲ
   lengthmod 3
   length 100
   Vowelin f1=2  f2=2700 400 600  f3=200 80 rate len=80

--- a/tests/language-phonemes.test
+++ b/tests/language-phonemes.test
@@ -22,7 +22,7 @@ test_phwav ar b102bcd61f4a81e22cb7a398691d2703fd5ace46 "ma na pa ta ka qa ?a ba 
 test_phwav as 05d4cca91fc3447ae8b6acd7892790dd364e8e23 "ma na Na pa ta ka p#a t#a k#a ba da ga b#a d#a g#a sa xa Xa ha tSa tS#a za wa ra ja la _:_ ma mi mu me m& mo mO mV ma~ mi~ mu~ me~ m&~ mo~ mO~ moj mo~j mow mo~w mew maV m@"
 test_phwav az 7bdb78c37433a47fb3b15808071b1a916202400c "ma na pa ba ta da tSa dZa tsa dza ca Ja Ca ka ga fa va sa za Sa Za xa Qa ha la ja wa Ra *a _:_ mi me m& my mW mu mo ma m@"
 test_phwav ba cf21e5edc1227d3483f49305fbb39e201e5a7f97 "ma na pa ba ta da tSa dZa tsa dza ca Ja Ca ka ga fa va sa za Sa Za xa Qa ha la ja wa Ra *a _:_ mi me m& my mW mu mo ma m@"
-test_phwav be 46e35280b05300c9b7ed2a6dd0434c299689b673 "a i\" Q;E Qu tsO ts;E ts:E ts.u ts.O ts.;E ts.:a dzO dz;a dz.O dz.u"
+test_phwav be f2618f59d1214e2a989b531fc29a565e818820e1 "a i\" Q;E Qu tsO ts;E ts:E ts.u ts.O ts.;E ts.:a dzO dz;a dz.O dz.u"
 test_phwav bg 3020acb23ac0f93d5479de3b305b71fc07b5e738 "ma na n^a Na m;a pa ba ta da ka ga p;a b;a t;a d;a ca Ja tsa dza tSa dZa ts;a dz;a fa va sa za Sa Za xa Qa f;a v;a s;a z;a x;a Ra R;a wa ja l/2a la l^a _:_ mi me m@ ma mo mu"
 test_phwav bn 7fc6c8c6b347677885c6e973ff4dc6b2b6fa6d59 "ma na Na pa ta t.a tSa ka p#a t#a t.#a tS#a k#a ba da d.a dZa ga b#a d#a d.#a g#a fa Ba sa za Sa Za ha Ha wa la ja ra *a Ra _:_ ma mE mO me mi mi mu m& mV"
 test_phwav bpy 7fc6c8c6b347677885c6e973ff4dc6b2b6fa6d59 "ma na Na pa ta t.a tSa ka p#a t#a t.#a tS#a k#a ba da d.a dZa ga b#a d#a d.#a g#a fa Ba sa za Sa Za ha Ha wa la ja ra *a Ra _:_ ma mE mO me mi mi mu m& mV"


### PR DESCRIPTION
Fixes Belarusian for the following:
- incorrect pronouncing with ts;, dz;, ts., dz, s;, z; etc.
- fixing incorrect numbers
- fixing incorrect rules pronounciations for any group of letters.