### PR TITLE
Rescale event sample positions after libsonic compresses the buffer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,7 @@ bug fixes:
 *  fixed subdivision flag emoji (England, Scotland, Wales) being read as "black flag" -- Alexander Epaneshnikov
 *  fixed the first letter of emoji descriptions being dropped when it is a non-ASCII capital ("Казахстан" was read as "азахстан") -- Alexander Epaneshnikov
 *  fixed hyphenated emoji descriptions losing everything from the hyphen on, which left flags such as 🇧🇫 silent in 84 languages -- Alexander Epaneshnikov
+*  fixed word and phoneme event positions drifting past the audio they belong to at speech rates where libsonic compresses the output, which broke word-boundary highlighting for API callers -- Alexander Epaneshnikov
 
 features:
 *  matched ZWJ emoji sequences against multi-codepoint dictionary entries -- Alexander Epaneshnikov

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,7 @@ bug fixes:
 *  fixed subdivision flag emoji (England, Scotland, Wales) being read as "black flag" -- Alexander Epaneshnikov
 *  fixed the first letter of emoji descriptions being dropped when it is a non-ASCII capital ("Казахстан" was read as "азахстан") -- Alexander Epaneshnikov
 *  fixed hyphenated emoji descriptions losing everything from the hyphen on, which left flags such as 🇧🇫 silent in 84 languages -- Alexander Epaneshnikov
+*  fixed word and phoneme event positions drifting past the audio they belong to at speech rates where libsonic compresses the output, which broke word-boundary highlighting for API callers -- Alexander Epaneshnikov
 
 features:
 *  matched ZWJ emoji sequences against multi-codepoint dictionary entries -- Alexander Epaneshnikov

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -573,7 +573,10 @@ void RescaleEventSamples(int length_pre, int length_post)
 			continue;
 		if (offset > length_pre)
 			offset = length_pre;
-		offset = (int)(((long)offset * length_post) / length_pre);
+		// Both factors are bounded by the buffer length, so the product can
+		// exceed 32 bits for buffers over about two seconds.  long is 32-bit on
+		// Windows, so widen explicitly rather than relying on it.
+		offset = (int)(((int64_t)offset * length_post) / length_pre);
 
 		ep->sample = base + offset;
 		ep->audio_position = (int)(((double)ep->sample * 1000.0) / samplerate);

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -539,6 +539,48 @@ void MarkerEvent(int type, unsigned int char_position, int value, int value2, un
 		ep->id.number = value;
 }
 
+#if USE_LIBSONIC
+void RescaleEventSamples(int length_pre, int length_post)
+{
+	// MarkerEvent() records positions while the buffer is being filled, which
+	// happens before libsonic compresses it, so the positions refer to audio
+	// that is longer than what is handed to the caller.  Map them onto the
+	// audio actually produced, keeping ep->sample and ep->audio_position
+	// consistent with the buffer passed to the synth callback.
+	//
+	// libsonic is a stream and can carry samples over between calls, so this
+	// linear mapping is an approximation; what it guarantees is that an event
+	// never points past the audio its buffer produced.
+
+#if !USE_MBROLA
+	static const int mbrola_delay = 0;
+#endif
+	int base;
+
+	if ((event_list == NULL) || (length_pre <= 0) || (length_pre == length_post))
+		return;
+
+	// count_samples is not advanced for this buffer until WavegenFill() has
+	// returned, so it still holds the total emitted by preceding buffers --
+	// the same base MarkerEvent() used.
+	base = count_samples + mbrola_delay;
+
+	for (int ix = 0; ix < event_list_ix; ix++) {
+		espeak_EVENT *ep = &event_list[ix];
+		int offset = ep->sample - base;
+
+		if (offset <= 0)
+			continue;
+		if (offset > length_pre)
+			offset = length_pre;
+		offset = (int)(((long)offset * length_post) / length_pre);
+
+		ep->sample = base + offset;
+		ep->audio_position = (int)(((double)ep->sample * 1000.0) / samplerate);
+	}
+}
+#endif
+
 espeak_ng_STATUS sync_espeak_Synth(unsigned int unique_identifier, const void *text,
                                    unsigned int position, espeak_POSITION_TYPE position_type,
                                    unsigned int end_position, unsigned int flags, void *user_data)

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -102,6 +102,12 @@ extern "C"
 
 void cancel_audio(void);
 
