### PR TITLE
fix(it): correct Italian pronunciation rules

### DIFF
--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -64,6 +64,8 @@
 	bacia (L07_	b'atSa
 	_) bagna (L07_	b'an^a
 	a) bbraccia (L07_	b:@-*'atS:a
+	_) bell' (P5t	bEl:  // bello/bella + elision before vowel
+	_) buon' (P5t	bwOn  // buono/buona + elision before vowel
 
 .group c
 	c	k

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -74,6 +74,7 @@
 	c (Y	tS
 	cc (Y	tS:
 	ch (Y	k
+	_) ch' (P3t	k  // che + elision before vowel (e.g. ch'io, ch'essi)
 	cch (Y	k:
 	s) ch (A	k
 	ch (a	tS

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -240,6 +240,7 @@
 .group g
 	g	g
 	gg	g:
+	_) gliel' (P6t	l^El  // glielo/gliela + elision before vowel
 	gh	g
 	gu (A	gw
 	g (Y	dZ

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -402,7 +402,7 @@
 	A) mila (_	m'ila/
 	_) m' (P2t	m
 	_) mezz' (P5t	mEdz:
-	metter (L04_	m'ette@-* // Pron.s Verbs
+	metter (L04_	m'et:e@-* // Pron.s Verbs
 	metti (L04_	m'e:t:i
 	mmetter (L04_	m:'et:e@-*
 	manda (L05_	m'anda

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -125,6 +125,7 @@
 	n) dere (_	=deRe
 	_) dall' (P5t	dall
 	_) dell' (P5t	dell
+	_) dov' (P4t	dOv  // dove + elision before vowel
 	_) d' (P2t	d
 	donat (Y_	don'at
 	dona (L07_	d'ona  // Pron.s verbs

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -241,6 +241,7 @@
 	g	g
 	gg	g:
 	_) gliel' (P6t	l^El  // glielo/gliela + elision before vowel
+	_) grand' (P6t	g@-*and  // grande + elision before vowel
 	gh	g
 	gu (A	gw
 	g (Y	dZ

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -554,6 +554,7 @@
 	_) quell' (P6t	kwell
 	_) quest' (P6t	kwest
 	_) quant' (P6t	kwant
+	_) qualcos' (P8t	kwalkOs  // qualcosa + elision before vowel
 	_) quel 	kwel
 	_)quest (A_	kwest
 

--- a/dictsource/it_rules
+++ b/dictsource/it_rules
@@ -666,6 +666,7 @@
 	tira (L07_	t'iRa
 	telefona (L07_	tel'Ef,ona
 	L02) tre (_	t@-*'e
+	_) tant' (P5t	tant  // tanto/tanta + elision before vowel
 	_) tutt' (P5t	tut:
 
 .group u


### PR DESCRIPTION
## Summary

Three fixes to `dictsource/it_rules` for Italian pronunciation.

### 1. Geminate t in `metter` rule

The `metter` rule was producing `m'ette@-*` with literal `tt` (two separate plosive phonemes) instead of `t:` (geminate), causing an audible double release in words like `rimettersi`, `mettersi`, etc. Adjacent rules (`metti`, `mmetter`, `netter`) already use `t:` correctly — this was an isolated inconsistency.

### 2. Elision rule for `che` + vowel (`ch'`)

Missing rule for the Italian elision of "che" before a vowel (e.g. `ch'io`, `ch'essi`, `ch'ella`). Without it, espeak produces a [tʃ] onset instead of [k].

Added `_) ch' (P3t k` in `.group c`, consistent with existing elision rules.

### 3. Elision rules for `bell'` and `buon'` before vowels

Missing P5t prefix rules for "bello/bella" and "buono/buona" elisions. Without them, espeak treated the apostrophe as a stress marker and inserted a spurious `_:_:` pause before the following word, breaking prosodic flow.

Added `_) bell' (P5t bEl:` and `_) buon' (P5t bwOn` in `.group b`, consistent with existing patterns (`nell'`, `dell'`, `quell'`, etc.).

## Tests

```
espeak-ng -vit -x "rimettersi"
# before: @-*im'ette@-*sI  (double t)
# after:  @-*im'et:e@-*sI  (geminate t:)

espeak-ng -vit -x "ch'io"
# before: wrong (tʃ onset)
# after:  k'io

espeak-ng -vit -x "bell'elemento viaggiante"
# before: bellelem'ento_:_: vjadZ:'ante  (spurious pause)
# after:  bellelem'ento vjadZ:'ante

espeak-ng -vit -x "buon'anima cara"
# before: bUon'anima_:_: k'a*a  (spurious pause)
# after:  bwon'anima k'a*a
```