### PR TITLE
Android: build libsonic from source and enable USE_LIBSONIC

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments "-DUSE_ASYNC:BOOL=OFF", "-DUSE_MBROLA:BOOL=OFF"
+                arguments "-DUSE_ASYNC:BOOL=OFF", "-DUSE_MBROLA:BOOL=OFF", "-DUSE_LIBSONIC:BOOL=ON"
                 targets "ttsespeak", "espeak-data"
             }
         }

--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 
 project(espeak-android)
 

--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -2,6 +2,21 @@ cmake_minimum_required(VERSION 3.8)
 
 project(espeak-android)
 
+# Build libsonic from source for Android and pre-seed the find results so
+# cmake/deps.cmake in the main project detects it (the NDK sysroot has no sonic).
+include(FetchContent)
+FetchContent_Declare(sonic-git
+        GIT_REPOSITORY https://github.com/waywardgeek/sonic.git
+        GIT_TAG fbf75c3d6d846bad3bb3d456cbc5d07d9fd8c104
+)
+FetchContent_MakeAvailable(sonic-git)
+add_library(sonic OBJECT ${sonic-git_SOURCE_DIR}/sonic.c)
+# enable PIC in order to embed libsonic in libttsespeak.so
+set_property(TARGET sonic PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(sonic PUBLIC ${sonic-git_SOURCE_DIR})
+set(SONIC_LIB sonic)
+set(SONIC_INC ${sonic-git_SOURCE_DIR})
+
 add_subdirectory(../../ espeakng)
 
 add_custom_target(


### PR DESCRIPTION
## Summary

The Android build had no way to use libsonic for faster speech rates: the NDK sysroot never provides it, and the FetchContent fallback was removed in 11e1d0d1 ("Don't fetch libsonic if not present").

This restores sonic support for the Android app only, without touching the shared CMake files:

- `android/jni/CMakeLists.txt`: fetch the pinned sonic revision (same one the old fallback used), build `sonic.c` as a position-independent object library, and pre-seed `SONIC_LIB`/`SONIC_INC` so `cmake/deps.cmake` detects it.
- `android/build.gradle`: pass `-DUSE_LIBSONIC:BOOL=ON` alongside the existing feature flags.

## Testing

- `./gradlew assemble` builds debug and release APKs for all four ABIs.
- Verified the generated `config.h` has `USE_LIBSONIC 1` and that `libttsespeak.so` inside the APK exports the `sonic*` symbols.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)