### PR TITLE
translate: segment $textmode replacement text like normal input

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,7 @@ bug fixes:
 *  handled fread errors and propagate ENS_UNEXPECTED_EOF in spect -- Rudi Heitbaum
 *  fixed %x format specifier type mismatch in SSML parsing -- Rudi Heitbaum
 *  fixed character classification to handle ZWJ and variation selectors -- Tamas Geczy
+*  fixed silently dropped emoji descriptions in Chinese, Cantonese and Thai: dictionary replacement text is now word-segmented like normal input, with nested text replacements (hanzi to pinyin) -- Alexander Epaneshnikov
 *  fixed PATH_ESPEAK_DATA macro type -- Anthony DePasquale
 *  added different voice identifier for Windows -- Charley3d
 *  increased Sonic synthesis activation threshold -- Danstiv

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -48,7 +48,7 @@
 static int CalcWordLength(int source_index, int charix_top, short int *charix, WORD_TAB *words, int word_count);
 static void CombineFlag(Translator *tr, WORD_TAB *wtab, int wtab_remaining, char *word, int *flags, unsigned char *p, char *word_phonemes);
 static void SwitchLanguage(char *word, char *word_phonemes);
-static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *wtab, int wtab_remaining, char *word_out);
+static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *wtab, int wtab_remaining, char *word_out, int depth);
 
 Translator *translator = NULL; // the main translator
 Translator *translator2 = NULL; // secondary translator for certain words
@@ -142,7 +142,46 @@ char *strchr_w(const char *s, int c)
 	return strchr((char *)s, c); // (char *) is needed for Borland compiler
 }
 
