### PR TITLE
Android: stop disabling the launcher alias, which closed the settings UI

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -80,7 +80,7 @@
         <activity-alias
             android:name=".WearLauncher"
             android:targetActivity=".TtsSettingsActivity"
-            android:enabled="true"
+            android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/icon"
             android:label="@string/tts_settings_label">

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -29,7 +29,10 @@ The Gradle build has custom tasks that run automatically:
 3. `createDataHash` generates SHA256 for upgrade detection
 4. `createDataVersion` writes the hash to `res/raw/espeakdata_version`
 
-Native build disables `USE_ASYNC` and `USE_MBROLA` (not needed on Android).
+Native build disables `USE_ASYNC` and `USE_MBROLA` (not needed on Android) and
+enables `USE_LIBSONIC` for speech rates above `espeakRATE_MAXIMUM`. libsonic has
+no NDK sysroot package, so `jni/CMakeLists.txt` fetches and builds it from
+source and pre-seeds `SONIC_LIB`/`SONIC_INC` for `cmake/deps.cmake`.
 
 ## Architecture
 
@@ -47,15 +50,31 @@ Android TTS Framework
 
 ### Key Classes (`src/com/reecedunn/espeak/`)
 
+- **EspeakApp** — `Application` subclass; owns the device-protected storage context and the Wear launcher alias state (see below)
 - **TtsService** — Android TTS engine service; handles `onSynthesizeText()`, voice selection, parameter setup
 - **SpeechSynthesis** — JNI wrapper; loads `libttsespeak.so`, exposes native functions as Java API
 - **VoiceSettings** — SharedPreferences wrapper for rate, pitch, volume, punctuation, variant
 - **LanguageSettings** — Filters available voices by user-selected languages
 - **CheckVoiceData** — Intent handler that verifies voice data files exist on device
 - **DownloadVoiceData** — Extracts `espeakdata.zip` to device-protected storage
-- **eSpeakActivity** — Demo/launcher activity for manual testing
-- **TtsSettingsActivity** — Preferences UI (voice variant, rate, pitch, etc.)
+- **TtsSettingsActivity** — Preferences UI (voice variant, rate, pitch, etc.); also the `CONFIGURE_ENGINE` target and, on Wear, the launcher entry point
 - **Voice / VoiceVariant** — Data models for voice metadata and variant parsing
+
+### Launcher icon and Wear
+
+There is no standalone launcher activity. The only `MAIN`/`LAUNCHER` entry is
+the `.WearLauncher` `<activity-alias>` targeting `TtsSettingsActivity`, and it
+ships `android:enabled="false"`. `EspeakApp.syncWearLauncherState()` enables it
+at runtime on watches only; phones reach the settings UI through the gear in
+the system Text-to-speech settings (`CONFIGURE_ENGINE`).
+
+**Never disable that alias at runtime.** Disabling a launcher alias closes the
+activity that was started through it — silently, with no exception, and
+`DONT_KILL_APP` does not prevent it. An earlier revision shipped the alias
+enabled and disabled it on phones at first launch, which made the settings
+screen open and immediately vanish. A `@bool/`-with-`values-watch` override on
+`android:enabled` does not work either: PackageManager parses that attribute
+against a configuration with no UI mode, so it always resolves to the default.
 
 ### JNI Layer (`jni/jni/eSpeakService.c`)
 
@@ -69,13 +88,13 @@ On first launch (or version mismatch), `DownloadVoiceData` extracts `res/raw/esp
 
 ```
 android/
-├── src/com/reecedunn/espeak/   # Java sources (18 classes)
+├── src/com/reecedunn/espeak/   # Java sources (14 classes)
 │   └── preference/             # Custom preference widgets (5 classes)
 ├── jni/
-│   ├── CMakeLists.txt          # Native build (links espeak-ng + JNI)
-│   ├── jni/eSpeakService.c     # JNI bridge (344 lines)
+│   ├── CMakeLists.txt          # Native build (links espeak-ng + JNI, builds libsonic)
+│   ├── jni/eSpeakService.c     # JNI bridge (11 native methods)
 │   └── include/                # config.h, Log.h
-├── res/                        # Resources (40+ locale translations)
+├── res/                        # Resources (46 locale translations, plus values-v21/-watch)
 ├── eSpeakTests/                # Instrumentation tests
 ├── build.gradle                # Gradle config
 └── AndroidManifest.xml         # Services, activities, intents

