### PR TITLE
Android: fall back to available voice when requested language is filtered out

### DIFF
--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
@@ -18,12 +18,15 @@ package com.reecedunn.espeak.test;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.speech.tts.TextToSpeech;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import com.reecedunn.espeak.LanguageSettings;
 import com.reecedunn.espeak.TtsService;
 import com.reecedunn.espeak.Voice;
 
@@ -32,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
@@ -69,6 +73,10 @@ public class TextToSpeechServiceTest
             return mMatchingVoice;
         }
 
+        public int selectLanguageWithFallback(String language, String country, String variant) {
+            return super.selectLanguageWithFallback(language, country, variant);
+        }
+
         @SuppressLint("NewApi")
         private android.speech.tts.Voice getVoice(String name) {
             for (android.speech.tts.Voice voice : onGetVoices()) {
@@ -81,21 +89,28 @@ public class TextToSpeechServiceTest
     }
 
     private TtsServiceTest mService = null;
+    private Context mContext = null;
 
     @Before
     public void setUp() throws Exception
     {
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        mContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            context = context.createDeviceProtectedStorageContext();
+            mContext = mContext.createDeviceProtectedStorageContext();
         }
-        mService = new TtsServiceTest(context);
+        mService = new TtsServiceTest(mContext);
         mService.onCreate();
     }
 
     @After
     public void tearDown()
     {
+        if (mContext != null) {
+            PreferenceManager.getDefaultSharedPreferences(mContext)
+                    .edit()
+                    .remove(LanguageSettings.PREF_SUPPORTED_LANGUAGES)
+                    .apply();
+        }
         if (mService != null)
         {
             mService.onDestroy();
@@ -269,5 +284,78 @@ public class TextToSpeechServiceTest
                 assertThat(features.size(), is(0));
             }
         }