-static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *wtab, int wtab_remaining, char *word_out)
+static void SegmentReplacement(Translator *tr, const char *text, char *out, int out_size)
+{
+	// Apply the word-splitting rules of the clause tokenizer (TranslateClause)
+	// to dictionary replacement text, so that a $textmode replacement is
+	// re-translated in the same word units as if it had been normal input:
+	// for languages with langopts.ideographs each CJK character is a separate
+	// word (so that hanzi words can match their multi-word *_list entries),
+	// and a non-alpha mark such as a Thai tone mark terminates a word instead
+	// of derailing the letter-to-phoneme rules mid-word.
+	// ASCII characters are always kept in-word: for Latin-script replacement
+	// text ("t-rex", "cai3hong2") the existing single-word behaviour is kept.
+	int ix = 0, out_ix = 0;
+	int c = 0;
+
+	while (text[ix] != 0) {
+		int prev = c;
+		int nbytes = utf8_in(&c, &text[ix]);
+		bool insert_space = false;
+
+		if (IsAlpha(prev)) {
+			if (IsAlpha(c)) {
+				if (tr->langopts.ideographs && ((c > 0x3040) || (prev > 0x3040)))
+					insert_space = true; // each ideograph is a separate word
+			} else if (!IsSpace(c) && (c >= 0x80) && (wcschr(tr->punct_within_word, c) == 0))
+				insert_space = true; // eg. a Thai tone mark ends the word, as in the clause tokenizer
+		} else if ((prev >= 0x80) && !IsSpace(prev) && IsAlpha(c) && (wcschr(tr->punct_within_word, prev) == 0))
+			insert_space = true; // a letter after such a mark starts a new word
+
+		if (out_ix + nbytes + 2 > out_size)
+			break;
+		if (insert_space)
+			out[out_ix++] = ' ';
+		memcpy(&out[out_ix], &text[ix], nbytes);
+		out_ix += nbytes;
+		ix += nbytes;
+	}
+	out[out_ix] = 0;
+}
+
+static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *wtab, int wtab_remaining, char *word_out, int depth)
 {
 	char words_phonemes[N_WORD_PHONEMES]; // a word translated into phoneme codes
 	char *phonemes = words_phonemes;
@@ -152,10 +191,12 @@ static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *w
 	if (flags & FLAG_TEXTMODE && word_out) {
 		// Ensure that start of word rules match with the replaced text,
 		// so that emoji and other characters are pronounced correctly.
-		char word[N_WORD_BYTES+1];
+		// The buffer allows for a space inserted after every character of
+		// the replacement by SegmentReplacement().
+		char word[2+N_WORD_BYTES*2];
 		word[0] = 0;
 		word[1] = ' ';
-		strcpy(word+2, word_out);
+		SegmentReplacement(tr, word_out, word+2, sizeof(word)-2);
 		word_out = word+2;
 
 			bool first_word = true;
@@ -174,7 +215,17 @@ static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *w
 			// However, dictionary_skipwords value is still needed outside this scope.
 			// So we backup and restore it at the end of this scope.
 			int skipwords = dictionary_skipwords;
-			TranslateWord3(tr, word_out, wtab, wtab_remaining, NULL, &any_stressed_words, current_alphabet, word_phonemes, sizeof(word_phonemes));
+			if (depth < 3) {
+				// translate through TranslateWordWithBounds so that a replacement
+				// word which itself has a $textmode entry is expanded too: eg. an
+				// emoji entry replaces the emoji by hanzi, and the hanzi words map
+				// to pinyin through *_list. The depth limit guards against an
+				// entry cycle in the dictionary (a $textmode b, b $textmode a).
+				char word_replacement2[N_WORD_BYTES+1];
+				word_replacement2[0] = 0;
+				TranslateWordWithBounds(tr, word_out, wtab, wtab_remaining, word_replacement2, depth+1);
+			} else
+				TranslateWord3(tr, word_out, wtab, wtab_remaining, NULL, &any_stressed_words, current_alphabet, word_phonemes, sizeof(word_phonemes));
 
 			int n;
 			if (first_word) {
@@ -213,7 +264,7 @@ static int TranslateWordWithBounds(Translator *tr, char *word_start, WORD_TAB *w
 
 int TranslateWord(Translator *tr, char *word_start, WORD_TAB *wtab, char *word_out)
 {
-	return TranslateWordWithBounds(tr, word_start, wtab, 0, word_out);
+	return TranslateWordWithBounds(tr, word_start, wtab, 0, word_out, 0);
 }
 
 static void SetPlist2(PHONEME_LIST2 *p, unsigned char phcode)
@@ -407,7 +458,7 @@ static int TranslateWord2(Translator *tr, char *word, WORD_TAB *wtab, int wtab_r
 		word_copy_len = ix;
 
 		word_replaced[2] = 0;
-		flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, &word_replaced[2]);
+		flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, &word_replaced[2], 0);
 
 		if (flags & FLAG_SPELLWORD) {
 			// re-translate the word as individual letters, separated by spaces
@@ -439,9 +490,9 @@ static int TranslateWord2(Translator *tr, char *word, WORD_TAB *wtab, int wtab_r
 					if (word_replaced[2] != 0) {
 						word_replaced[0] = 0; // byte before the start of the word
 						word_replaced[1] = ' ';
-						flags = TranslateWordWithBounds(translator2, &word_replaced[1], wtab, wtab_remaining, NULL);
+						flags = TranslateWordWithBounds(translator2, &word_replaced[1], wtab, wtab_remaining, NULL, 0);
 					} else
-						flags = TranslateWordWithBounds(translator2, word, wtab, wtab_remaining, &word_replaced[2]);
+						flags = TranslateWordWithBounds(translator2, word, wtab, wtab_remaining, &word_replaced[2], 0);
 				}
 
 				if (p[0] != phonSWITCH)
@@ -1773,7 +1824,7 @@ static void CombineFlag(Translator *tr, WORD_TAB *wtab, int wtab_remaining, char
 		char ph_buf[N_WORD_PHONEMES];
 		strcpy(ph_buf, word_phonemes);
 
-		flags2[0] = TranslateWordWithBounds(tr, p2+1, wtab+1, wtab_remaining-1, NULL);
+		flags2[0] = TranslateWordWithBounds(tr, p2+1, wtab+1, wtab_remaining-1, NULL, 0);
 		if ((flags2[0] & FLAG_WAS_UNPRONOUNCABLE) || (word_phonemes[0] == phonSWITCH))
 			ok = false;
 
@@ -1794,11 +1845,11 @@ static void CombineFlag(Translator *tr, WORD_TAB *wtab, int wtab_remaining, char
 	if (ok) {
 		*p2 = '-'; // replace next space by hyphen
 		wtab[0].flags &= ~FLAG_ALL_UPPER; // prevent it being considered an abbreviation
-		*flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, NULL); // translate the combined word
+		*flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, NULL, 0); // translate the combined word
 		if ((sylimit > 0) && (CountSyllables(p) > (sylimit & 0x1f))) {
 			// revert to separate words
 			*p2 = ' ';
-			*flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, NULL);
+			*flags = TranslateWordWithBounds(translator, word, wtab, wtab_remaining, NULL, 0);
 		} else {
 			if (*flags == 0)
 				*flags = flags2[0]; // no flags for the combined word, so use flags from the second word eg. lang-hu "nem december 7-e"

--- a/tests/translate.test
+++ b/tests/translate.test
@@ -68,7 +68,9 @@ test_phon en "h@w'aIi:" "Hawaiʻi"
 
 # ED-3 - emoji_character
 test_phon en "'e@ri:z" "♈"
-test_phon my "pru3'a2nke3DN_|_| mj@@lu3'a2mj@2tsnh,a2N_|_| nm_|n'e3DN_|_| mj@@nh,ats" "😙"
+# the replacement text is segmented like direct input (see SegmentReplacement),
+# so the Burmese asat mark now ends a word as it does in normal text
+test_phon my "pru3'a2nke3DN _|_| mj@k _| lu3'a2mj@2tsnh,a2N _|_| nm _| n'e3DN _|_| mj@k _| nh'ats" "😙"
 test_phon ka "k'ots#nis g'amomx,atveli s'axe m'omQim,are t#v'alebit#" "😙"
 test_phon ka "'imedg,ats#ru,ebuli m'agram Sv'ebis g'amomx,atveli s'axe" "😥"
 # Adjacent emoji without whitespace now correctly separated (IsAlpha emoji fix).
@@ -115,6 +117,24 @@ test_phon en "w'Um@n s'aI@ntIst m'i:di@m sk'In t'oUn" "👩🏽‍🔬"
 test_phon en "T'Vmz 'Vp l'aIt sk'In t'oUn" "👍🏻"
 # the modifier alone keeps its own dictionary entry
 test_phon en "m'i:di@m sk'In t'oUn" "🏽"
+
+# languages whose replacement text needs clause-style word segmentation
+# (SegmentReplacement): each hanzi is a separate word which then maps to
+# pinyin/jyutping through a second $textmode lookup, and a Thai tone mark
+# ends a word; without this the replacement text was silently dropped
+test_phon cmn "tshai21X'ong35_|" "🌈"
+test_phon yue "c'oi2_| h'ung4_|" "🌈"
+test_phon th "r'u2 ng" "🌈"
+# ZWJ sequence keys combined with segmented replacement text
+test_phon cmn "X'ei55_| m'Au55_|" "🐈‍⬛"
+test_phon yue "h'a1k_| m'aau1_|" "🐈‍⬛"
+test_phon th "tha2ng'a2ssru2 ng" "🏳️‍🌈"
+# skin tone sequence: base name and modifier name (女人 中等肤色) are both
+# segmented and expanded hanzi to pinyin
+test_phon cmn "n'y21_| z.'@35n_| ts.ong55t'@21N_| f'u55_| s'o-51_|" "👩🏽"
+# no Thai modifier name in CLDR yet, so only the base name is spoken,
+# but the sequence must not fall back to codepoint spelling or silence
+test_phon th "ch'u:2ni2 w'o2p nga5kh'ue2 n" "👍🏻"
 
 # bug: https://github.com/espeak-ng/espeak-ng/issues/471
 test_phon sk "sm'eju:tsa s'a tv'a:R" "☺"


### PR DESCRIPTION
Languages that need clause-level word segmentation silently dropped dictionary replacement text. A matching `$textmode` emoji entry printed its `Replace:` trace, but the replacement was then re-translated as a single word, bypassing the word-splitting rules of the clause tokenizer, and produced no phonemes at all:

- **Chinese/Cantonese**: each hanzi must be a separate word so that words can match their multi-word `*_list` entries, which map them to pinyin/jyutping via a second `$textmode` replacement. The single-word re-translation of e.g. Mandarin 彩虹 matched nothing, and the nested replacement was impossible anyway because the re-translation loop called `TranslateWord3` with `word_out=NULL`, which discards a nested `$textmode` match without producing phonemes.
- **Thai**: a tone mark is not `IsAlpha` and terminates a word in the clause tokenizer, so `th_rules` never see one word-internally; re-translating a replacement such as รุ้ง as one word derailed at the tone mark.

Fixed by mirroring the tokenizer's word-splitting rules over the replacement text in `TranslateWordWithBounds` (new `SegmentReplacement`): ideographs become separate words, and non-ASCII non-alpha marks terminate a word. ASCII characters are always kept in-word, preserving the existing behaviour of Latin-script replacements ("t-rex", "cai3hong2"). The re-translation loop now recurses through `TranslateWordWithBounds` with a depth limit, so a replacement word that itself has a `$textmode` entry (hanzi → pinyin) is expanded too.

With this, emoji output is **identical to typing the description directly** for cmn, yue and th — including ZWJ sequences (🐈‍⬛ → 黑猫) and skin tone sequences (👩🏽 → 女人 中等肤色 through the nested hanzi→pinyin path). The Burmese test expectation is updated: the replacement of 😙 is now segmented at the asat mark exactly like direct input of the same text (the old expectation encoded the unsegmented, inconsistent pronunciation).

Japanese still reads kanji emoji descriptions as "Chinese letter"; that is the pre-existing kanji limitation of the ja voice (direct kanji input does the same), unrelated to replacement handling.

Stacked on #2454 (the Thai test cases need `th_emoji` from that PR); the cmn/yue behaviour reproduces on master alone.

Verified: 19/19 tests pass; ASAN-clean on emoji salads across 9 languages and on the longest cmn replacement (23 hanzi, previously silent, now reads fully); en/de/ru/uk/he output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.