### PR TITLE
Android: report word boundaries and synthesis errors to the TTS framework

### DIFF
--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/SpeechSynthesisTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/SpeechSynthesisTest.java
@@ -109,6 +109,11 @@ public class SpeechSynthesisTest extends TextToSpeechTestCase
         public void onSynthDataComplete()
         {
         }
+
+        @Override
+        public void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames)
+        {
+        }
     };
 
     private Map<String, Voice> mVoices = null;

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
@@ -46,6 +46,11 @@ public class VoiceSettingsTest extends TextToSpeechTestCase
         public void onSynthDataComplete()
         {
         }
+
+        @Override
+        public void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames)
+        {
+        }
     };
 
     // No Settings (New Install)

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/WordBoundaryTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/WordBoundaryTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Reece H. Dunn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import com.reecedunn.espeak.SpeechSynthesis;
+import com.reecedunn.espeak.Voice;
+import com.reecedunn.espeak.VoiceVariant;
+
+import android.speech.tts.TextToSpeech;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Checks the word boundary events that back {@code SynthesisCallback.rangeStart}.
+ *
+ * <p>eSpeak reports word positions as 1-based Unicode code point indices, while
+ * the Android API expects 0-based UTF-16 indices, so the interesting cases are
+ * text outside the Basic Multilingual Plane and text with multi-byte characters.
+ */
+@RunWith(AndroidJUnit4.class)
+public class WordBoundaryTest extends TextToSpeechTestCase
+{
+    private static final Locale ENGLISH = new Locale("en");
+
+    private static class Word
+    {
+        final int position;
+        final int length;
+        final int marker;
+
+        Word(int position, int length, int marker)
+        {
+            this.position = position;
+            this.length = length;
+            this.marker = marker;
+        }
+    }
+
+    private final List<Word> mWords = new ArrayList<Word>();
+
+    private final SpeechSynthesis.SynthReadyCallback mCallback =
+            new SpeechSynthesis.SynthReadyCallback()
+    {
+        @Override
+        public void onSynthDataReady(byte[] audioData)
+        {
+        }
+
+        @Override
+        public void onSynthDataComplete()
+        {
+        }
+
+        @Override
+        public void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames)
+        {
+            mWords.add(new Word(textPosition, textLength, markerInFrames));
+        }
+    };
+
+    /** Synthesizes {@code text} with the en voice and returns the words reported. */
+    private List<Word> wordsFor(String text)
+    {
+        mWords.clear();
+
+        SpeechSynthesis synth = new SpeechSynthesis(getContext(), mCallback);
+        // Match on locale rather than voice name, which varies between eSpeak
+        // releases.
+        Voice en = null;
+        for (Voice voice : synth.getAvailableVoices())
+        {
+            if (voice.match(ENGLISH) != TextToSpeech.LANG_NOT_SUPPORTED)
+            {
+                en = voice;
+                break;
+            }
+        }
+        assertThat(en, is(notNullValue()));
+
+        synth.setVoice(en, VoiceVariant.parseVoiceVariant(VoiceVariant.MALE));
+        // synthesize() blocks until eSpeak has finished, so every event for this
+        // request has been delivered by the time it returns.
+        synth.synthesize(text, false);
+        return mWords;
+    }
+
+    /**
+     * Applies the same conversion as {@code TtsService}: eSpeak's 1-based code
+     * point position and code point length to a UTF-16 substring.
+     */
+    private static String substringFor(String text, Word word)
+    {
+        int start = text.offsetByCodePoints(0, word.position - 1);
+        int end = text.offsetByCodePoints(start, word.length);
+        return text.substring(start, end);
+    }
+
+    @Test
+    public void ascii()
+    {
+        String text = "Hello world again";
+        List<Word> words = wordsFor(text);
+
+        assertThat(words.size(), is(3));
+        assertThat(substringFor(text, words.get(0)), is("Hello"));
+        assertThat(substringFor(text, words.get(1)), is("world"));
+        assertThat(substringFor(text, words.get(2)), is("again"));
+    }
+
+    @Test
+    public void multiByteCharactersAreCountedAsOne()
+    {
+        // Each accented letter is two UTF-8 bytes but a single code point, so a
+        // byte-based reading of text_position would drift on the later words.
+        String text = "héllo wörld tëst";
+        List<Word> words = wordsFor(text);
+
+        assertThat(words.size(), is(3));
+        assertThat(substringFor(text, words.get(0)), is("héllo"));
+        assertThat(substringFor(text, words.get(1)), is("wörld"));
+        assertThat(substringFor(text, words.get(2)), is("tëst"));
+    }
+
+    @Test
+    public void surrogatePairsAreNotSplit()
+    {
+        // The emoji is one code point but two UTF-16 units. Treating eSpeak's
+        // position as a UTF-16 index would yield half a surrogate pair.
+        String text = "ab 😀 cd";
+        List<Word> words = wordsFor(text);
+
+        assertThat(words.size(), greaterThanOrEqualTo(2));
+        assertThat(substringFor(text, words.get(0)), is("ab"));
+        assertThat(substringFor(text, words.get(1)), is("😀"));
+        // The last word must still land on "cd" despite the surrogate pair.
+        assertThat(substringFor(text, words.get(words.size() - 1)), is("cd"));
+    }
+
+    @Test
+    public void markersAreNonDecreasingAndStartAtZero()
+    {
+        List<Word> words = wordsFor("Hello world again");
+
+        assertThat(words.isEmpty(), is(false));
+        assertThat(words.get(0).marker, is(0));
+        for (int i = 1; i < words.size(); ++i)
+        {
+            assertThat(words.get(i).marker, greaterThanOrEqualTo(words.get(i - 1).marker));
+        }
+    }
+
+    @Test
+    public void markersRestartForEachRequest()
+    {
+        wordsFor("Hello world again");
+        // frames_delivered is reset per espeak_Synth call, so a second request
+        // must not continue counting from the first.
+        List<Word> words = wordsFor("Hello world again");
+
+        assertThat(words.isEmpty(), is(false));
+        assertThat(words.get(0).marker, is(0));
+    }
+}

