### PR TITLE
ci: skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for fork PRs — secrets and OIDC tokens are unavailable
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip the `claude-review` job on PRs from forks, since OIDC tokens and repository secrets are unavailable in that context
- Fixes the `Could not fetch an OIDC token` error seen on external contributor PRs (e.g. #2242)

## Test plan
- [ ] Verify the `claude-review` check no longer runs (and fails) on fork PRs
- [ ] Verify the `claude-review` check still runs on same-repo PRs