### PR TITLE
Add diff-gated clang-tidy CI check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+---
+# Checks run against changed lines only (see .github/workflows/lint.yml,
+# which drives this through clang-tidy-diff.py). Existing code is never
+# required to pass this config; only new/changed lines are linted, so the
+# set below is deliberately small and high-signal to avoid blocking
+# unrelated changes with pre-existing legacy-code noise.
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.*,
+  -clang-analyzer-security.ArrayBound,
+  readability-isolate-declaration,
+  readability-else-after-return,
+  readability-redundant-declaration,
+  misc-redundant-expression
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'src/(libespeak-ng|include)/.*'
+FormatStyle: none

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     - name: apt-deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y ronn kramdown python3 clang-tidy-21
+        sudo apt-get install -y ronn kramdown python3 clang-tidy
 
     - uses: actions/checkout@v7
       with:
@@ -28,9 +28,8 @@ jobs:
     - name: clang-tidy-diff
       run: |
         git diff -U0 "origin/${{ github.base_ref }}...HEAD" -- 'src/libespeak-ng/*.c' 'src/libespeak-ng/*.h' \
-          | python3 /usr/lib/llvm-21/share/clang/clang-tidy-diff.py \
-              -clang-tidy-binary clang-tidy-21 \
+          | clang-tidy-diff \
+              -clang-tidy-binary clang-tidy \
               -path build \
-              -config-file .clang-tidy \
               -j "$(nproc)" \
               -p1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  clang-tidy-diff:
+    runs-on: ubuntu-22.04
+    name: clang-tidy (changed lines)
+
+    steps:
+    - name: apt-deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ronn kramdown python3 clang-tidy-21
+
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: configure
+      run: cmake -Bbuild -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_ASYNC:BOOL=OFF
+
+    - name: make-data
+      run: cmake --build build --target data
+
+    - name: clang-tidy-diff
+      run: |
+        git diff -U0 "origin/${{ github.base_ref }}...HEAD" -- 'src/libespeak-ng/*.c' 'src/libespeak-ng/*.h' \
+          | python3 /usr/lib/llvm-21/share/clang/clang-tidy-diff.py \
+              -clang-tidy-binary clang-tidy-21 \
+              -path build \
+              -config-file .clang-tidy \
+              -j "$(nproc)" \
+              -p1


### PR DESCRIPTION
Adds a `clang-tidy` CI job that lints only the lines changed in a PR (via `clang-tidy-diff.py`), so it catches new bugs and code-quality regressions without requiring the existing ~32K lines of legacy C to pass first.

Related to #64 (whole-codebase `scan-build`) and #9 (declare-at-first-use) — this is a smaller, immediately-mergeable step: it can't retroactively fix existing code, but it stops new PRs from adding more of the same debt, and `readability-isolate-declaration` directly helps with #9 going forward.

Checks: `bugprone-*`, `clang-analyzer-*` (excluding `insecureAPI` and `ArrayBound`, which produced false positives on this codebase's bounded `strcpy`/`strncat` calls and the `PHONEME_LIST` pointer-walk idiom — verified by re-enabling them against real merged diffs), plus a few `readability-*`/`misc-*` checks.

Verified locally against 3 recent merged diffs — clean with this config, confirmed the excluded checks are the reason (they trip on the same diffs when re-enabled).