### PR TITLE
voices: fix unsafe strcat into fixed-size voice_identifier buffer

### DIFF
--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -507,8 +507,9 @@ voice_t *LoadVoice(const char *vname, int control)
 		// append the variant file name to the voice identifier
 		if ((p = strchr(voice_identifier, '+')) != NULL)
 			*p = 0;    // remove previous variant name
-		sprintf(buf, "+%s", &vname[3]);    // omit  !v/  from the variant filename
-		strcat(voice_identifier, buf);
+		else
+			p = voice_identifier + strlen(voice_identifier);
+		snprintf(p, sizeof(voice_identifier) - (p - voice_identifier), "+%s", &vname[3]);    // omit  !v/  from the variant filename
 	}
 	VoiceReset(tone_only);
 


### PR DESCRIPTION
voice_identifier is a static char[40] holding the current voice name plus an optional variant suffix like "+m3". The variant was appended by formatting into the large path buf and then calling strcat, giving no bounds protection on voice_identifier itself.

buf is a path buffer sized to N_PATH_BUF (PATH_MAX); using it as a scratch buffer to hold a short variant string like "+m3" before appending it elsewhere was a misuse of its purpose and an unnecessary stack allocation.

If voice_identifier was already near 40 bytes before the append, strcat would write past the end of the buffer.

Replace the sprintf+strcat pair with a single snprintf that writes directly into voice_identifier at the correct offset — either at the '+' found by strchr (overwriting a previous variant) or at the end of the existing string — and bounds the write to the remaining capacity of voice_identifier.