### PR TITLE
Fix Windows build broken by standalone <windef.h> include in speech.h

### DIFF
--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -57,9 +57,9 @@ extern "C"
 #define PLATFORM_WINDOWS 1
 #define PATHSEP '\\'
 #define NO_VARIADIC_MACROS
-#include <windef.h>    // defines MAX_PATH (260, includes NUL)
+#include <stdlib.h>    // defines _MAX_PATH (260, includes NUL)
 #ifndef N_PATH_BUF
-#  define N_PATH_BUF  MAX_PATH
+#  define N_PATH_BUF  _MAX_PATH
 #endif
 
 #else


### PR DESCRIPTION
## Summary

The Windows and `windows-msbuild` CI jobs have been failing on `master` since #2407 ("Fix path buffer overflows and standardize path handling"). Every MSVC configuration fails with:

```
winnt.h(169,1): error C1189: #error: "No Target Architecture"
```

### Root cause

#2407 added `#include <windef.h>` to `src/libespeak-ng/speech.h` to obtain `MAX_PATH` for the new `N_PATH_BUF`:

```c
#include <windef.h>    // defines MAX_PATH (260, includes NUL)
#ifndef N_PATH_BUF
#  define N_PATH_BUF  MAX_PATH
#endif
```

Including `<windef.h>` **directly** is the bug. It pulls in `<winnt.h>`, but it is `<windows.h>`'s prologue that first derives the `_AMD64_` / `_X86_` / `_ARM_` macros (from the compiler's `_M_*` macros) that `winnt.h` checks. Reached standalone, `winnt.h` hits `#error "No Target Architecture"`.

Because `speech.h` is included by nearly every source file, this breaks **all 8 Windows configs** plus `windows-msbuild`; the first failing translation unit is `compiledata.c`. `speech.c` itself compiled only because it happens to include `<windows.h>` before `speech.h`.

### Fix

Use the CRT's `_MAX_PATH` from `<stdlib.h>` instead:

```c
#include <stdlib.h>    // defines _MAX_PATH (260, includes NUL)
#ifndef N_PATH_BUF
#  define N_PATH_BUF  _MAX_PATH
#endif
```

`_MAX_PATH` is the same value (260) and is the CRT's own constant for a full-path buffer. This:
- needs no Win32 header, so it sidesteps the arch-macro setup the standalone `<windef.h>` lacked;
- avoids pulling the entire Win32 API surface into a widely-included internal header (`<stdlib.h>` is already included by 31/35 `libespeak-ng` sources);
- is a minimal two-token change kept inside the existing `_WIN32` branch, matching the file's per-platform include style.

The POSIX branch is unchanged.

## Testing

- Linux `Debug` + ASan build compiles cleanly and the full `ctest` suite passes (the change is confined to the `#if defined(_WIN32)` branch, so Linux exercises the unchanged POSIX path).
- The MSVC fix cannot be compiled on the Linux dev host, but the failure mechanism (`C1189` from a standalone `<windef.h>`) and the `<stdlib.h>`/`_MAX_PATH` remedy are well established; CI on this PR will confirm the Windows jobs go green.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code was reviewed and tested by the author before submission.