### PR TITLE
tests: skip generated build artifacts in BOM check

### DIFF
--- a/tests/bom.test
+++ b/tests/bom.test
@@ -16,7 +16,7 @@ cd $(dirname $0)/..
 # Fall back to a plain recursive scan when not running inside a git work tree.
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1 ; then
 	git ls-files -z --cached --others --exclude-standard \
-		| xargs -0 grep -lI $'\xEF\xBB\xBF' \
+		| xargs -0 grep -lI -e $'\xEF\xBB\xBF' -- \
 		| tee tests/bom.check >/dev/null # UTF-8
 else
 	grep -ErlI $'\xEF\xBB\xBF' * | grep -v '^build/' | tee tests/bom.check >/dev/null # UTF-8

--- a/tests/bom.test
+++ b/tests/bom.test
@@ -9,7 +9,18 @@ echo -n "testing for Byte Order Marks in source files ... "
 # otherwise it shows many false positives
 
 cd $(dirname $0)/..
-grep -ErlI $'\xEF\xBB\xBF' * | grep -v '^build/' | tee tests/bom.check >/dev/null # UTF-8
+
+# Limit the scan to files git knows about (tracked + untracked-not-ignored)
+# so generated build artifacts don't produce false positives — e.g. the sonic
+# dependency samples pulled into android/.cxx/ by the gradle native build.
+# Fall back to a plain recursive scan when not running inside a git work tree.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1 ; then
+	git ls-files -z --cached --others --exclude-standard \
+		| xargs -0 grep -lI $'\xEF\xBB\xBF' \
+		| tee tests/bom.check >/dev/null # UTF-8
+else
+	grep -ErlI $'\xEF\xBB\xBF' * | grep -v '^build/' | tee tests/bom.check >/dev/null # UTF-8
+fi
 
 if [ -s tests/bom.check ] ; then
 	echo "found:"


### PR DESCRIPTION
## Summary

- `tests/bom.test` recursed across the whole working tree and only excluded the top-level `build/` directory, so any other generated tree could trip it up.
- After exercising the gradle native build for android, third-party sources unpack into `android/.cxx/_deps/` — among them a sonic sample (`test1.txt`) that legitimately starts with a UTF-8 BOM — and the test failed on an otherwise-clean checkout.
- Switch the scan to `git ls-files --cached --others --exclude-standard` when run inside a git work tree so the existing `.gitignore` (which already covers `.cxx`, `.gradle/`, `build/`) is the single source of truth for what should be ignored. Keep the previous recursive scan as a fallback for non-git checkouts (release tarballs).

## Test plan

- [x] `sh tests/bom.test` reports `none found` after a gradle native build has populated `android/.cxx/`.
- [x] Verified `git ls-files --cached --others --exclude-standard | grep -c '\.cxx/'` is `0`, while the previous `grep -ErlI` would have flagged 32 generated BOM files under `android/.cxx/`.
- [x] CI passes the `bom` test.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code was reviewed and tested by the author before submission.