### PR TITLE
Android: build the TTS settings screen off the main thread

### DIFF
--- a/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
+++ b/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
@@ -18,12 +18,15 @@
 
 package com.reecedunn.espeak;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.util.Log;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.ListPreference;
 import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
@@ -293,7 +296,11 @@ public class TtsSettingsActivity extends PreferenceActivity {
         return info;
     }
 
-    private static void ensureLangInfoLoaded() {
+    // Synchronized because createPreferences() warms this from a worker thread
+    // while lookupLangInfo() may reach it from the main thread. Readers always
+    // come through here first, so they block until a build in progress
+    // finishes rather than observing a half-populated map.
+    private static synchronized void ensureLangInfoLoaded() {
         if (!sLangInfo.isEmpty() || storageContext == null) return;
         File root = new File(CheckVoiceData.getDataPath(storageContext), "lang");
         if (!root.exists()) return;
@@ -343,16 +350,80 @@ public class TtsSettingsActivity extends PreferenceActivity {
     }
 
     /**
+     * Gathers what the preference screen needs from the engine, then builds it.
+     *
+     * All of the expensive part used to run inline in onCreate(): constructing
+     * SpeechSynthesis initialises the native library (nativeCreate loads
+     * phondata and the dictionaries), getAvailableVoices() enumerates every
+     * voice over JNI, and building the supported-languages list walks the whole
+     * lang/ tree opening and parsing one file per voice. That is seconds of
+     * disk and JNI work on a cold start with a slow filesystem, on the thread
+     * that has to stay responsive -- the ANR risk reported in #2430.
+     *
+     * So it is gathered on a worker thread and the preferences are added when
+     * it lands. The Preference objects themselves are still built on the main
+     * thread, which is required: they bind to the hosting PreferenceGroup.
+     */
+    private static void createPreferences(final Context context, final PreferenceGroup group) {
+        final Context storage = storageContext;
+        final Handler handler = new Handler(Looper.getMainLooper());
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                final boolean isWatch = context.getPackageManager()
+                        .hasSystemFeature(PackageManager.FEATURE_WATCH);
+
+                final SpeechSynthesis engine = new SpeechSynthesis(storage, null);
+                final List<Voice> voices = engine.getAvailableVoices();
+
+                // Warm the lang/ metadata cache here rather than leaving it to
+                // the first getVoiceLabel() call, which would drag the whole
+                // scan back onto the main thread. Skipped on Wear, where the
+                // supported-languages list is not built at all.
+                if (!isWatch) {
+                    ensureLangInfoLoaded();
+                }
+
+                handler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (isGone(context)) {
+                            return;
+                        }
+                        addPreferences(context, group, engine, voices, isWatch);
+                    }
+                });
+            }
+        }, "espeak-settings-load").start();
+    }
+
+    /**
+     * True once the hosting activity can no longer accept preference updates.
+     * The load outlives a screen the user backed straight out of, and adding
+     * preferences to a dead activity's group would leak it.
+     */
+    private static boolean isGone(Context context) {
+        if (!(context instanceof Activity)) {
+            return false;
+        }
+        final Activity activity = (Activity) context;
+        if (activity.isFinishing()) {
+            return true;
+        }
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1
+                && activity.isDestroyed();
+    }
+
+    /**
      * Since the "%s" summary is currently broken, this sets the preference
      * change listener for all {@link ListPreference} views to fill in the
      * summary with the current entry value.
      */
-    private static void createPreferences(Context context, PreferenceGroup group) {
-        SpeechSynthesis engine = new SpeechSynthesis(storageContext, null);
+    private static void addPreferences(Context context, PreferenceGroup group,
+                                       SpeechSynthesis engine, List<Voice> voices,
+                                       boolean isWatch) {
         VoiceSettings settings = new VoiceSettings(PreferenceManager.getDefaultSharedPreferences(storageContext), engine);
-        final List<Voice> voices = engine.getAvailableVoices();
-
-        boolean isWatch = context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WATCH);
 
         // The supported-languages multi-select and the file-picker-driven
         // voice import don't fit on a watch screen and have no meaningful


### PR DESCRIPTION
Addresses #2430.

## Problem

`TtsSettingsActivity.createPreferences()` ran all of its engine work inline in `onCreate()`:

- `new SpeechSynthesis(...)` initialises the native library — `nativeCreate` loads `phondata` and the dictionaries
- `getAvailableVoices()` enumerates every voice over JNI, then builds a `Locale` per voice
- building the supported-languages list calls `getVoiceLabel()` per voice, which reaches `ensureLangInfoLoaded()` — a recursive walk of the whole `lang/` tree that opens and parses one file per voice (148 files on a current build)

All of it on the thread that has to stay responsive.

Note this is broader than the report in #2430, which flags `CheckVoiceData.onCreate()` calling `hasBaseResources()` — six `File.exists()` calls. The heavier path is in the settings screen.

## Fix

Gather the engine data on a worker thread and add the preferences when it lands. The `Preference` objects themselves are still built on the main thread, which is required — they bind to the hosting `PreferenceGroup`.

`ensureLangInfoLoaded()` becomes `synchronized`. It is now warmed from the worker thread while `lookupLangInfo()` can still reach it from the main thread; readers enter through it, so they block on a build in progress rather than observing a half-populated map.

A guard drops the result if the hosting activity is finishing or destroyed, so a screen the user backed straight out of does not get preferences added to a dead group.

No new `hasBaseResources()` guard was added: `SpeechSynthesis.attemptInit()` already performs that check before `nativeCreate`, so the missing-data path was never unguarded — moving the work off the main thread is the whole fix.

## Testing

Pixel 6 AVD (API 34, `google_apis`, `x86_64`) and Wear OS 5 AVD (API 34), both with voice data extracted (131 data entries, 148 `lang/` files).

Cold start of the settings screen, `am start -W`, three runs each:

| Build | TotalTime | Median |
|---|---|---|
| Before | 480 / 426 / 434 ms | **434 ms** |
| After | 350 / 319 / 327 ms | **327 ms** |

The absolute numbers are small on emulated desktop hardware — this is not a build that was reliably ANR-ing. The point is that disk and JNI work no longer sits on the main thread, where its cost scales with filesystem speed and voice count.

Also verified:

- **Preferences still populate.** All seven render with real values — `Supported languages` reading "139 of 141 languages reported to Android", `Speech rate` at "175 WPM", `Voice variant` at "Male (Default)".
- **Wear path intact.** On the watch the screen correctly shows only `Voice variant`, `Speak punctuation`, `Speech rate`, `Pitch`, `Pitch variation`, `Volume` — `Supported languages` and `Import eSpeak dictionary` stay omitted, and the `lang/` scan is skipped entirely. 303 ms, no crashes.
- **Destroy race.** Launch-then-immediate-back, 8 iterations: zero `FATAL EXCEPTION` and zero ANRs.

Not covered: real hardware, and the pre-Honeycomb `addPreferencesFromResource` path in `onCreate()` (`minSdk` is 21, so that branch is dead in practice but was left alone).

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
