### PR TITLE
Normalize stylized Latin letters and digits to plain ASCII

### DIFF
--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -829,12 +829,61 @@ static int SubstituteChar(Translator *tr, unsigned int c, unsigned int next_in, 
 	return new_c;
 }
 
+static int NormalizeStyledLatin(unsigned int c)
+{
+	// Map a stylized Latin letter or digit to plain ASCII so it is read as
+	// text instead of spelled out as a Unicode codepoint. Covers the
+	// Mathematical Alphanumeric Symbols (bold, italic, script, fraktur,
+	// double-struck, sans-serif, monospace), the Letterlike Symbols that fill
+	// the holes in that block, and the fullwidth Latin forms. Returns 0 if c
+	// is not one of these.
+
+	// Mathematical Alphanumeric Symbols
+	if (c >= 0x1d400 && c <= 0x1d7ff) {
+		if (c >= 0x1d7ce)
+			return '0' + (c - 0x1d7ce) % 10; // five styles of digits 0-9
+		if (c <= 0x1d6a3) {
+			// 13 styles of 52 letters, each laid out A-Z then a-z
+			int o = (c - 0x1d400) % 52;
+			return o < 26 ? 'A' + o : 'a' + (o - 26);
+		}
+		if (c == 0x1d6a4) return 'i'; // italic dotless i
+		if (c == 0x1d6a5) return 'j'; // italic dotless j
+		return 0; // Greek styles (1d6a8..1d7cd): left unchanged
+	}
+
+	// Fullwidth Latin letters and digits
+	if (c >= 0xff21 && c <= 0xff3a) return 'A' + (c - 0xff21);
+	if (c >= 0xff41 && c <= 0xff5a) return 'a' + (c - 0xff41);
+	if (c >= 0xff10 && c <= 0xff19) return '0' + (c - 0xff10);
+
+	// Letters reserved in the math block because they are unified with the
+	// Letterlike Symbols block; the Letterlike codepoint is what appears.
+	switch (c) {
+	case 0x210e: return 'h'; // italic small h (PLANCK CONSTANT)
+	case 0x212c: return 'B'; case 0x2130: return 'E'; case 0x2131: return 'F';
+	case 0x210b: return 'H'; case 0x2110: return 'I'; case 0x2112: return 'L';
+	case 0x2133: return 'M'; case 0x211b: return 'R'; // script capitals
+	case 0x212f: return 'e'; case 0x210a: return 'g'; case 0x2134: return 'o'; // script small
+	case 0x212d: return 'C'; case 0x210c: return 'H'; case 0x2111: return 'I';
+	case 0x211c: return 'R'; case 0x2128: return 'Z'; // fraktur capitals
+	case 0x2102: return 'C'; case 0x210d: return 'H'; case 0x2115: return 'N';
+	case 0x2119: return 'P'; case 0x211a: return 'Q'; case 0x211d: return 'R';
+	case 0x2124: return 'Z'; // double-struck capitals
+	}
+	return 0;
+}
+
 static int TranslateChar(Translator *tr, char *ptr, int prev_in, unsigned int c, unsigned int next_in, int *insert, int *wordflags)
 {
 	// To allow language specific examination and replacement of characters
 
 	int code;
 	int next2;
+
+	int styled = NormalizeStyledLatin(c);
+	if (styled != 0)
+		return styled;
 
 	static const unsigned char hangul_compatibility[0x34] = {
 		0,  0x00, 0x01, 0xaa, 0x02, 0xac, 0xad, 0x03,

--- a/tests/language-pronunciation.test
+++ b/tests/language-pronunciation.test
@@ -70,6 +70,8 @@ test_phon de "v'Ikto:r j'A:kt tsv'Wlf b'OkskEmpf3 kv'e:r_:_: _|,y:b3 de:n gr'o:s
 h'aItsWlr,yksto:s,abdEmpf,UN" "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich. Heizölrückstoßabdämpfung." "Latn"
 test_phon el "ks,escep'azo t'im bz,ixofT'ora vD,eliQm'i;a" "Ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία." "Grek"
 test_phon en "D@ kw'Ik br'aUn f'0ks dZ'Vmps ,oUv3 D@ l'eIzi d'0g" "The quick brown fox jumps over the lazy dog" "Latn"
+test_phon en "h@l'oU" "𝐇𝐞𝐥𝐥𝐨" "math-bold normalized to ASCII"
+test_phon en "h@l'oU" "ℍ𝕖𝕝𝕝𝕠" "double-struck normalized to ASCII"
 test_phon en "h'i@3rIN m'i: b'oU
 DI2; 'aZ3 Tr'VS k'O:z
 'e@ j'O@ dZ'OIf@l 'A@ri:;@


### PR DESCRIPTION
## Problem

Stylized Latin text is read out as "letter &lt;codepoint&gt;" instead of as words, because none of it is plain ASCII. For example the math-bold "Hello" currently produces "letter 1D407, letter 1D41E, ..." — useless. This styling (𝐛𝐨𝐥𝐝, 𝑖𝑡𝑎𝑙𝑖𝑐, 𝓼𝓬𝓻𝓲𝓹𝓽, 𝔣𝔯𝔞𝔨𝔱𝔲𝔯, 𝕕𝕠𝕦𝕓𝕝𝕖-𝕤𝕥𝕣𝕦𝕔𝕜, fullwidth, …) is very common on social media, where it effectively hides the text from the synthesizer.

## Fix

Map these characters to their plain ASCII equivalent in `TranslateChar()`, right next to the existing Hangul decomposition. Coverage:

- **Mathematical Alphanumeric Symbols** (U+1D400–U+1D7FF): the 13 Latin letter styles and the 5 digit styles, mapped algorithmically.
- **Letterlike Symbols** that fill the reserved holes in that block (ℋ, ℛ, ℭ, ℍ, ℕ, …).
- **Fullwidth** Latin letters and digits (U+FF21–FF5A, U+FF10–FF19).

The remap happens before the word-boundary test in `TranslateClause`, so the letters re-form words — e.g. `𝐇𝐞𝐥𝐥𝐨` reads as "Hello" and `𝟏𝟐` reads as "twelve". Greek math styles and enclosed/circled forms are intentionally left for a later change.

## Test

Added two cases to `tests/language-pronunciation.test` (math-bold and double-struck "Hello"). Verified with a source build across bold/italic/script/fraktur/double-struck/sans/mono/fullwidth, and `ctest -R language-pronunciation` passes for all languages.