### PR TITLE
cmake: use GNUInstalldirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if (WITH_COVERAGE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
+include(GNUInstallDirs)
 include(cmake/deps.cmake)
 include(cmake/config.cmake)
 add_subdirectory(src)

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -21,8 +21,8 @@ set(VERSION ${PROJECT_VERSION})
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-set(libdir "\${exec_prefix}/lib")
-set(includedir "\${prefix}/include")
+set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
 set_target_properties(
   espeak-ng-bin PROPERTIES
   MACOSX_RPATH ON
-  INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+  INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
 )
 if (MINGW)
   target_link_options(espeak-ng-bin PRIVATE "-static-libstdc++" "-static")

--- a/src/libespeak-ng/CMakeLists.txt
+++ b/src/libespeak-ng/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(espeak-ng
 set_target_properties(
   espeak-ng PROPERTIES
   MACOSX_RPATH ON
-  INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+  INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
 )
 
 target_include_directories(espeak-ng BEFORE PRIVATE $<TARGET_PROPERTY:espeak-include,INTERFACE_INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
include GNUInstalldirs to define CMAKE_INSTALL_* vars and use it

fixes 35524b3

Closes: #2410

@heitbaum