### PR TITLE
soundicon: fix out-of-bounds accesses when loading SSML <audio src> files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,7 @@ bug fixes:
 *  fixed subdivision flag emoji (England, Scotland, Wales) being read as "black flag" -- Alexander Epaneshnikov
 *  fixed the first letter of emoji descriptions being dropped when it is a non-ASCII capital ("Казахстан" was read as "азахстан") -- Alexander Epaneshnikov
 *  fixed hyphenated emoji descriptions losing everything from the hyphen on, which left flags such as 🇧🇫 silent in 84 languages -- Alexander Epaneshnikov
+*  fixed out-of-bounds accesses when loading sound icon files referenced by SSML <audio src> -- Nexory
 
 features:
 *  matched ZWJ emoji sequences against multi-codepoint dictionary entries -- Alexander Epaneshnikov

--- a/src/libespeak-ng/soundicon.c
+++ b/src/libespeak-ng/soundicon.c
@@ -123,6 +123,10 @@ static espeak_ng_STATUS LoadSoundFile(const char *fname, int index, espeak_ng_ER
 		fclose(f);
 		return ENOMEM;
 	}
+	// realloc() has taken ownership of the previous buffer, so the table must
+	// not keep pointing at it if one of the error paths below is taken.
+	soundicon_tab[index].data = NULL;
+	soundicon_tab[index].length = 0;
 	if (fread(p, 1, length, f) != length) {
 		int error = errno;
 		fclose(f);
@@ -135,8 +139,22 @@ static espeak_ng_STATUS LoadSoundFile(const char *fname, int index, espeak_ng_ER
 	if (fname_temp[0])
 		remove(fname_temp);
 
-	length = p[40] | (p[41] << 8) | (p[42] << 16) | (p[43] << 24);
-	soundicon_tab[index].length = length / 2; // length in samples
+	if (length < 44) {
+		// Fewer bytes than the 44-byte WAV header. The buffer can even be
+		// empty, because a file whose format does not match is replaced by an
+		// empty temp file above. Reject it rather than reading past the end.
+		free(p);
+		return EINVAL;
+	}
+
+	// The data-size field in the header is not trustworthy, so bound it by the
+	// number of bytes actually read. Otherwise the wave player is handed a
+	// sample count that walks past the end of the buffer.
+	unsigned int data_size = (unsigned int)p[40] | ((unsigned int)p[41] << 8)
+	                       | ((unsigned int)p[42] << 16) | ((unsigned int)p[43] << 24);
+	if (data_size > (unsigned int)(length - 44))
+		data_size = length - 44;
+	soundicon_tab[index].length = data_size / 2; // length in samples
 	soundicon_tab[index].data = (char *) p;
 	return ENS_OK;
 }
@@ -178,6 +196,8 @@ int LoadSoundFile2(const char *fname)
 	}
 
 	// load the file into the current slot and increase index
+	if (n_soundicon_tab >= N_SOUNDICON_TAB)
+		return -1; // soundicon table is full
 	if (LoadSoundFile(fname, n_soundicon_tab, NULL) != ENS_OK)
 		return -1;
 

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -52,6 +52,47 @@ test_ssml_audio "<prosody>" 88fccb35536158f25f4ae44a03fb005fef95c99b "<speak><pr
 test_ssml_audio "<prosody> bug #410" 8d3bace9548ae73c4770a73c88c6f65e848b45cf "<speak><prosody rate=\"x-slow\" pitch=\"low\"> Slow and low. </prosody><prosody rate=\"x-fast\" pitch=\"x-high\"> Fast and high.</prosody></speak>"
 test_ssml_audio "<audio>" 5134c1db757b2d6b8d1f3f2416124462e401b4c6 "<speak>ha: <audio src=\"$PWD/phsource/h/ha.wav\"></audio></speak>"
 
+# The sound icon loader must stay inside the buffer it read, whatever the
+# <audio> file turns out to contain. Each of these accessed memory out of
+# bounds before LoadSoundFile()/LoadSoundFile2() were given bounds checks.
+test_ssml_audio_nocrash() {
+	TEST_NAME=$1
+	TEST_TEXT=$2
+
+	echo "testing ${TEST_NAME}"
+	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
+		$VALGRIND src/espeak-ng --stdout -m "${TEST_TEXT}" > /dev/null || exit 1
+}
+
+# A file whose format does not match is replaced by an empty temporary file,
+# so the loader ends up with nothing to read the WAV header from.
+test_ssml_audio_nocrash "<audio> file that is not a WAV" \
+	"<speak><audio src=\"$PWD/ChangeLog.md\"></audio>x</speak>"
+
+# The same file again after the first load was rejected: the table entry must
+# not still point at the buffer that was released.
+test_ssml_audio_nocrash "<audio> rejected file loaded twice" \
+	"<speak><audio src=\"$PWD/ChangeLog.md\"></audio>a<audio src=\"$PWD/ChangeLog.md\"></audio>b</speak>"
+
+# A truncated icon: the header still announces the full data chunk, but only a
+# few bytes of it are present.
+SOUNDICON_TRUNCATED="${TMPDIR:-/tmp}/espeak-ng-truncated-icon.wav"
+head -c 60 "$PWD/phsource/h/ha.wav" > "$SOUNDICON_TRUNCATED"
+test_ssml_audio_nocrash "<audio> truncated WAV" \
+	"<speak><audio src=\"$SOUNDICON_TRUNCATED\"></audio>x</speak>"
+rm -f "$SOUNDICON_TRUNCATED"
+
+# More distinct icon paths than the table has room for.
+SOUNDICON_MANY="<speak>"
+SOUNDICON_SLASHES=""
+SOUNDICON_I=0
+while [ $SOUNDICON_I -lt 85 ] ; do
+	SOUNDICON_MANY="${SOUNDICON_MANY}<audio src=\"$PWD${SOUNDICON_SLASHES}/phsource/h/ha.wav\"></audio>"
+	SOUNDICON_SLASHES="${SOUNDICON_SLASHES}/"
+	SOUNDICON_I=$((SOUNDICON_I+1))
+done
+test_ssml_audio_nocrash "<audio> more icons than the table holds" "${SOUNDICON_MANY}</speak>"
+
 test_ssml_audio "<break> at start" 949ad49d180108b30c1f0f16bef6ca2f3b6199cd "<speak><break time=\"1000ms\"/>test</speak>"
 
 # Test SSML breaks inside prosody (#1512)


