### PR TITLE
Fix Spanish MBrola files

### DIFF
--- a/espeak-ng-data/voices/mb/mb-es3
+++ b/espeak-ng-data/voices/mb/mb-es3
@@ -2,5 +2,5 @@ language es-es 3
 language es 3
 name spanish-mbrola-3
 gender female
-pitch 140 260
+pitch 140 230
 mbrola es3 es3_phtrans

--- a/phsource/mbrola/es
+++ b/phsource/mbrola/es
@@ -15,12 +15,13 @@
 
 0  ** NULL   0  r
 0  R  NULL   0  rr
-0  R2 NULL   0  NULL
+0  R2 NULL   0  rr
 0  v# NULL   0  b
 0  v  NULL   0  b
 0  j  NULL   0  i
+0  j: NULL   0  i
 0  J  NULL   0  L
-0  J^ NULL   0  L
+0  J^ NULL   0  jj
 0  n^ NULL   0  J
 0  N  NULL   0  n
 0  B  NULL   0  b
@@ -31,7 +32,9 @@
 0  T  s      0  s
 
 0  a/ NULL   0  a
+0  e/ NULL   0  e
 0  E  NULL   0  e
+0  o/ NULL   0  o
 0  O  NULL   0  o
 0  aI NULL   60 a i
 0  eI NULL   60 e i
@@ -40,8 +43,10 @@
 0  eU NULL   60 e u
 
 0  dZ NULL   0  tS
-0  S  NULL   60 s jj
-0  Z  NULL   60 s jj
+0  tS NULL   0  tS
+0  ts NULL   50 t s
+0  S  NULL   90 s jj
+0  Z  NULL   90 s jj
 
 0  @  NULL   0  e
 0  @2 NULL   0  e

--- a/phsource/mbrola/es3
+++ b/phsource/mbrola/es3
@@ -1,44 +1,71 @@
 volume 15
+
+0  a   a     0   NULL
+0  a   a/    0   NULL
 0  a   NULL  0   a
+0  a/  a     0   NULL
+0  a/  a/    0   NULL
 0  a/  NULL  0   a
 0  a:  NULL  50  a   a
+0  aI  NULL  60  a   i
+0  aU  NULL  60  a   u
 0  B   NULL  0   b
 0  b   NULL  0   b
 0  D   NULL  0   d
+0  d   NULL  0   d
 0  E   NULL  0   e
 0  e   NULL  0   e
 0  e/  NULL  0   e
 0  e:  NULL  50  e   e
+0  eI  NULL  60  e   i
+0  eU  NULL  60  e   u
 0  f   NULL  0   f
 0  g   NULL  0   g
-0  h   NULL  0   h
+0  h   NULL  0   NULL
 0  i   NULL  0   i
 0  i:  NULL  50  i   i
-0  y   NULL  0   y
-0  j   NULL  0   j
+0  y   NULL  0   i
+0  j   NULL  0   i
+0  J^  NULL  0   Y		// Y is J^ in es3
 0  k   NULL  0   k
 0  l   NULL  0   l
-0  l^ NULL   0  L
+0  l^  NULL  60  l   i		// there's no L in es3
 0  l/  NULL  0   l
 0  m   NULL  0   m
 0  N   NULL  0   n
 0  n   NULL  0   n
-0  n^  NULL  0   n
-0  **  NULL  0   h
+0  n^  NULL  60  n   i		// there's no J in es3
+0  o   o     0   NULL
+0  o   o/    0   NULL
 0  o   NULL  0   o
+0  o/  o     0   NULL
+0  o/  o/    0   NULL
 0  o/  NULL  0   o
 0  o:  NULL  50  o   o
+0  oI  NULL  60  o   i
 0  p   NULL  0   p
-0  Q   NULL  0   H
+0  Q   NULL  0   g
 0  q   NULL  0   k
+0  **  NULL  0   r
 0  r   NULL  0   r