+    }
+
+    private void setFilteredLanguages(String... voiceIds) {
+        Set<String> selected = new HashSet<>();
+        for (String id : voiceIds) {
+            selected.add(id);
+        }
+        PreferenceManager.getDefaultSharedPreferences(mContext)
+                .edit()
+                .putStringSet(LanguageSettings.PREF_SUPPORTED_LANGUAGES, selected)
+                .commit();
+    }
+
+    @Test
+    public void testOnIsLanguageAvailable_filteredFallback() {
+        // Filter to Russian only.
+        setFilteredLanguages("rus");
+
+        // English is not in the filtered set, but Russian is available.
+        // Should report LANG_AVAILABLE so screen readers don't skip this engine.
+        assertThat(mService.onIsLanguageAvailable("eng", "", ""),
+                isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
+    }
+
+    @Test
+    public void testOnLoadLanguage_filteredFallback_freshStart() {
+        // Filter to Russian only.
+        setFilteredLanguages("rus");
+
+        // Fresh start: no voice loaded yet, requesting English.
+        // Should fall back to Russian and report LANG_AVAILABLE.
+        assertThat(mService.onLoadLanguage("eng", "", ""),
+                isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
+        assertThat(mService.getActiveVoice(), is(notNullValue()));
+        assertThat(mService.getActiveVoice().name, is("ru"));
+    }
+
+    @Test
+    public void testOnLoadLanguage_filteredFallback_reusesExistingVoice() {
+        // Load Russian first.
+        assertThat(mService.onLoadLanguage("rus", "", ""),
+                isTtsLangCode(TextToSpeech.LANG_COUNTRY_VAR_AVAILABLE));
+        assertThat(mService.getActiveVoice().name, is("ru"));
+
+        // Now filter to Russian only.
+        setFilteredLanguages("rus");
+
+        // Request English — should keep the previously loaded Russian voice.
+        assertThat(mService.onLoadLanguage("eng", "", ""),
+                isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
+        assertThat(mService.getActiveVoice(), is(notNullValue()));
+        assertThat(mService.getActiveVoice().name, is("ru"));
+    }
+
+    @Test
+    public void testSelectLanguageWithFallback_filteredToRussianOnly() {
+        // Filter to Russian only.
+        setFilteredLanguages("rus");
+
+        // Fresh start: requesting English should fall back to Russian.
+        int result = mService.selectLanguageWithFallback("eng", "", "");
+        assertThat(result, is(TextToSpeech.SUCCESS));
+        assertThat(mService.getActiveVoice(), is(notNullValue()));
+        assertThat(mService.getActiveVoice().name, is("ru"));
+    }
+
+    @Test
+    public void testSelectLanguageWithFallback_supportedLanguageStillWorks() {
+        // With all languages available, requesting English should work normally.
+        int result = mService.selectLanguageWithFallback("eng", "", "");
+        assertThat(result, is(TextToSpeech.SUCCESS));
+        assertThat(mService.getActiveVoice(), is(notNullValue()));
+        assertThat(mService.getActiveVoice().name, startsWith("en-gb"));
     }
 }

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
@@ -77,6 +77,10 @@ public class TextToSpeechServiceTest
             return super.selectLanguageWithFallback(language, country, variant);
         }
 
+        public void rebuildAvailableVoicesNow() {
+            rebuildAvailableVoices();
+        }
+
         @SuppressLint("NewApi")
         private android.speech.tts.Voice getVoice(String name) {
             for (android.speech.tts.Voice voice : onGetVoices()) {
@@ -161,7 +165,10 @@ public class TextToSpeechServiceTest
         assertThat(mService.getActiveVoice(), is(notNullValue()));
         assertThat(mService.getActiveVoice().name, is(defaultEnName));
 
-        assertThat(mService.onLoadLanguage("ine", "", ""), isTtsLangCode(TextToSpeech.LANG_NOT_SUPPORTED));
+        // Genuinely unsupported languages now fall back to the previously
+        // loaded voice and report LANG_AVAILABLE so screen readers don't skip
+        // the engine.
+        assertThat(mService.onLoadLanguage("ine", "", ""), isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
         assertThat(mService.getActiveVoice(), is(notNullValue()));
         assertThat(mService.getActiveVoice().name, is(defaultEnName));
     }
@@ -205,7 +212,9 @@ public class TextToSpeechServiceTest
         assertThat(mService.getActiveVoice(), is(notNullValue()));
         assertThat(mService.getActiveVoice().name, is("vi-vn-x-central"));
 
-        assertThat(mService.onIsLanguageAvailable("ine", "", ""), isTtsLangCode(TextToSpeech.LANG_NOT_SUPPORTED));
+        // Genuinely unsupported languages now report LANG_AVAILABLE so that
+        // screen readers don't skip the engine when other voices are loaded.
+        assertThat(mService.onIsLanguageAvailable("ine", "", ""), isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
         checkLanguage(mService.onGetLanguage(), "vie", "VNM", "central");
         assertThat(mService.getActiveVoice(), is(notNullValue()));
         assertThat(mService.getActiveVoice().name, is("vi-vn-x-central"));
@@ -295,6 +304,10 @@ public class TextToSpeechServiceTest
                 .edit()
                 .putStringSet(LanguageSettings.PREF_SUPPORTED_LANGUAGES, selected)
                 .commit();
+        // SharedPreferences listener is dispatched on the main thread when
+        // commit() is called from a non-main thread, so the service's filter
+        // would otherwise rebuild asynchronously after our assertions run.
+        mService.rebuildAvailableVoicesNow();
     }
 
     @Test

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechTest.java
@@ -165,7 +165,9 @@ public class TextToSpeechTest extends TextToSpeechTestCase
         assertThat(getEngine(), is(notNullValue()));
 
         Locale initialLocale = getLanguage(getEngine());
-        assertThat(getEngine().isLanguageAvailable(new Locale("cel")), isTtsLangCode(TextToSpeech.LANG_NOT_SUPPORTED));
+        // Engine now reports LANG_AVAILABLE for unsupported languages when any
+        // voice is loaded so screen readers don't skip the engine.
+        assertThat(getEngine().isLanguageAvailable(new Locale("cel")), isTtsLangCode(TextToSpeech.LANG_AVAILABLE));
         Locale language = getLanguage(getEngine());
 
         assertThat(getLanguage(getEngine()).getLanguage(), is(initialLocale.getLanguage()));

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -386,7 +386,7 @@ public class TtsService extends TextToSpeechService {
         mEngine.synthesize(text, text.startsWith("<speak"));
     }
 
-    private void rebuildAvailableVoices() {
+    protected void rebuildAvailableVoices() {
         synchronized (mAvailableVoices) {
             mAvailableVoices.clear();
             List<Voice> voices = mAllVoices;

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -194,7 +194,18 @@ public class TtsService extends TextToSpeechService {
 
     @Override
     protected int onIsLanguageAvailable(String language, String country, String variant) {
-        return findVoice(language, country, variant).second;
+        final int result = findVoice(language, country, variant).second;
+        if (result == TextToSpeech.LANG_NOT_SUPPORTED) {
+            // When the requested language is filtered out but other voices are
+            // available, report the language as available so that screen readers
+            // (e.g. Jieshuo) don't skip this engine entirely.
+            synchronized (mAvailableVoices) {
+                if (!mAvailableVoices.isEmpty()) {
+                    return TextToSpeech.LANG_AVAILABLE;
+                }
+            }
+        }
+        return result;
     }
 
     @Override
@@ -203,6 +214,20 @@ public class TtsService extends TextToSpeechService {
         if (match.first != null) {
             synchronized (mAvailableVoices) {
                 mMatchingVoice = match.first;
+            }
+            return match.second;
+        }
+        if (match.second == TextToSpeech.LANG_NOT_SUPPORTED) {
+            // Fall back to a previously selected or available voice so that
+            // screen readers requesting the system language still get speech.
+            synchronized (mAvailableVoices) {
+                if (mMatchingVoice != null) {
+                    return TextToSpeech.LANG_AVAILABLE;
+                }
+                if (!mAvailableVoices.isEmpty()) {
+                    mMatchingVoice = mAvailableVoices.values().iterator().next();
+                    return TextToSpeech.LANG_AVAILABLE;
+                }
             }
         }
         return match.second;
@@ -271,6 +296,32 @@ public class TtsService extends TextToSpeechService {
         }
     }
 
+    protected int selectLanguageWithFallback(String language, String country, String variant) {
+        final int result = onLoadLanguage(language, country, variant);
+        switch (result) {
+            case TextToSpeech.LANG_MISSING_DATA:
+                return TextToSpeech.ERROR;
+            case TextToSpeech.LANG_NOT_SUPPORTED:
+                // fall back to a previously selected or available voice instead of failing.
+                // This allows screen readers that request the system language (e.g. Jieshuo)
+                // to still work when the user has selected only other languages.
+                synchronized (mAvailableVoices) {
+                    // Prefer reusing the last matching voice if one is already selected.
+                    if (mMatchingVoice != null) {
+                        return TextToSpeech.SUCCESS;
+                    }
+                    // Otherwise, pick an arbitrary available voice if any exist.
+                    if (!mAvailableVoices.isEmpty()) {
+                        mMatchingVoice = mAvailableVoices.values().iterator().next();
+                        return TextToSpeech.SUCCESS;
+                    }
+                }
+                // No previous voice and no available voices to fall back to.
+                return TextToSpeech.ERROR;
+        }
+        return TextToSpeech.SUCCESS;
+    }
+
     private int selectVoice(SynthesisRequest request) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             final String name = request.getVoiceName();
@@ -278,18 +329,14 @@ public class TtsService extends TextToSpeechService {
                 return onLoadVoice(name);
             }
         }
-
-        final int result = onLoadLanguage(request.getLanguage(), request.getCountry(), request.getVariant());
-        switch (result) {
-            case TextToSpeech.LANG_MISSING_DATA:
-            case TextToSpeech.LANG_NOT_SUPPORTED:
-                return TextToSpeech.ERROR;
-        }
-        return TextToSpeech.SUCCESS;
+        return selectLanguageWithFallback(request.getLanguage(), request.getCountry(), request.getVariant());
     }
 
     @Override
     protected synchronized void onSynthesizeText(SynthesisRequest request, SynthesisCallback callback) {
+        if (selectVoice(request) == TextToSpeech.ERROR)
+            return;
+
         final Voice voice;
         synchronized (mAvailableVoices) {
             voice = mMatchingVoice;


### PR DESCRIPTION
## Summary

- When a screen reader (e.g. Jieshuo) requests the system language for synthesis, but that language is not in the user's language selector, synthesis previously failed silently
- Now falls back to an available voice from the user's selected set instead of returning an error
- This fixes the issue where Jieshuo wouldn't work on English-system devices with only Russian selected in the eSpeak language selector (TalkBack was unaffected because it queries available voices first)

## Problem

On an English-system Android device with eSpeak's language selector set to Russian only:
1. Jieshuo sends `onLoadLanguage("eng", ...)` based on the system language
2. English is not in the filtered voice set → `LANG_NOT_SUPPORTED`
3. `selectVoice()` returns `ERROR` → `mMatchingVoice` stays `null` → synthesis silently fails

TalkBack works because it calls `onGetVoices()` first and picks an available voice.

## Fix

In `selectVoice()`, when the requested language returns `LANG_NOT_SUPPORTED`:
- If `mMatchingVoice` is already set from a previous load, keep it (reuse the last working voice)
- If `mMatchingVoice` is null (fresh start), pick the first available voice from the filtered set
- `LANG_MISSING_DATA` still fails hard (no data installed at all)

This effectively "pins" the engine to the user's selected language(s) regardless of what the screen reader requests.

## Test plan

- [x] On English-system Android with only Russian in language selector: verify Jieshuo synthesizes in Russian
- [x] On Russian-system Android with only Russian selected: verify no regression
- [x] With multiple languages selected: verify correct language is still chosen when available
- [x] With all languages selected (default): verify no behavior change
- [x] APK builds successfully (`./gradlew assembleDebug`)
- [x] All native tests pass (`ctest --test-dir build`)