### PR TITLE
data: build the fo, kaa and xex dictionaries in CMake

### DIFF
--- a/cmake/data.cmake
+++ b/cmake/data.cmake
@@ -4,12 +4,12 @@ list(APPEND _dict_compile_list
   ca chr cmn crh cs cv cy
   da de
   el en eo es et eu
-  fa fi fr
+  fa fi fo fr
   ga gd gn grc gu
   hak haw he hi hr ht hu hy
   ia id io is it
   ja jbo
-  ka kk kl kn kok ko ku ky
+  ka kaa kk kl kn kok ko ku ky
   la lb lfn lij lt lv
   mi mk ml mn mr ms mto mt my
   nci ne nl nog no
@@ -21,6 +21,7 @@ list(APPEND _dict_compile_list
   ta te ti th tk tn tr tt
   ug uk ur uz
   vi
+  xex
   yue
 )
 


### PR DESCRIPTION
## Summary

Three languages — **fo** (Faroese), **kaa** (Karakalpak), and **xex** — ship full `dictsource/*_rules`, `*_list`, and voice files, but were **missing from `_dict_compile_list` in `cmake/data.cmake`**. As a result their dictionaries stopped being compiled after the autotools→CMake migration, the same regression class as `ps` (just fixed in #2444).

This was found by diffing every `dictsource/*_rules` against the CMake compile list — `fo`, `kaa`, `ps`, `xex` were the only four missing; `ps` is handled by #2444, leaving these three.

## Change
Add `fo`, `kaa`, `xex` to `_dict_compile_list` (alphabetical placement).

## Verification
Built the `data` target locally after the change — all three compile cleanly:

| dict | size |
|------|------|
| `fo_dict`  | 5,669,268 B |
| `kaa_dict` | 1,833 B |
| `xex_dict` | 5,275 B |

No errors. With #2444 + this PR, every language that has a dictionary source now builds under CMake.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code was reviewed and tested by the author before submission.