### PR TITLE
Improve Slovenian pronunciation rules: assimilation and word-final devoicing

### DIFF
--- a/dictsource/sl_rules
+++ b/dictsource/sl_rules
@@ -7,6 +7,10 @@
 .L03 a e
 .L04 l v
 
+.L05 m l n r j v
+.l06 g d z b ž dž
+.L07 p t s š č k f h c
+
 .group a
         a        a:
         a (X$w_alt3+  'a

--- a/dictsource/sl_rules
+++ b/dictsource/sl_rules
@@ -23,6 +23,7 @@
 .group b
         b        b
         b (L07   p
+        b (_     p
 
 .group c
         c        ts
@@ -38,7 +39,8 @@
         dz       dz
         dž       dZ
         d (L07   t
-
+        d (_     t
+        dž (_    tS
 
 .group e
         e        e:
@@ -63,7 +65,7 @@
 .group g
         g        g
         g (L07   k
-
+        g (_     k
 
 .group h
         h        x
@@ -202,11 +204,13 @@
 .group z
         z        z
         z (L07   s
+        z (_     s
 
 
 .group ž
         ž        Z
         ž (L07   S
+        ž (_     S
 
 
 .group

--- a/dictsource/sl_rules
+++ b/dictsource/sl_rules
@@ -8,7 +8,7 @@
 .L04 l v
 
 .L05 m l n r j v
-.l06 g d z b ž dž
+.L06 g d z b ž dž
 .L07 p t s š č k f h c
 
 .group a
@@ -22,6 +22,7 @@
 
 .group b
         b        b
+        b (L07   p
 
 .group c
         c        ts
@@ -36,6 +37,7 @@
         d        d
         dz       dz
         dž       dZ
+        d (L07   t
 
 
 .group e
@@ -60,6 +62,7 @@
 
 .group g
         g        g
+        g (L07   k
 
 
 .group h
@@ -81,6 +84,7 @@
 
 .group k
         k        k
+        k (L06   g
 
 
 .group l
@@ -131,6 +135,7 @@
         
 .group p
         p        p
+        p (L06   b
 
 
 .group q
@@ -148,15 +153,18 @@
 .group s
         s        s
         sch      S
+        s (L06   z
 
 
 .group š
         š        S
+        š (L06   Z
 
 
 .group t
         t        t
    Krs) t (_     _|t
+        t (L06   d
 
 
 .group u
@@ -193,10 +201,12 @@
 
 .group z
         z        z
+        z (L07   s
 
 
 .group ž
         ž        Z
+        ž (L07   S
 
 
 .group


### PR DESCRIPTION
This PR improves Slovenian pronunciation by introducing phonological rules based on assimilation (prilikovanje / asimilacija) and word-final devoicing.

### Changes
- Added consonant group classifications:
  - L05 group (currently unused, intended for potential future extensions)
  - L06: voiced obstruents (g, d, z, b, ž, dž)
  - L07: voiceless obstruents (p, t, s, š, č, k, f, h, c)
- Implemented assimilation rules between L06 and L07 groups
- Added word-final devoicing rules, closely related to assimilation
- Updated multiple consonant groups (b, d, g, k, p, s, š, t, z, ž, etc.)

### Details
- Introduced ~16 new rules across multiple groups
- Handles cases where voiced consonants become voiceless before voiceless ones and at the end of words
- Improves naturalness and correctness of Slovenian pronunciation

### Notes
- Rules are based on standard Slovenian phonological processes
- Tested locally with espeak-ng