### PR TITLE
synthdata: clear phoneme_tab on table switch so absent codes resolve to NULL

### DIFF
--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -366,7 +366,7 @@ void SelectPhonemeTable(int number)
 {
 	if (current_phoneme_table == number) return;
 	n_phoneme_tab = 0;
-	MAKE_MEM_UNDEFINED(&phoneme_tab, sizeof(phoneme_tab));
+	memset(phoneme_tab, 0, sizeof(phoneme_tab)); // clear so a code absent from the new table looks up as NULL, not a stale pointer from the previous table
 	SetUpPhonemeTable(number); // recursively for included phoneme tables
 	n_phoneme_tab++;
 	current_phoneme_table = number;


### PR DESCRIPTION
## Summary

`SelectPhonemeTable()` marked the whole `phoneme_tab[]` array undefined with
`MAKE_MEM_UNDEFINED()` and then let `SetUpPhonemeTable()` fill only the codes
present in the selected table, zero-filling gaps **up to the highest code**.
Codes above that maximum were left untouched. Since `MAKE_MEM_UNDEFINED()` is a
no-op outside valgrind, those slots kept **stale pointers from the previously
selected table**, so a phoneme code absent from the newly selected table did
not resolve to `NULL` as callers assume.

`TranslateWord2()` emits a `phonSWITCH` mid-word, switches tables, then keeps
reading phoneme codes from the same string:

```c
ph = phoneme_tab[ph_code];
if (ph == NULL) { ... continue; }   // guard for a code absent from the table
... ph->type ...
```

If a following code was absent from the switched-to table, the `NULL` guard
failed on the stale pointer and `ph->type` dereferenced the wrong table's
phoneme. Valgrind reports an uninitialised-value read; in production it
silently reads a phoneme from the previously selected table.

The fix clears the whole table on switch (`memset` instead of
`MAKE_MEM_UNDEFINED`), so absent codes resolve to `NULL` and the existing
guards work. Behaviour is unchanged for codes present in the table.

## Testing

- Full `ctest` suite: 100% (19/19).
- Reproduced under valgrind (`--track-origins=yes`): with the Arabic
  `AL_WORDS` association applied (see #2439), `crash` vector `cve-2023-49990`
  fails before this change and is clean after; all eight crash vectors are
  valgrind-clean with the fix.

## Context

This is a pre-existing latent bug. It is surfaced by #2439 (associate the
Arabic script with the Arabic language), whose valgrind CI currently fails on
the `crash` test for exactly this reason — a malformed input decodes into the
Arabic block and triggers the mid-word switch to the small `ar` table. With
this fix, #2439 passes. Recommend landing this first, then rebasing #2439 on
top; #2439's crash-test run under valgrind is the regression guard for this
fix.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code
was reviewed and tested by the author before submission.
