### PR TITLE
translate: split emoji from adjacent words at clause tokenization

### DIFF
--- a/src/libespeak-ng/common.c
+++ b/src/libespeak-ng/common.c
@@ -224,13 +224,25 @@ int IsAlpha(unsigned int c)
 	// dictionary lookup where $textmode entries map them to text
 	// descriptions (e.g. U+1F600 → "grinning face").
 	// Without this, espeak_TextToPhonemes() silently drops emoji.
+	if (IsEmoji(c))
+		return 1;
+
+	return 0;
+}
+
+int IsEmoji(unsigned int c)
+{
+	// Returns true for codepoints in the emoji/symbol ranges that IsAlpha()
+	// admits as word characters. Used by the clause tokenizer to force a
+	// word boundary between emoji and adjacent letters, so that a regular
+	// word followed directly by an emoji (e.g. "дыму🐠") is not merged
+	// into one token — that would defeat dictionary lookup for the word
+	// and trigger letter-by-letter spelling of its alphabetic part.
 	if ((c >= 0x2600) && (c <= 0x27bf))
 		return 1; // Miscellaneous Symbols + Dingbats
 	if ((c >= 0x1f000) && (c <= 0x1fbff))
-		return 1; // Emoji blocks (Emoticons, Transport, Supplemental, etc.)
-	if ((c >= 0x1f1e0) && (c <= 0x1f1ff))
-		return 1; // Regional Indicator Symbols (flag sequences)
-
+		return 1; // Emoji blocks (Emoticons, Transport, Supplemental, etc.),
+		          // includes Regional Indicator Symbols at U+1F1E0..U+1F1FF
 	return 0;
 }
 

--- a/src/libespeak-ng/common.h
+++ b/src/libespeak-ng/common.h
@@ -30,6 +30,7 @@ void espeak_srand(long seed);
 long espeak_rand(long min, long max);
 
 int IsAlpha(unsigned int c);
+int IsEmoji(unsigned int c);
 int IsBracket(int c);
 int IsDigit(unsigned int c);
 int IsDigit09(unsigned int c);

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -1217,7 +1217,7 @@ void TranslateClauseWithTerminator(Translator *tr, int *tone_out, char **voice_c
 
 			if (IsAlpha(c)) {
 				alpha_count++;
-				if (!IsAlpha(prev_out) || (tr->langopts.ideographs && ((c > 0x3040) || (prev_out > 0x3040)))) {
+				if (!IsAlpha(prev_out) || (tr->langopts.ideographs && ((c > 0x3040) || (prev_out > 0x3040))) || (IsEmoji(c) != IsEmoji(prev_out))) {
 					if (wcschr(tr->punct_within_word, prev_out) == 0)
 						letter_count = 0; // don't reset count for an apostrophy within a word
 

--- a/tests/translate.test
+++ b/tests/translate.test
@@ -75,6 +75,12 @@ test_phon ka "'imedg,ats#ru,ebuli m'agram Sv'ebis g'amomx,atveli s'axe" "😥"
 test_phon en "'e@ri:z r'eInboU" "♈🌈"
 test_phon en "'e@ri:z r'eInboU" "♈ 🌈"
 
+# A regular word directly followed by an emoji must not be merged into a
+# single token; otherwise the rules engine aborts on the unrecognised
+# emoji and falls back to spelling the alphabetic part letter-by-letter.
+test_phon en "f'IS tr'0pIk@L f'IS" "fish🐠"
+test_phon ru "d'ymu t@-rVp;'itS;iskVja @-r'yba#" "дыму🐠"
+
 # multi-word emoji
 test_phon en "Ekskla#m'eIS@n kw'EstS@n m'A@k" "⁉"
 test_phon en "Ekskla#m'eIS@n kw'EstS@n m'A@k r'eInboU" "⁉ 🌈"


### PR DESCRIPTION
## Summary

Fixes a regression introduced by 22ba0feb (which made emoji codepoints word characters so `\$textmode` dictionary entries could resolve them): a regular word followed directly by an emoji such as `дыму🐠` was tokenised as a single word, the rules engine matched the alphabetic part, hit the unrecognised emoji and set `FLAG_SPELLWORD`, then re-translated the whole word letter-by-letter.

Reproducer:

```
$ espeak-ng -x -v ru+max "Рыбка в дыму🐠"
@-r'ypka# v d'E 'y 'Em u t@-rVp;'itS;iskVja @-r'yba#       # before
@-r'ypka# v dym'u t@-rVp;'itS;iskVja @-r'yba#              # after
```

The same bug affected English (`fish🐠` → `'Ef 'aI 'Es 'eItS tr'0pIk@L f'IS`).

## Changes

- Add `IsEmoji()` in `common.{c,h}` covering the emoji ranges that `IsAlpha()` admits (`U+2600..U+27BF`, `U+1F000..U+1FBFF`).
- In the clause tokenizer (`translate.c`), force a word boundary whenever the emoji-ness of two adjacent alpha characters differs, so emoji are always their own token.
- Add regression tests for `fish🐠` (en) and `дыму🐠` (ru) in `tests/translate.test`.

## Test plan

- [x] `ctest --test-dir build -j\$(nproc)` — all 18 relevant tests pass (the unrelated `bom` test fails due to pre-existing Android Sonic third-party samples in the build tree).
- [x] Manual verification of the reproducer from the bug report.
- [x] Verified emoji-only, emoji-before-word, and adjacent-emoji cases still work.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code was reviewed and tested by the author before submission.