--- a/android/jni/jni/eSpeakService.c
+++ b/android/jni/jni/eSpeakService.c
@@ -97,6 +97,11 @@ enum synthesis_result {
 
 static JavaVM *jvm = NULL;
 jmethodID METHOD_nativeSynthCallback;
+jmethodID METHOD_nativeSynthWordCallback;
+
+/* Audio frames handed to the Java layer so far for the current request.
+ * Reset by nativeSynthesize before each espeak_Synth call. */
+static int frames_delivered = 0;
 
 static JNIEnv *getJniEnv() {
   JNIEnv *env = NULL;
@@ -110,15 +115,45 @@ static int SynthCallback(short *audioData, int numSamples,
   JNIEnv *env = getJniEnv();
   jobject object = (jobject)events->user_data;
 
-  if (numSamples < 1) {
+  /* espeak marks the end of the request with a NULL buffer, not with a zero
+   * sample count -- an empty buffer can legitimately occur mid-stream. */
+  if (audioData == NULL) {
     (*env)->CallVoidMethod(env, object, METHOD_nativeSynthCallback, NULL);
     return SYNTH_ABORT;
-  } else {
+  }
+
+  for (espeak_EVENT *event = events;
+       event->type != espeakEVENT_LIST_TERMINATED; ++event) {
+    if (event->type != espeakEVENT_WORD)
+      continue;
+
+    /* event->sample is an absolute frame index within the request, but it is
+     * recorded inside WavegenFill2() before libsonic compresses the buffer, so
+     * at sonic-accelerated rates (wpm above espeakRATE_MAXIMUM) it can point
+     * past the audio actually produced.  Clamping to the current buffer keeps
+     * it exact while sonic is idle and bounded by one buffer when it is not. */
+    int marker = event->sample;
+    if (marker < frames_delivered)
+      marker = frames_delivered;
+    else if (marker > frames_delivered + numSamples)
+      marker = frames_delivered + numSamples;
+
+    (*env)->CallVoidMethod(env, object, METHOD_nativeSynthWordCallback,
+                           (jint) event->text_position, (jint) event->length,
+                           (jint) marker);
+  }
+
+  if (numSamples > 0) {
     jbyteArray arrayAudioData = (*env)->NewByteArray(env, numSamples * 2);
     (*env)->SetByteArrayRegion(env, arrayAudioData, 0, (numSamples * 2), (jbyte *) audioData);
     (*env)->CallVoidMethod(env, object, METHOD_nativeSynthCallback, arrayAudioData);
-    return SYNTH_CONTINUE;
+    /* The callback runs many times per request without returning to Java, so
+     * the local reference has to be released here or the table overflows. */
+    (*env)->DeleteLocalRef(env, arrayAudioData);
+    frames_delivered += numSamples;
   }
+
+  return SYNTH_CONTINUE;
 }
 
 #ifdef __cplusplus
@@ -143,6 +178,7 @@ JNICALL Java_com_reecedunn_espeak_SpeechSynthesis_nativeClassInit(
     JNIEnv* env, jclass clazz) {
   if (DEBUG) LOGV("%s", __FUNCTION__);
   METHOD_nativeSynthCallback = (*env)->GetMethodID(env, clazz, "nativeSynthCallback", "([B)V");
+  METHOD_nativeSynthWordCallback = (*env)->GetMethodID(env, clazz, "nativeSynthWordCallback", "(III)V");
 
   return JNI_TRUE;
 }
@@ -310,6 +346,7 @@ JNICALL Java_com_reecedunn_espeak_SpeechSynthesis_nativeSynthesize(
   unsigned int unique_identifier;
 
   espeak_SetSynthCallback(SynthCallback);
+  frames_delivered = 0;
   const espeak_ERROR result = espeak_Synth(c_text, strlen(c_text), 0,  // position
                POS_CHARACTER, 0, // end position (0 means no end position)
                isSsml ? espeakCHARS_UTF8 | espeakSSML // UTF-8 encoded SSML

--- a/android/src/com/reecedunn/espeak/CheckVoiceData.java
+++ b/android/src/com/reecedunn/espeak/CheckVoiceData.java
@@ -190,5 +190,10 @@ public class CheckVoiceData extends Activity {
         public void onSynthDataComplete() {
             // Do nothing.
         }
+
+        @Override
+        public void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames) {
+            // Do nothing.
+        }
     };
 }

--- a/android/src/com/reecedunn/espeak/SpeechSynthesis.java
+++ b/android/src/com/reecedunn/espeak/SpeechSynthesis.java
@@ -274,6 +274,14 @@ public class SpeechSynthesis {
         }
     }
 
+    @SuppressWarnings("unused") // called from eSpeakService.c
+    private void nativeSynthWordCallback(int textPosition, int textLength, int markerInFrames) {
+        if (mCallback == null)
+            return;
+
+        mCallback.onSynthWordBoundary(textPosition, textLength, markerInFrames);
+    }
+
     private void attemptInit() {
         if (mInitialized) {
             return;
@@ -333,6 +341,19 @@ public class SpeechSynthesis {
         void onSynthDataReady(byte[] audioData);
 
         void onSynthDataComplete();
+
+        /**
+         * Reports the start of a spoken word.
+         *
+         * @param textPosition 1-based index of the word in the synthesized text,
+         *                     counted in Unicode code points (not UTF-16 units).
+         * @param textLength Word length in code points. eSpeak packs this into a
+         *                   single byte, so words longer than 255 report a
+         *                   truncated length.
+         * @param markerInFrames Absolute frame offset of the word within the audio
+         *                       generated for this request.
+         */
+        void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames);
     }
 
     public static String getIanaLanguageCode(String code) {

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -64,6 +64,16 @@ public class TtsService extends TextToSpeechService {
     private SpeechSynthesis mEngine;
     private SynthesisCallback mCallback;
 
+    /** Text handed to eSpeak for the current request. */
+    private String mSynthText;
+    /** Where {@link #mSynthText} starts within the text the caller supplied. */
+    private int mSynthTextOffset;
+    /** Number of code points in {@link #mSynthText}. */
+    private int mSynthTextCodePoints;
+    /** Anchor for incremental code point to UTF-16 index conversion. */
+    private int mAnchorCodePoint;
+    private int mAnchorOffset;
+
     private List<Voice> mAllVoices = new ArrayList<Voice>();
     private final Map<String, Voice> mAvailableVoices = new HashMap<String, Voice>();
     protected Voice mMatchingVoice = null;
@@ -332,21 +342,68 @@ public class TtsService extends TextToSpeechService {
         return selectLanguageWithFallback(request.getLanguage(), request.getCountry(), request.getVariant());
     }
 
+    /**
+     * Reports a synthesis failure to the caller.
+     *
+     * <p>The framework only dispatches an error once {@code done()} follows, and
+     * treats a request that returns without calling either as a successful empty
+     * utterance, which hides failures from screen readers.
+     */
+    private void reportError(SynthesisCallback callback, int errorCode) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            callback.error(errorCode);
+        } else {
+            callback.error();
+        }
+        callback.done();
+    }
+
+    /**
+     * Converts a 0-based code point index within {@link #mSynthText} into the
+     * UTF-16 index that {@link SynthesisCallback#rangeStart} expects.
+     *
+     * <p>Walks forward from the previous result, since word events arrive in text
+     * order; the occasional out-of-order event falls back to a full rescan.
+     */
+    private int codePointToOffset(int codePointIndex) {
+        if (codePointIndex <= 0) {
+            return 0;
+        }
+        if (codePointIndex >= mSynthTextCodePoints) {
+            return mSynthText.length();
+        }
+        if (codePointIndex < mAnchorCodePoint) {
+            mAnchorCodePoint = 0;
+            mAnchorOffset = 0;
+        }
+        mAnchorOffset = mSynthText.offsetByCodePoints(
+                mAnchorOffset, codePointIndex - mAnchorCodePoint);
+        mAnchorCodePoint = codePointIndex;
+        return mAnchorOffset;
+    }
+
     @Override
     protected synchronized void onSynthesizeText(SynthesisRequest request, SynthesisCallback callback) {
-        if (selectVoice(request) == TextToSpeech.ERROR)
+        if (selectVoice(request) == TextToSpeech.ERROR) {
+            reportError(callback, CheckVoiceData.hasBaseResources(storageContext)
+                    ? TextToSpeech.ERROR_SERVICE : TextToSpeech.ERROR_NOT_INSTALLED_YET);
             return;
+        }
 
         final Voice voice;
         synchronized (mAvailableVoices) {
             voice = mMatchingVoice;
         }
-        if (voice == null)
+        if (voice == null) {
+            reportError(callback, TextToSpeech.ERROR_SERVICE);
             return;
+        }
 
         String text = getRequestString(request);
-        if (text == null)
+        if (text == null) {
+            reportError(callback, TextToSpeech.ERROR_INVALID_REQUEST);
             return;
+        }
 
         if (DEBUG) {
             Log.i(TAG, "Received synthesis request: {language=\"" + voice.name + "\"}");
@@ -358,12 +415,27 @@ public class TtsService extends TextToSpeechService {
             }
         }
 
+        int textOffset = 0;
         if (text.startsWith("<?xml"))
         {
             // eSpeak does not recognise/skip "<?...?>" preprocessing tags,
             // so need to remove these before passing to synthesize.
-            text = text.substring(text.indexOf("?>") + 2).trim();
+            final int declarationEnd = text.indexOf("?>") + 2;
+            // Track what was dropped from the front, so that word boundaries can
+            // be reported against the text the caller actually passed in. This
+            // mirrors what String.trim() strips (anything <= ' ').
+            textOffset = declarationEnd;
+            while (textOffset < text.length() && text.charAt(textOffset) <= ' ') {
+                textOffset++;
+            }
+            text = text.substring(declarationEnd).trim();
         }
+
+        mSynthText = text;
+        mSynthTextOffset = textOffset;
+        mSynthTextCodePoints = text.codePointCount(0, text.length());
+        mAnchorCodePoint = 0;
+        mAnchorOffset = 0;
 
         mCallback = callback;
         mCallback.start(mEngine.getSampleRate(), mEngine.getAudioFormat(), mEngine.getChannelCount());
@@ -432,6 +504,26 @@ public class TtsService extends TextToSpeechService {
         @Override
         public void onSynthDataComplete() {
             mCallback.done();
+        }
+
+        @Override
+        public void onSynthWordBoundary(int textPosition, int textLength, int markerInFrames) {
+            // rangeStart() is API 26; below that the framework has no way to
+            // deliver word boundaries to the caller.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || mSynthText == null) {
+                return;
+            }
+
+            // eSpeak counts code points from 1, rangeStart() wants 0-based UTF-16
+            // indices into the text the caller supplied.
+            final int wordStart = textPosition - 1;
+            final int start = codePointToOffset(wordStart);
+            final int end = codePointToOffset(wordStart + Math.max(textLength, 0));
+            if (end <= start) {
+                return;
+            }
+
+            mCallback.rangeStart(markerInFrames, mSynthTextOffset + start, mSynthTextOffset + end);
         }
     };
 }

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -350,11 +350,9 @@ public class TtsService extends TextToSpeechService {
      * utterance, which hides failures from screen readers.
      */
     private void reportError(SynthesisCallback callback, int errorCode) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            callback.error(errorCode);
-        } else {
-            callback.error();
-        }
+        // error(int) has been available since API 21, which is minSdk here, so
+        // the code always reaches the caller.
+        callback.error(errorCode);
         callback.done();
     }
 
@@ -419,16 +417,22 @@ public class TtsService extends TextToSpeechService {
         if (text.startsWith("<?xml"))
         {
             // eSpeak does not recognise/skip "<?...?>" preprocessing tags,
-            // so need to remove these before passing to synthesize.
-            final int declarationEnd = text.indexOf("?>") + 2;
-            // Track what was dropped from the front, so that word boundaries can
-            // be reported against the text the caller actually passed in. This
-            // mirrors what String.trim() strips (anything <= ' ').
-            textOffset = declarationEnd;
-            while (textOffset < text.length() && text.charAt(textOffset) <= ' ') {
-                textOffset++;
+            // so need to remove these before passing to synthesize. A
+            // declaration missing its "?>" is left alone rather than having its
+            // first character eaten by a -1 index.
+            final int terminator = text.indexOf("?>");
+            if (terminator >= 0)
+            {
+                final int declarationEnd = terminator + 2;
+                // Track what was dropped from the front, so that word boundaries can
+                // be reported against the text the caller actually passed in. This
+                // mirrors what String.trim() strips (anything <= ' ').
+                textOffset = declarationEnd;
+                while (textOffset < text.length() && text.charAt(textOffset) <= ' ') {
+                    textOffset++;
+                }
+                text = text.substring(declarationEnd).trim();
             }
-            text = text.substring(declarationEnd).trim();
         }
 
         mSynthText = text;


### PR DESCRIPTION
## Problem

The engine implements every `TextToSpeechService` overridable, but only four of the nine `SynthesisCallback` members, leaving two gaps that callers notice.

**`rangeStart()` was never called**, so clients had no word boundary events and could not highlight spoken text. eSpeak already emits `espeakEVENT_WORD`, but `SynthCallback()` used the event list only to fetch `user_data`, and the JNI-to-Java bridge carried audio bytes alone.

**`error()` was never called either.** The failure paths in `onSynthesizeText()` returned without calling `start()` or `done()`. The framework treats that as a successful empty utterance (`PlaybackSynthesisCallback.done()` only dispatches once `mItem == null` is reached via an explicit `done()`), so clients saw `onDone` instead of `onError` and could not distinguish a failure from silence — for example when voice data is missing.

## Changes

Word events are now forwarded through a new `nativeSynthWordCallback(III)V` binding, surfaced on `SynthReadyCallback`, and delivered to `SynthesisCallback.rangeStart()` (guarded to API 26+).

Two conversions are needed:

- eSpeak reports positions as **1-based Unicode code point indices**, while `rangeStart()` expects **0-based UTF-16 indices**. An emoji naively treated as one unit would split a surrogate pair. The conversion walks forward from the previous word so it stays linear over the utterance.
- Positions are relative to the text handed to eSpeak, so the offset dropped by the `<?xml` strip is tracked and added back.

For the frame marker, `event->sample` is an absolute frame index within the request. It is recorded before libsonic compresses the buffer, so above `espeakRATE_MAXIMUM` it can overshoot; clamping to the current buffer is exact while sonic is idle and bounded otherwise. (espeak-ng/espeak-ng#2470 fixes this at the source; with that merged the clamp becomes a no-op safety net. The two branches are independent and can land in either order.)

The failure paths now call `error(code)` then `done()`, mapping to `ERROR_NOT_INSTALLED_YET` / `ERROR_SERVICE` / `ERROR_INVALID_REQUEST`.

## Two bugs fixed in the callback along the way

- End of synthesis is now detected by a **NULL buffer** rather than a zero sample count. eSpeak marks the end with `synth_callback(NULL, 0, ...)`, but can also pass a real buffer with `length == 0` mid-stream, which would previously have truncated the utterance.
- The audio `jbyteArray` local reference is now released. The callback runs many times per request without returning to Java, so at 300 ms buffers the old code would hit the 512-entry local reference table limit on utterances longer than roughly 2.5 minutes.

## Testing

`WordBoundaryTest.java` added, covering ASCII, multi-byte characters, surrogate pairs, marker monotonicity, and per-request marker reset.

The conversion logic was additionally verified off-device against real eSpeak event output: `"ab 😀 cd"` extracts the intact `😀` (which a UTF-16 assumption would split), `"héllo wörld tëst"` stays aligned where a byte-based reading would drift, and `"abc 日本 xyz"` revealed that eSpeak emits two word events at the same position for `日本`, which the code handles.

Builds clean: app plus native library for all four ABIs, and the instrumentation test sources.

`WordBoundaryTest` has now run on-target in CI: the instrumented job executes 56 tests here against 51 on the C-only branch (#2470) — exactly the five new cases — on an `android-29` emulator, 0 skipped, 0 failed. An earlier revision of this description said it had not been executed on a device; that no longer applies.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

