### PR TITLE
fixed slovenian v phoneme

### DIFF
--- a/phsource/ph_slovenian
+++ b/phsource/ph_slovenian
@@ -91,7 +91,7 @@ endphoneme
 
 
 phoneme v
-  import_phoneme base1/v#
+  import_phoneme base1/z
 endphoneme
 
 


### PR DESCRIPTION
Fix Slovenian "v" phoneme pronunciation

The previous mapping produced an incorrect sound (closer to "m").
This change updates the phoneme import to produce a more accurate "v" sound in Slovenian.