+#if USE_LIBSONIC
+// Maps event positions recorded against the uncompressed buffer onto the
+// audio libsonic produced from it.  Called by WavegenFill() after SpeedUp().
+void RescaleEventSamples(int length_pre, int length_post);
+#endif
+
 extern char path_home[N_PATH_BUF];    // this is the espeak-ng-data directory
 
 #ifdef __cplusplus

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -1455,10 +1455,16 @@ int WavegenFill(void)
 	if (sonicSpeed > 1.0) {
 		int length;
 		int max_length;
+		int length_in;
 
 		max_length = (out_end - p_start);
-		length =  2*SpeedUp((short *)p_start, (out_ptr-p_start)/2, max_length/2, finished);
+		length_in = (out_ptr-p_start)/2;
+		length =  2*SpeedUp((short *)p_start, length_in, max_length/2, finished);
 		out_ptr = p_start + length;
+
+		// The events recorded while this buffer was filled refer to the
+		// uncompressed audio, so move them onto what libsonic produced.
+		RescaleEventSamples(length_in, length/2);
 
 		if (length >= max_length)
 			finished = 0; // there may be more data to flush

--- a/tests/api.c
+++ b/tests/api.c
@@ -626,6 +626,66 @@ test_espeak_ng_phoneme_events(int enabled, int ipa) {
 
 // endregion
 
+// region word event positions
+
+static long _test_word_event_frames;
+static int _test_word_event_out_of_range;
+
+static int
+_test_word_event_positions_cb(short *samples, int num_samples, espeak_EVENT *events) {
+	if (samples == NULL)
+		return 0;
+
+	for (espeak_EVENT *e = events; e->type != espeakEVENT_LIST_TERMINATED; e++) {
+		if (e->type != espeakEVENT_WORD)
+			continue;
+		// A word must lie within the audio its own buffer produced.
+		if ((e->sample < _test_word_event_frames) ||
+		    (e->sample > _test_word_event_frames + num_samples))
+			_test_word_event_out_of_range++;
+	}
+
+	if (num_samples > 0)
+		_test_word_event_frames += num_samples;
+	return 0;
+}
+
+static void
+test_word_event_positions(int rate) {
+	printf("testing word event positions at rate=%d\n", rate);
+
+	TEST_ASSERT(event_list == NULL);
+	TEST_ASSERT(translator == NULL);
+	TEST_ASSERT(p_decoder == NULL);
+
+	espeak_ng_InitializePath(NULL);
+	espeak_ng_ERROR_CONTEXT context = NULL;
+	TEST_ASSERT(espeak_ng_Initialize(&context) == ENS_OK);
+	TEST_ASSERT(espeak_ng_InitializeOutput(0, 0, NULL) == ENS_OK);
+	espeak_SetSynthCallback(_test_word_event_positions_cb);
+	TEST_ASSERT(espeak_ng_SetParameter(espeakRATE, rate, 0) == ENS_OK);
+
+	_test_word_event_frames = 0;
+	_test_word_event_out_of_range = 0;
+
+	const char *test = "The quick brown fox jumps over the lazy dog.";
+	TEST_ASSERT(espeak_ng_Synthesize(test, strlen(test)+1, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL) == ENS_OK);
+	TEST_ASSERT(espeak_ng_Synchronize() == ENS_OK);
+
+	// Above espeakRATE_MAXIMUM libsonic compresses each buffer after the events
+	// have been recorded against the uncompressed audio, so without rescaling
+	// the positions run past the audio that was handed to this callback.
+	TEST_ASSERT(_test_word_event_frames > 0);
+	TEST_ASSERT(_test_word_event_out_of_range == 0);
+
+	TEST_ASSERT(espeak_Terminate() == EE_OK);
+	TEST_ASSERT(event_list == NULL);
+	TEST_ASSERT(translator == NULL);
+	TEST_ASSERT(p_decoder == NULL);
+}
+
+// endregion
+
 int
 main(int argc, char **argv)
 {
@@ -665,6 +725,9 @@ main(int argc, char **argv)
 	test_espeak_ng_phoneme_events(0, 0);
 	test_espeak_ng_phoneme_events(1, 0);
 	test_espeak_ng_phoneme_events(1, 1);
+
+	test_word_event_positions(espeakRATE_NORMAL); // libsonic idle
+	test_word_event_positions(900);               // libsonic compressing
 
 	free(progdir);
 


### PR DESCRIPTION
## Problem

`MarkerEvent()` records `ep->sample` and `ep->audio_position` from `out_ptr` while `WavegenFill2()` is filling the buffer. `WavegenFill()` then hands that buffer to `SpeedUp()`, which compresses it in place and rewrites `out_ptr`. So at speech rates above `espeakRATE_MAXIMUM`, every position recorded for a buffer refers to audio longer than what the caller actually receives.

`count_samples` is advanced from the compressed length, so the per-buffer base stays correct and the error does not accumulate across the utterance. But *within* a buffer an event can point well past the audio that buffer produced.

Synthesizing a pangram at rate 900 put **20 of 23** word events out of range, the worst by 4748 frames (215 ms), with one landing past the end of the utterance entirely:

| rate | events out of range (of 23) | max overshoot |
|------|------------------------------|---------------|
| 175  | 0                            | –             |
| 450  | 0                            | –             |
| 600  | 17                           | 4023 frames   |
| 900  | 20                           | 4748 frames   |

At rate 900 the largest event sample was 33031 while the whole utterance was only 32342 frames.

## Fix

`RescaleEventSamples()` maps the recorded positions onto the audio libsonic actually produced. `WavegenFill()` calls it directly after `SpeedUp()`.

It lives in `speech.c` because `event_list_ix` and `count_samples` are static there and `wavegen.c` cannot reach them. `count_samples` is the correct base: it is not advanced for the current buffer until `WavegenFill()` returns, so it still holds exactly what `MarkerEvent()` used.

Because libsonic is a stream that carries samples between calls, the linear mapping is an approximation. What it guarantees is the property callers depend on: an event never points past the audio its own buffer produced.

This matters for anything consuming `espeakEVENT_WORD` to align highlighting with speech (screen readers frequently run at rates where sonic engages), and espeak's own playback path feeds `audio_position` into `create_events` for the same purpose.

Rates at or below `espeakRATE_MAXIMUM` leave `sonicSpeed` at 1.0 and are completely unaffected — output is identical before and after.

## Testing

`test_word_event_positions()` added to `tests/api.c`, following the existing `test_espeak_ng_phoneme_events` pattern, run at `espeakRATE_NORMAL` (sonic idle) and 900 (sonic compressing).

Confirmed it is a genuine regression test: with the fix reverted it fails at the 900 case while still passing at 175, so it is pinned to the sonic path rather than asserting something vacuous.

Full suite run against three build configurations, since the change sits behind `#if USE_LIBSONIC` and touches the `#if !USE_MBROLA` path:

- default (`USE_LIBSONIC=ON`, `USE_MBROLA=OFF`) — 19/19 pass
- `USE_LIBSONIC=OFF` — 19/19 pass
- `USE_MBROLA=ON` + `USE_LIBSONIC=ON` — 20/20 pass

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
