### PR TITLE
common.h: restore the missing extern "C" opening

### DIFF
--- a/src/libespeak-ng/common.h
+++ b/src/libespeak-ng/common.h
@@ -23,6 +23,11 @@
 #include "espeak-ng/espeak_ng.h"
 #include "translate.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 extern ESPEAK_NG_API int GetFileLength(const char *filename);
 extern ESPEAK_NG_API void strncpy0(char *to, const char *from, int size);
 
@@ -52,4 +57,4 @@ int utf8_out(unsigned int c, char *buf);
 }
 #endif
 
-#endif // SPEECH_H
+#endif // ESPEAK_NG_COMMON_H


### PR DESCRIPTION
`src/libespeak-ng/common.h` carries the *closing* half of an `extern "C"` block with no opening, so including it from C++ fails to compile:

```
src/libespeak-ng/common.h:63:1: error: expected declaration before '}' token
```

It is the only unbalanced header of the 30 in `src/libespeak-ng` — the other 29 all have the matched pair:

```c
#ifdef __cplusplus
extern "C"
{
#endif
...
#ifdef __cplusplus
}
#endif
```

The stale `#endif // SPEECH_H` on a file guarded by `ESPEAK_NG_COMMON_H` shows how it happened: the file was copied from `speech.h` and the opening half was lost. This PR restores the pair and corrects the guard comment.

This is latent rather than active — every in-tree consumer of `common.h` is C, so nothing is broken today. But the `extern "C"` linkage the header clearly intends is currently absent, and the file cannot be picked up by any future C++ translation unit.

## Testing

- `g++ -fsyntax-only` on a TU that includes `common.h`: fails on master, compiles clean here.
- Full C build unaffected; `ctest` 19/19.

## Note on #2477

This **conflicts with #2477** — both insert at the same point in `common.h`, just after the includes. The resolution is trivial and the two changes are independent; whichever lands second just needs both hunks kept, with the macro outside the `extern "C"` block:

```c
#include "translate.h"

// Marks a deliberate fall-through ...      <- #2477
#define ESPEAK_FALLTHROUGH ...

#ifdef __cplusplus                          <- this PR
extern "C"
{
#endif

extern ESPEAK_NG_API int GetFileLength(const char *filename);
```

Happy to rebase whichever way suits the merge order.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.
