### PR TITLE
build: enable -Wimplicit-fallthrough for libespeak-ng

### DIFF
--- a/src/libespeak-ng/CMakeLists.txt
+++ b/src/libespeak-ng/CMakeLists.txt
@@ -63,6 +63,7 @@ if (NOT MSVC)
     "-Wint-conversion"
     "-Wimplicit"
     "-Wmisleading-indentation"
+    "-Wimplicit-fallthrough"
 
     # All path buffers are sized to the platform path limit (PATH_MAX /
     # MAX_PATH) and written with snprintf. Truncation on a near-limit path

--- a/src/libespeak-ng/common.h
+++ b/src/libespeak-ng/common.h
@@ -23,6 +23,17 @@
 #include "espeak-ng/espeak_ng.h"
 #include "translate.h"
 
+// Marks a deliberate fall-through between switch labels, so that
+// -Wimplicit-fallthrough only fires on accidental ones. A comment alone is not
+// enough: clang ignores comment forms entirely.
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ > 201710L
+#define ESPEAK_FALLTHROUGH [[fallthrough]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define ESPEAK_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define ESPEAK_FALLTHROUGH ((void)0)
+#endif
+
 extern ESPEAK_NG_API int GetFileLength(const char *filename);
 extern ESPEAK_NG_API void strncpy0(char *to, const char *from, int size);
 

--- a/src/libespeak-ng/common.h
+++ b/src/libespeak-ng/common.h
@@ -23,6 +23,17 @@
 #include "espeak-ng/espeak_ng.h"
 #include "translate.h"
 
+// Marks a deliberate fall-through between switch labels, so that
+// -Wimplicit-fallthrough only fires on accidental ones. A comment alone is not
+// enough: clang ignores comment forms entirely.
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ > 201710L
+#define ESPEAK_FALLTHROUGH [[fallthrough]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define ESPEAK_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define ESPEAK_FALLTHROUGH ((void)0)
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -2033,7 +2033,7 @@ static int CompilePhoneme(CompileContext *ctx, int compile_phoneme)
 				break;
 			case kWAV:
 				ctx->if_stack[ctx->if_level].returned = true;
-				// fallthrough:
+				ESPEAK_FALLTHROUGH;
 			case kVOWELSTART:
 			case kVOWELENDING:
 			case kANDWAV:
@@ -2063,7 +2063,7 @@ static int CompilePhoneme(CompileContext *ctx, int compile_phoneme)
 			case kINCLUDE:
 			case kPHONEMETABLE:
 				error(ctx, "Missing 'endphoneme' before '%s'", ctx->item_string);  // drop through to endphoneme
