### PR TITLE
dictionary: restore prevPh conditions in phoneme (IPA) output

### DIFF
--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -468,7 +468,7 @@ char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int 
 		if (plist == NULL)
 			InterpretPhoneme2(ph->code, &phdata);
 		else
-			InterpretPhoneme(NULL, 0, plist, plist, &phdata, NULL);
+			InterpretPhoneme(NULL, 0, plist, phoneme_list, &phdata, NULL);
 
 		p = phdata.ipa_string;
 		if (*p == 0x20) {

--- a/tests/ssml/badly-escaped1.expected
+++ b/tests/ssml/badly-escaped1.expected
@@ -1,1 +1,1 @@
-kəmpˈa͡ɪl ænd flˈæʃ lˈɪnɪʲɪd͡ʒ ˈændɹɔ͡ɪd ˌo͡ʊˈɛs
+kəmpˈa͡ɪl ænd flˈæʃ lˈɪnɪɪd͡ʒ ˈændɹɔ͡ɪd ˌo͡ʊˈɛs

--- a/tests/ssml/linking-j.expected
+++ b/tests/ssml/linking-j.expected
@@ -1,0 +1,2 @@
+wiː ˈiːt ænd ɑː͡ɹ hˈæpi ɐbˈa͡ʊt ɪt
+ðə sˈɪɾi ɪz ˈiːzi tə sˈiː ˌɛni ˈiːvnɪŋ

--- a/tests/ssml/linking-j.ssml
+++ b/tests/ssml/linking-j.ssml
@@ -1,0 +1,2 @@
+We eat and are happy about it.
+The city is easy to see any evening.

--- a/tests/ssml/spec-example-1.expected
+++ b/tests/ssml/spec-example-1.expected
@@ -3,7 +3,7 @@
 juː hæv fˈɔː͡ɹ nˈuː mˈɛsɪd͡ʒᵻz
 
 ðə fˈɜːst ɪz fɹʌm stˈɛfəni wˈɪljəmz ænd ɚɹˈa͡ɪvd æt
-θɹˈiː fˈɔː͡ɹɾi fˈa͡ɪv pˌiːʲˈɛm
+θɹˈiː fˈɔː͡ɹɾi fˈa͡ɪv pˌiːˈɛm
 
 ðə sˈʌbd͡ʒɛkt ɪz skˈiː tɹˈɪp
 


### PR DESCRIPTION
Fixes #2367.

## Summary

`WritePhMnemonic()` produces the phoneme text for `-x` / `--ipa` /
phoneme-event output by re-running `InterpretPhoneme()`. Since #2082
("Avoid underflowing ph_list3", commit 8afe77ba) it passed `plist` as **both**
the current phoneme and the list start:

```c
InterpretPhoneme(NULL, 0, plist, plist, &phdata, NULL);
```

With `plist_start == plist`, the underflow guards that commit introduced make
every `prevPh` / `prevPhW` / `prev2PhW` condition short-circuit to `false`, so
conditional IPA rules are never applied in the text-output path.

The audio path is **unaffected** — `Generate()` in `synthesize.c` passes the
real list base (`phoneme_list`) — so on current master the printed IPA
disagrees with the audio that is actually synthesised.

## Impact (regression versus 1.52)

| | 1.52 | master | this PR |
|---|---|---|---|
| en `happy` | `hˈapi` | `hˈapiʲ` | `hˈapi` |
| de `drei` | `dɾˈaɪ` | `drˈaɪ` | `dɾˈaɪ` |
| pt `dia` | `dˈiɐ` | `dˈiʲɐ` | `dˈiɐ` |

This matters most for the many downstream tools that use eSpeak NG as a
phonemizer / G2P front-end — the emitted IPA is the product for them. The
linking-j phoneme `;` is even defined with `IF prevPh(#i) THEN ipa NULL`
("don't show in ipa"), which master was ignoring. Independently reported for
Portuguese as well (see #2367).

## Fix

Pass `phoneme_list` as `plist_start`, matching the audio path. Every
`WritePhMnemonic` caller iterates over the global `phoneme_list`, so the
lookback is bounded correctly and cannot underflow.

## Testing

- Reverted the two `tests/ssml/*.expected` files that #2082 had updated to the
  incorrect output.
- Added `tests/ssml/linking-j` (auto-run by the `ssml` test under `--ipa=2`) as
  a dedicated regression guard for the linking-j / `prevPh` conditions; it
  fails on current master and passes with this change.
- Verified the synthesised WAV is **byte-identical** with and without this
  change — the audio path is untouched.
- Full `ctest` suite passes.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code
was reviewed and tested by the author before submission.
