### PR TITLE
Fix stack buffer overflows in number and clause formatting

### DIFF
--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -921,7 +921,7 @@ static int LookupThousands(Translator *tr, int value, int thousandplex, int thou
 	// thousands_exact:  bit 0  no hundreds,tens,or units,  bit 1  ordinal numberr
 	int found;
 	int found_value = 0;
-	char string[14];
+	char string[26];
 	char ph_of[12];
 	char ph_thousands[N_PHONEME_BYTES];
 	char ph_buf[N_PHONEME_BYTES];
@@ -1026,7 +1026,7 @@ static int LookupNum2(Translator *tr, int value, int thousandplex, const int con
 	int found_ordinal = 0;
 	int next_phtype;
 	int ord_type = 'o';
-	char string[12]; // for looking up entries in *_list
+	char string[14]; // for looking up entries in *_list
 	char ph_ordinal[20];
 	char ph_tens[50];
 	char ph_digits[50];
@@ -1267,13 +1267,13 @@ static int LookupNum3(Translator *tr, int value, char *ph_out, bool suppress_nul
 	int tplex;
 	bool say_zero_hundred = false;
 	bool say_one_hundred;
-	char string[12]; // for looking up entries in **_list
+	char string[14]; // for looking up entries in **_list
 	char buf1[100];
 	char buf2[100];
 	char ph_100[N_PHONEME_BYTES];
 	char ph_10T[N_PHONEME_BYTES];
 	char ph_digits[50];
-	char ph_thousands[50];
+	char ph_thousands[211];
 	char ph_hundred_and[12];
 	char ph_thousand_and[12];
 

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -195,7 +195,7 @@ static const char *LookupSpecial(Translator *tr, const char *string, char *text_
 	return NULL;
 }
 
-static const char *LookupCharName(char buf[60], Translator *tr, int c, bool only)
+static const char *LookupCharName(char buf[74], Translator *tr, int c, bool only)
 {
 	// Find the phoneme string (in ascii) to speak the name of character c
 	// Used for punctuation characters and symbols
@@ -277,7 +277,7 @@ static int AnnouncePunctuation(Translator *tr, int c1, int *c2_ptr, char *output
 	int bufix1;
 	char buf[200];
 	char ph_buf[30];
-	char cn_buf[60];
+	char cn_buf[74];
 
 	c2 = *c2_ptr;
 	buf[0] = 0;
@@ -829,7 +829,7 @@ int ReadClause(Translator *tr, char *buf, short *charix, int *charix_top, int n_
 				char *p2;
 
 				p2 = &buf[ix];
-				char cn_buf[60];
+				char cn_buf[74];
 				sprintf(p2, "%s", LookupCharName(cn_buf, tr, c1, true));
 				if (p2[0] != 0) {
 					ix += strlen(p2);


### PR DESCRIPTION
numbers.c:
- string in LookupThousands was 14 bytes but GCC calculates the _%dM%do/e/x format can produce up to 25 bytes; increase to 26
- string in LookupNum2 was 12 bytes but the _%dX/%dXf format can reach 14 bytes; increase to 14
- string in LookupNum3 was 12 bytes but the _%dC0/Co format can reach 14 bytes; increase to 14
- ph_thousands in LookupNum3 was 50 bytes but is written by sprintf(ph_thousands, "%s%c%s%c", ph_digits, ..., ph_10T, ...) where ph_digits is 50 bytes and ph_10T is N_PHONEME_BYTES (160); increase to 211

readclause.c:
- cn_buf in AnnouncePunctuation and ReadClause was 60 bytes but DecodeWithPhonemeMode writes the format "[\002_^_%s %s _^_%s]]" into it with a phoneme string up to 54 bytes and a 4-byte translator name, requiring up to 73 bytes; increase to 74
- update the LookupCharName signature to match