-				// fallthrough:
+				ESPEAK_FALLTHROUGH;
 			case kENDPHONEME:
 			case kENDPROCEDURE:
 				endphoneme = 1;

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -283,7 +283,7 @@ char *DecodeRule(const char *group_chars, int group_length, char *rule, int cont
 				break;
 			case RULE_PRE_ATSTART:
 				at_start = true;
-				// fallthrough:
+				ESPEAK_FALLTHROUGH;
 			case RULE_PRE:
 				match_type = RULE_PRE;
 				*p = 0;
@@ -879,7 +879,7 @@ static void copy_rule_string(CompileContext *ctx, char *string, int *state_out)
 
 				case 'Y':
 					c = 'I';
-					// fallthrough:
+					ESPEAK_FALLTHROUGH;
 				case 'A': // vowel
 				case 'B':
 				case 'C':
@@ -994,7 +994,7 @@ static void copy_rule_string(CompileContext *ctx, char *string, int *state_out)
 					break;
 				case 'P': // Prefix
 					sxflags |= SUFX_P;
-					// fallthrough
+					ESPEAK_FALLTHROUGH;
 				case 'S': // Suffix
 					output[ix++] = RULE_ENDING;
 					value = 0;

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -322,6 +322,7 @@ const char *EncodePhonemes(const char *p, char *outptr, int *bad_phoneme)
 			if ((c = p[1]) == '|') {
 				// treat double || as a word-break symbol, drop through
 				// to the default case with c = '|'
+				ESPEAK_FALLTHROUGH;
 			} else {
 				p++;
 				break;
@@ -1033,7 +1034,7 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 		// stress on first syllable, unless it is a light syllable followed by a heavy syllable
 		if ((syllable_weight[1] > 0) || (syllable_weight[2] == 0))
 			break;
-		// fallthrough:
+		ESPEAK_FALLTHROUGH;
 	case STRESSPOSN_2L:
 		// stress on second syllable
 		if ((stressed_syllable == 0) && (vowel_count > 2)) {

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -322,6 +322,7 @@ const char *EncodePhonemes(const char *p, char *outptr, int *bad_phoneme)
 			if ((c = p[1]) == '|') {
 				// treat double || as a word-break symbol, drop through
 				// to the default case with c = '|'
+				ESPEAK_FALLTHROUGH;
 			} else {
 				p++;
 				break;
@@ -1039,7 +1040,7 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 		// stress on first syllable, unless it is a light syllable followed by a heavy syllable
 		if ((syllable_weight[1] > 0) || (syllable_weight[2] == 0))
 			break;
-		// fallthrough:
+		ESPEAK_FALLTHROUGH;
 	case STRESSPOSN_2L:
 		// stress on second syllable
 		if ((stressed_syllable == 0) && (vowel_count > 2)) {

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -1734,7 +1734,7 @@ static int TranslateNumber_1(Translator *tr, char *word, char *ph_out, char *ph_
 		{
 		case NUM_DFRACTION_4:
 			max_decimal_count = 5;
-			// fallthrough:
+			ESPEAK_FALLTHROUGH;
 		case NUM_DFRACTION_2:
 			// French/Polish decimal fraction
 			while (word[n_digits] == '0') {

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -841,7 +841,7 @@ Translator *SelectTranslator(const char *name)
 		break;
 	case L('e', 't'): // Estonian
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4;
-		// fallthrough:
+		ESPEAK_FALLTHROUGH;
 	case L('f', 'i'): // Finnish
 	{
 		tr->langopts.long_stop = 130;

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -846,7 +846,7 @@ Translator *SelectTranslator(const char *name)
 		break;
 	case L('e', 't'): // Estonian
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4;
-		// fallthrough:
+		ESPEAK_FALLTHROUGH;
 	case L('f', 'i'): // Finnish
 	{
 		tr->langopts.long_stop = 130;

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -1051,6 +1051,7 @@ void SetEmbedded(int control, int value)
 	{
 	case EMBED_T:
 		WavegenSetEcho(); // and drop through to case P
+		ESPEAK_FALLTHROUGH;
 	case EMBED_P:
 		SetPitchFormants();
 		break;
@@ -1329,6 +1330,7 @@ static int WavegenFill2(void)
 			break;
 		case WCMD_SPECT2: // as WCMD_SPECT but stop any concurrent wave file
 			wdata.n_mix_wavefile = 0; // ... and drop through to WCMD_SPECT case
+			ESPEAK_FALLTHROUGH;
 		case WCMD_SPECT:
 			echo_complete = echo_length;
 			result = Wavegen(length & 0xffff, q[1] >> 16, resume, (frame_t *)q[2], (frame_t *)q[3], wvoice);
@@ -1336,6 +1338,7 @@ static int WavegenFill2(void)
 #if USE_KLATT
 		case WCMD_KLATT2: // as WCMD_SPECT but stop any concurrent wave file
 			wdata.n_mix_wavefile = 0; // ... and drop through to WCMD_SPECT case
+			ESPEAK_FALLTHROUGH;
 		case WCMD_KLATT:
 			echo_complete = echo_length;
 			result = Wavegen_Klatt(length & 0xffff, resume, (frame_t *)q[2], (frame_t *)q[3], &wdata, wvoice);


### PR DESCRIPTION
Fixes #2476.

`SelectTranslator()` in `tr_languages.c` is a ~1000-line `switch`. A missing `break` between two `case` blocks silently gives one language another language's `langopts`, and until now nothing in the build or CI would catch it — see #2476 for the case that prompted this, where Oromo was overwritten by a neighbouring language and the only symptom was a changed audio hash.

## What this does

- Adds `-Wimplicit-fallthrough` to the `espeak-ng` target's existing warning list.
- Annotates the twelve deliberate fall-throughs in `libespeak-ng` with a new `ESPEAK_FALLTHROUGH` macro.

All twelve sites were *already* documented in prose (`// fallthrough:`, `// and drop through to case P`, and so on). I checked each one: every one is intentional, and this change found no latent bugs in master. But a comment is not an annotation as far as clang is concerned, so they need the attribute to stay quiet.

## Why clang and not gcc

gcc's `-Wimplicit-fallthrough=3` **misses** the exact shape that caused #2476 — it does not fire when both case bodies are braced compound statements:

```c
	case L('o', 'm'): { ... }
		case L('o', 's'): { ... }
		break;
```

clang catches it. CI already runs clang jobs, so this costs nothing extra to get.

## Notes

- `ESPEAK_FALLTHROUGH` lives in `common.h` (included by all six affected files) and degrades to `((void)0)` on compilers without the attribute, since MSVC builds these sources too. It prefers C23 `[[fallthrough]]` where available.
- The vendored `src/ucd-tools` is deliberately left alone — separate upstream project with its own `AUTHORS`/`COPYING`. It has one such site (`proplist.c:1746`, benign: the fall-through target returns the same value). The flag is scoped to the `espeak-ng` target so ucd-tools is unaffected.
- No behaviour change; the annotations are no-ops.

## Testing

Configured and built from scratch under both gcc and clang: zero fall-through warnings from `libespeak-ng` under either. `ctest` is 19/19 green.

The one remaining clang warning in the tree, `dictionary.c:1506 address of array 'phoneme_tab' will always evaluate to 'true' [-Wpointer-bool-conversion]`, is pre-existing and untouched here — though it looks worth a separate look, since it means a NULL guard there is a no-op.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.