+0  R   NULL  0   R		// R is r (trill, strong r) in es3
+0  R2  NULL  0   R
+0  s   x     50  s  _
+0  s   s     0   NULL
 0  s   NULL  0   s
-0  T   NULL  0   t
+0  T   NULL  0   z		// z is T in es3, as in 'zorro'
 0  t   NULL  0   t
 0  u   NULL  0   u
 0  u:  NULL  50  u   u
 0  v   NULL  0   b
 0  v#  NULL  0   b
-0  w   NULL  0   b
-0  x   NULL  0   H
+0  w   NULL  0   u
+0  x   NULL  0   j		// j is x in es3, as in 'mujer'
 0  z   NULL  0   z
+
+0  dZ  NULL  60  H		// H is close to dZ in es3, as in 'hache'
+0  tS  NULL  0   H		// H is tS in es3, as in 'hache'
+0  ts  NULL  0   H		// pizza :p
+0  S   NULL  90  s i
+0  Z   NULL  90  s i
+0  ;   NULL  0   NULL

--- a/phsource/mbrola/es4
+++ b/phsource/mbrola/es4
@@ -1,46 +1,61 @@
 volume 15
+
 0  a   NULL  0   a
 0  a/  NULL  0   a
 0  a:  NULL  50  a   a
+0  aI  NULL  60  a   i
+0  aU  NULL  60  a   u
 0  B   NULL  0   b
 0  b   NULL  0   b
 0  D   NULL  0   d
+0  d   NULL  0   d
 0  E   NULL  0   e
 0  e   NULL  0   e
 0  e/  NULL  0   e
 0  e:  NULL  50  e   e
+0  eI  NULL  60  e   i
+0  eU  NULL  60  e   u
 0  f   NULL  0   f
 0  g   NULL  0   g
-0  h   NULL  0   jj
+0  h   NULL  0   NULL
 0  i   NULL  0   i
 0  i:  NULL  50  i   i
 0  y   NULL  0   i
-0  j   NULL  0   j
+0  j   NULL  0   i
+0  J^  NULL  0   i
 0  k   NULL  0   k
-0  l   NULL  0   L
-0  l^ NULL   0  L
-0  l/  NULL  0   L
+0  l   NULL  0   l
+0  l^  NULL  0   L
+0  l/  NULL  0   l
 0  m   NULL  0   m
-0  n^  NULL  0   J
 0  N   NULL  0   n
 0  n   NULL  0   n
-0  **  NULL  0   jj
+0  n^  NULL  0   J
 0  o   NULL  0   o
 0  o/  NULL  0   o
 0  o:  NULL  50  o   o
+0  oI  NULL  60  o   i
 0  p   NULL  0   p
-0  Q   NULL  0   jj
+0  Q   NULL  0   g
 0  q   NULL  0   k
+0  **  NULL  0   r
 0  r   NULL  0   r
 0  R   NULL  0   rr
+0  R2  NULL  0   rr
 0  s   NULL  0   s
 0  T   NULL  0   T
 0  t   NULL  0   t
-0  tS  NULL  0   tS
 0  u   NULL  0   u
 0  u:  NULL  50  u   u
 0  v   NULL  0   b
 0  v#  NULL  0   b
-0  w   NULL  0   b
+0  w   NULL  0   u
 0  x   NULL  0   x
 0  z   NULL  0   z
+
+0  dZ  NULL  60  tS
+0  tS  NULL  0   tS
+0  ts  NULL  50  t   s
+0  S   NULL  90  s i
+0  Z   NULL  90  s i
+0  ;   NULL  0   NULL


### PR DESCRIPTION
Many phonemes in the MBrola files for the Spanish language were incorrect, particularly in the `es3` voice file. Consequently, MBrola's pronunciation of `es3` was incomprehensible.

The [official documentation](https://github.com/numediart/MBROLA-voices/tree/master/data/es3) for `es3` in MBrola project itself is incorrect.