--- a/android/src/com/reecedunn/espeak/EspeakApp.java
+++ b/android/src/com/reecedunn/espeak/EspeakApp.java
@@ -21,8 +21,11 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.util.Log;
 
 public class EspeakApp extends Application {
+
+    private static final String TAG = EspeakApp.class.getSimpleName();
 
     private static Context storageContext;
 
@@ -43,28 +46,63 @@ public class EspeakApp extends Application {
      * Text-to-speech settings has no per-engine config affordance. On phones
      * the user reaches CONFIGURE_ENGINE through the gear in TTS settings.
      *
-     * Done at runtime rather than via @bool/-watch resource on the
-     * activity-alias's android:enabled: PackageManager parses that attribute
-     * against a configuration that does not include the device's UI mode,
-     * so a values-watch override resolves to its default at install time
-     * (verified on a Pixel Watch 3, mCurUiMode=0x16, where the alias was
-     * registered as disabled despite the bool's watch qualifier).
-     * setComponentEnabledSetting bypasses the manifest-time resolution.
+     * The alias ships android:enabled="false", so this only ever *enables* it,
+     * and only on a watch. Never disable it: disabling a launcher alias closes
+     * the activity that was started through it -- silently, with no exception,
+     * and DONT_KILL_APP does not prevent it. A phone tapping the icon that the
+     * old always-enabled alias put on the home screen therefore watched the
+     * settings screen open and immediately vanish, which reads as a crash.
+     * Shipping the alias disabled means a phone is already in the desired
+     * state and needs no PackageManager write at all.
+     *
+     * A @bool/-watch resource on android:enabled cannot replace this:
+     * PackageManager parses that attribute against a configuration that does
+     * not include the device's UI mode, so a values-watch override resolves to
+     * its default at install time (verified on a Pixel Watch 3,
+     * mCurUiMode=0x16, where the alias stayed disabled despite the bool's
+     * watch qualifier). setComponentEnabledSetting bypasses that resolution.
+     *
      * Use the FQCN built from the Java package, not getPackageName(): the
      * latter returns the runtime applicationId, which may differ from the
      * manifest namespace that the activity-alias's relative ".WearLauncher"
      * was resolved against at build time.
+     *
+     * TtsService shares this process, so onCreate() also runs whenever the TTS
+     * framework binds the engine -- at boot, or the first time a screen reader
+     * speaks. The launcher alias is irrelevant to that path, so the work is
+     * pushed off the startup thread rather than charging binder round trips to
+     * every cold start. It is also fully guarded: changing component state can
+     * be refused by device policy on managed profiles and some vendor ROMs, and
+     * an escaping exception here would take down the engine before it ever
+     * reaches onSynthesizeText().
      */
     private void syncWearLauncherState() {
-        PackageManager pm = getPackageManager();
-        boolean isWatch = pm.hasSystemFeature(PackageManager.FEATURE_WATCH);
-        ComponentName alias = new ComponentName(this, EspeakApp.class.getPackage().getName() + ".WearLauncher");
-        int desired = isWatch
-            ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-            : PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
-        if (pm.getComponentEnabledSetting(alias) != desired) {
-            pm.setComponentEnabledSetting(alias, desired, PackageManager.DONT_KILL_APP);
-        }
+        final PackageManager pm = getPackageManager();
+        final ComponentName alias = new ComponentName(
+            this, EspeakApp.class.getPackage().getName() + ".WearLauncher");
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (!pm.hasSystemFeature(PackageManager.FEATURE_WATCH)) {
+                        return; // already disabled in the manifest
+                    }
+                    if (pm.getComponentEnabledSetting(alias)
+                            != PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+                        pm.setComponentEnabledSetting(alias,
+                            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                            PackageManager.DONT_KILL_APP);
+                    }
+                } catch (RuntimeException e) {
+                    // SecurityException (device policy), IllegalArgumentException
+                    // (alias missing from a repackaged build), or anything a
+                    // vendor PackageManager throws. Losing the launcher icon is
+                    // a cosmetic failure; taking the process down is not.
+                    Log.w(TAG, "Could not enable the Wear launcher alias", e);
+                }
+            }
+        }, "wear-launcher-sync").start();
     }
 
     public static Context getStorageContext() {


### PR DESCRIPTION
## Problem

Testers reported that the app "crashes when you open it" — on some devices, for some people, with no crash dialog and no stack trace to show for it.

There is no crash. `.WearLauncher` is the app's only `MAIN`/`LAUNCHER` entry (the standalone launcher activity was dropped in be2dd14e). It shipped `android:enabled="true"`, and `EspeakApp.onCreate()` disabled it on every non-watch device the first time the process started.

Disabling a launcher `activity-alias` **closes the activity that was started through it** — silently, with no exception, and `DONT_KILL_APP` does not prevent it ([long-standing, well documented behaviour](https://stackoverflow.com/questions/28436280/app-closes-after-calling-setcomponentenabledsetting-for-using-activity-alias)). So on a phone: tap the icon → settings screen opens → `EspeakApp` disables the alias → the screen closes and the icon is gone. Nothing throws, which is exactly why the reports came with no logs.

Because what the user sees next is up to their launcher (icon silently vanishes, or stays cached and errors on tap), it presents as device-specific. And it only affects people who open the app from the icon at all, rather than through the gear in TTS settings — hence "some users, some devices".

This has now been reproduced end to end on an emulator; see **Testing** below.

## Fix

Ship the alias `android:enabled="false"` and only ever *enable* it, on watches.

A phone is then already in the desired state and needs no `PackageManager` write, so the destructive path stops existing rather than being worked around. Enabling is additive and never closes an activity, so the Wear path is safe by construction. Behaviour on phones is unchanged by design — the settings UI is still reached through `CONFIGURE_ENGINE`.

A `@bool/` with a `values-watch` override cannot replace the runtime toggle, which is why this was done at runtime originally: `PackageManager` parses `android:enabled` against a configuration with no UI mode, so it always resolves to the default. That finding is preserved in the code comment.

`syncWearLauncherState()` is also now guarded and off the startup thread. It runs from `Application.onCreate()`, which `TtsService` shares (no `android:process` anywhere in the manifest), so it executes whenever the TTS framework binds the engine — at boot, or the first time a screen reader speaks. Changing component state can be refused by device policy on managed profiles and some vendor ROMs, and an escaping exception there would take the engine down before it ever reached `onSynthesizeText()`.

## Testing

Reproduced and verified on emulators: a Pixel 6 AVD (API 34, `google_apis`, `x86_64`) and a Wear OS 5 AVD (API 34, `android-wear`, `x86_64`). "Pre-fix" is a build of the parent commit, whose `EspeakApp` is byte-identical to the one on the `google-play` branch that testers run.

| # | Scenario | Result |
|---|---|---|
| 1 | Pre-fix, launch via the icon | **Bug reproduced** — UI displayed, then closed itself |
| 2 | Pre-fix, alias state after first launch | Flips to `explicit DISABLED`, icon removed |
| 3 | Post-fix, clean install on a phone | Stays at manifest default — **no `PackageManager` write at all** |
| 4 | Post-fix, settings via `CONFIGURE_ENGINE` | Opens and stays focused through +7s |
| 5 | Pre-fix → post-fix upgrade, phone | `DISABLED` override persists; icon stays gone |
| 6 | Pre-fix → post-fix upgrade, watch | `ENABLED` override persists; icon kept, survives a cold start |
| 7 | Post-fix, clean install on a watch | Alias → `explicit ENABLED`, icon appears ~1s after first start |

Row 1, the reproduction:

```
t=+0s  alias=manifest default | LAUNCHER-VISIBLE | settings=ALIVE
t=+1s  alias=explicit DISABLED | launcher-absent | settings=ALIVE
       focus = com.reecedunn.espeak/.WearLauncher      <- UI up and focused
t=+2s  alias=explicit DISABLED | launcher-absent | settings=gone
       focus = nexuslauncher                           <- back to home screen
```

with the mechanism visible in logcat:

```
18:13:57.733  ActivityTaskManager: Displayed com.reecedunn.espeak/.WearLauncher: +485ms
18:13:58.466  Transition requested: type = CLOSE, triggerTask = .../.WearLauncher
18:13:58.558  ModelWriter: removing items from db. Reason: [removed because the
              corresponding package or component is removed.
              removedComponents=[{com.reecedunn.espeak/...WearLauncher}]]
```

No `FATAL`, no `AndroidRuntime`, no ANR anywhere in the log — the app displays its UI for roughly half a second, closes its own task, and the launcher deletes the icon from its database. That silence is why the reports arrived without stack traces.

What is **not** covered: real hardware, and the device-policy / vendor-ROM paths that the `catch (RuntimeException)` exists for. The instrumentation suite does not touch launcher-alias state.

## Upgrade behaviour

Verified in both directions (rows 5 and 6). Phones that ran the old build carry an explicit `DISABLED` override, which matches the new manifest default and persists across the upgrade — so the icon stays gone and the bug is no longer reachable. Watches that ran it carry an explicit `ENABLED` override, keep their icon through the upgrade, and keep it across a cold start.

## Trade-off

On a **fresh watch install** the icon appears only once the process has run once, because the runtime enable is what creates it. Measured on the Wear OS 5 emulator: nothing started the process on its own in the 10s after install, and the icon appeared about a second after the first `am start`. The pre-fix build showed it immediately on install.

I previously described this as immediate in practice; the measurement does not support that, so it is tracked separately rather than glossed. Impact is low and self-correcting — the process starts during engine setup, at boot, or on first speech, and selecting the engine does not require the process to be running. Making it fully declarative would mean a `wear` product flavour and a second APK, which is the officially sanctioned route but a much larger change.

## Also

`android/CLAUDE.md` is corrected — it still described `eSpeakActivity` as the launcher (dropped in April), listed stale class counts, and omitted `USE_LIBSONIC` from the native build flags. It now documents the launcher/Wear rule so the alias does not get flipped back to `enabled="true"`.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