### PR DESCRIPTION
# soundicon: fix out-of-bounds accesses when loading SSML `<audio src>` files

Loading a sound icon through the SSML `<audio src="...">` element can access
memory out of bounds in three related ways. All three are confirmed with
AddressSanitizer on current master (84a37de). These are memory-safety defects and
crashes; I am not claiming anything beyond that.

The path is reachable when the caller synthesizes with `espeakSSML` and has not
registered a URI callback through `espeak_SetUriCallback`, which is the default
for libespeak-ng and for the command line tool with `-m`.

## What goes wrong

**1. The sound icon table has no upper bound.** `soundicon_tab` has
`N_SOUNDICON_TAB` (80) entries. `LoadSoundFile2()` writes to
`soundicon_tab[n_soundicon_tab]` and then increments, with nothing checking the
index first, so the 81st distinct `src` string writes past the end of the array.

**2. The WAV header is read without checking that it is present.**
`LoadSoundFile()` takes the data-size field from `p[40..43]`, but `p` holds only
`length` bytes. A file whose format block at offset 20 is not mono, 16 bit, at
the current sample rate is replaced by a freshly created empty temporary file
(the `sox` conversion just above is commented out), so `length` becomes 0 however
large the file the caller named actually was. A file that does pass the format
check but is shorter than 44 bytes underruns the same way.

**3. The data-size field itself is never bounded.** Even with a complete header,
`soundicon_tab[index].length` is taken straight from the file and never compared
against the bytes that were read. `synthesize.c` then queues `data + 44` with
that sample count and `PlayWave()` walks it, so a truncated icon (a real header
announcing a data chunk that is not there) reads far past the allocation. This
is the largest of the three reads.

Behind all of them is a smaller ownership problem: `p` comes from
`realloc(soundicon_tab[index].data, ...)`, so once that call returns, the pointer
still stored in the table is stale. Any error path that frees `p` leaves it
there, and the next load into the same slot hands it back to `realloc()`.

## The fix

- bound `n_soundicon_tab` before it is used as an index;
- reject a buffer shorter than the 44 byte header;
- clamp the data-size field to the bytes actually read;
- clear the table entry immediately after `realloc()` takes ownership, which
  covers every error path below it rather than one at a time.

`LoadConfig()` in `langopts.c` also appends to this table without a bound, but it
is fed by the local language configuration file rather than by document input, so
I have left it alone here.

## Reproduction

```sh
cmake -B build -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g -O1"
cmake --build build
export ESPEAK_DATA_PATH=$PWD/build

# 2: a file that is not a WAV
build/src/espeak-ng --stdout -m \
  "<speak><audio src=\"$PWD/ChangeLog.md\"></audio>x</speak>" > /dev/null

# 3: a real icon truncated to 60 of its 3356 bytes
head -c 60 phsource/h/ha.wav > /tmp/trunc.wav
build/src/espeak-ng --stdout -m \
  "<speak><audio src=\"/tmp/trunc.wav\"></audio>x</speak>" > /dev/null

# 1: more distinct icon paths than the table holds
M="<speak>"; S=""; i=0
while [ $i -lt 85 ]; do
  M="$M<audio src=\"$PWD$S/phsource/h/ha.wav\"></audio>"; S="$S/"; i=$((i+1))
done
build/src/espeak-ng --stdout -m "$M</speak>" > /dev/null
```

Before the change, in order: `heap-buffer-overflow` at `soundicon.c:138`,
`heap-buffer-overflow` at `wavegen.c:959` in `PlayWave`, and
`global-buffer-overflow` at `soundicon.c:122`. After it, all three are clean and
a valid icon still produces byte for byte the same audio.

## Tests

Four cases are added to `tests/ssml.test`, reusing files already in the tree
(`ChangeLog.md` as a non-WAV file, `phsource/h/ha.wav` whole and truncated), so
no new fixtures are needed. Each one fails on master and passes with this change;
the existing hash-compared `<audio>` test is unaffected, because `ha.wav`
declares exactly the 3312 data bytes it actually has.

`ctest --test-dir build` gives the same result with and without this change: 16
of 18 pass, and `non-executable-files-with-executable-bit` and `variants` fail
either way in my environment, which is a mounted filesystem and a build without
klatt support.
