### PR TITLE
cmake: restore intended RPATH behavior

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
 set_target_properties(
   espeak-ng-bin PROPERTIES
   MACOSX_RPATH ON
-  INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
+  INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
 )
 if (MINGW)
   target_link_options(espeak-ng-bin PRIVATE "-static-libstdc++" "-static")

--- a/src/libespeak-ng/CMakeLists.txt
+++ b/src/libespeak-ng/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(espeak-ng
 set_target_properties(
   espeak-ng PROPERTIES
   MACOSX_RPATH ON
-  INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}"
+  INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
 )
 
 target_include_directories(espeak-ng BEFORE PRIVATE $<TARGET_PROPERTY:espeak-include,INTERFACE_INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
Using CMAKE_INSTALL_FULL_LIBDIR restores the intended behavior while ensuring a valid absolute RUNPATH and compatibility with temporary install dirs.

Oh sorry, I didn’t think you both would be so quick to test and check the previous PR. It should be fine now.