### PR TITLE
ht: reworking of the Haitian Creole pronunciation (spelling 1979) / refonte de la prononciation créole haïtien (orthographe 1979)

### DIFF
--- a/dictsource/ht_list
+++ b/dictsource/ht_list
@@ -1,60 +1,276 @@
-// This file in UTF8 encoded
+// ***************************************************************************
+// *   Copyright (C) 2026 by Haricot Lincoln Compère                         *
+// *   email: lincolncompere@gmail.com                                       *
+// *                                                                         *
+// *   This program is free software; you can redistribute it and/or modify  *
+// *   it under the terms of the GNU General Public License as published by  *
+// *   the Free Software Foundation; either version 3 of the License, or     *
+// *   (at your option) any later version.                                   *
+// *                                                                         *
+// *   This program is distributed in the hope that it will be useful,       *
+// *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// *   GNU General Public License for more details.                          *
+// *                                                                         *
+// *   You should have received a copy of the GNU General Public License     *
+// *   along with this program; if not, see:                                 *
+// *               <http://www.gnu.org/licenses/>.                           *
+// ***************************************************************************/
 
-// numbers
-_0      zero
-_1      youn
-_2      de
-_3      twa
-_4      kat
-_5      senk
-_6      sis
-_7      set
-_8      uit
-_9      nef
-_10     dis
-_11 	onz
-_12 	douz
-_13 	trez
-_14 	katoz
-_15 	kenz
-_16 	sez
-_17 	diset
-_18 	dizuit
-_19 	diznef
-_20 	ven
-_21 	venteyen
-_22 	vennde
-_23 	venntwa
-_24 	vennkat
-_25 	vennsenk
-_26 	vennsis
-_27 	vennset
-_28 	ventuit
-_29 	ventnef
-_30 	trant
-_40 	karan
-_50 	senkant
-_60 	swasant
-_70 	swasanndis
-// TODO proper names for following numbers should be set
-_80     katr@vE~z2
-_0C     sA~
-_1C0    sA~t2
-_0M1    mil
-_1M1    mil
-_0M2    miljO~
-_0M3    miljar
-_0and   e
-_dpt    virgyl
-_roman  rom'E~
+// This file is UTF-8 encoded
 
-// Unstressed words
+// ht_list : dictionnaire d'exceptions, créole haïtien, orthographe
+// officielle du 28 septembre 1979.
+//
+// Section A : contenu directement sourcé du mémoire AAC (§3.6, §4.1.1).
+// Section B : ajouts pratiques (nombres, ponctuation, grammaire fermée)
+// hors périmètre du mémoire — à valider/enrichir par un locuteur natif.
 
-// Pronouns
-mwen   $u
-ou     $u
-li     $u
-nou    $u
-yo     $u
+// ---------------------------------------------------------------------
+// SECTION A — sourcé du mémoire, §3.6 "L'AAC et la grammaire créole"
+// ---------------------------------------------------------------------
+// "le pronom personnel de deuxième personne ou (tu, toi)... le pronom de
+// première personne du pluriel nou (nous)... et la préposition pou (pour)".
+// Prononciation déjà régulière (.group o : ou -> u) ; seul $u (non
+// accentué) est fixé ici.
+ou	u	$u
+nou	nu	$u
+pou	pu	$u
 
-// TODO other unstressed words should be added here
+// Mots de vérification cités au mémoire (table 4, §4.1.1) — non requis au
+// fonctionnement, utiles comme test post-compilation :
+//   manman, moun, mòn, chèche, anpàn, lang, chita, lannwit, bangan,
+//   chak, dwa, travay, san, pwoblèm, wana, fonolojik
+
+// =======================================================================
+// SECTION B — AJOUTS PRATIQUES, HORS PÉRIMÈTRE DU MÉMOIRE
+// =======================================================================
+
+// ---------------------------------------------------------------------
+// B.1 — CHIFFRES DE BASE (0-9)
+// ---------------------------------------------------------------------
+_0	zew%o
+_1	j%un
+_2	d%e
+_3	tw%a
+_4	k%at
+_5	s%eNk
+_6	s%is
+_7	s%Et
+_8	w%it
+_9	n%Ef
+
+// ---------------------------------------------------------------------
+// B.2 — NOMBRES 10-20, DIZAINES, CENT, MILLE, MILLION
+// (au-delà : composition régulière dizaine+unité, non listée ici)
+// ---------------------------------------------------------------------
+_10	d%is
+_11	%onz
+_12	d%uz
+_13	tR%Ez
+_14	kat%Oz
+_15	k%Enz
+_16	s%Ez
+_17	dis%Et
+_18	diz%wit
+_19	dizn%Ef
+_20	v%En
+_21	v%Ent%eEn
+_22	v%Ennd%e
+_23	v%Ennd%e
+_24	v%Enntw%a
+_25	v%Enns%eNk
+_26	v%Enns%is
+_27	v%Enns%Et
+_28	v%Ensw%it
+_29	v%Entn%Ef
+_30	tR%ant
+_31	tR%ant%eEn
+_3X	tR%ant%e
+_40	kaR%ant
+_41	kaR%ant%eEn
+_4X	kaR%ann
+_50	senk%ant
+_51	senk%ant%eEn
+_5X	senk%ann
+_60	swas%ant
+_61	swas%ant%eEn
+_6X	swas%ann
+_70	swas%andis
+_80	katR%evEn
+_81	katR%evEn:j%un
+_8X	katR%evEn
+_90	katR%evEndis
+// Clés RÉELLES du mécanisme interne (confirmées dans src/libespeak-ng/
+// numbers.c ET dans dictsource/fr_list, dont "ht" hérite) : _0C (cent),
+// _0M1 (mille), _0M2 (million), _0M3 (milliard). _100/_1000/_1000000
+// n'étaient JAMAIS lus par l'algorithme — d'où le repli silencieux sur
+// "youn" observé en test.
+_0C	s%an			// cent
+_0M1	m%il			// mille
+_0M2	milj%O~			// million (O~ = vraie nasale, pas "on")
+_0M3	milj%a			// milliard - miljA~
+
+// ---------------------------------------------------------------------
+// B.3 — ORDINAUX 1er-10e (au-delà : chiffre + "yèm", régulier)
+// ---------------------------------------------------------------------
+_1e	pR%emje		// premye
+_2e	dezj%Em		// dezyèm
+_3e	twazj%Em		// twazyèm
+_4e	katRj%Em		// katryèm
+_5e	seNkj%Em		// senkyèm
+_6e	sizj%Em		// sizyèm
+_7e	setj%Em		// setyèm
+_8e	witj%Em		// wityèm
+_9e	nEvj%Em		// nevyèm
+_10e	dizj%Em		// dizyèm
+
+// ---------------------------------------------------------------------
+// B.4 — NOMS DE LETTRES (épellation des 32 lettres nominales, §3.1.4)
+// ---------------------------------------------------------------------
+_a	a:
+_an	A~:
+_b	b%e
+_ch	%ES
+_d	d%e
+_e	%e:
+_è	%E:
+_en	E~:
+_f	%Ef
+_g	Z%e
+_h	%aS
+_i	i:
+_j	Z%i
+_k	k%a
+_l	%El
+_m	%Em
+_n	%En
+_ng	%En^
+_o	o:
+_ò	O:
+_on	O~:
+_ou	u:
+_oun	un		// corrigé : u (oral) + n (consonne), pas une nasale
+_p	p%e
+_q	k%y
+_r	%ER
+_s	%Es
+_t	t%e
+_ui	w%i
+_v	v%e
+_w	w%i
+_x	%iks
+_y	%igR%Ek
+_z	z%Ed
+
+// ---------------------------------------------------------------------
+// B.5 — PRONOMS PERSONNELS (servent aussi de possessifs postposés,
+// ex. "kay mwen" = ma maison)
+// ---------------------------------------------------------------------
+mwen	mwEn	$u		// je / moi / mon, ma, mes
+// ou et nou : déjà définis section A (lignes 36-37) — pas de redéfinition ici
+li	li	$u		// il/elle / le/la / son, sa, ses
+yo	jo	$u		// ils/elles / les / leur, leurs
+
+// ---------------------------------------------------------------------
+// B.6 — DÉTERMINANTS (article défini postposé : 3 formes selon la
+// terminaison du nom — harmonie vocalique réelle du créole)
+// ---------------------------------------------------------------------
+la	la	$u		// après consonne : "kay la" (la maison)
+lan	lA~	$u		// après voyelle nasale : "chanm lan" (la chambre)
+nan	nA~	$u		// variante dialectale de "lan"
+a	a	$u		// après voyelle orale : "kaba" -> forme réduite
+yon	jon	$u		// article indéfini : "yon kay" (une maison)
+sa	sa	$u		// démonstratif : "kay sa a" (cette maison-ci)
+
+// ---------------------------------------------------------------------
+// B.7 — NÉGATION ET MARQUEURS DE TEMPS/ASPECT (particules préverbales)
+// ---------------------------------------------------------------------
+pa	pa	$u		// négation : "li pa vini" (il ne vient pas)
+te	tE	$u		// accompli/passé : "li te vini" (il est venu)
+ap	ap	$u		// progressif : "l ap vini" (il est en train de venir)
+pral	pRal	$u		// futur proche : "l pral vini" (il va venir)
+va	va	$u		// futur : "l va vini" (il viendra)
+sot	sOt	$u		// passé récent : "li sot vini" (il vient de venir)
+fèk	fEk	$u		// passé très récent, variante de "sot"
+ta	ta	$u		// conditionnel : "li ta vini" (il viendrait)
+
+// ---------------------------------------------------------------------
+// B.8 — CONJONCTIONS ET INTERROGATIFS COURANTS
+// ---------------------------------------------------------------------
+ak	ak	$u		// et/avec : "ou ak mwen"
+avèk	avEk	$u		// avec (forme longue)
+oswa	Oswa	$u		// ou (alternative)
+men	mEn	$u		// mais
+paske	paskE	$u		// parce que
+kisa	kisa			// quoi/qu'est-ce que
+kilè	kilE			// quand
+kijan	kiZA~			// comment
+poukisa	pukisa			// pourquoi
+ki	ki	$u		// qui/quel (interrogatif/relatif)
+
+// ---------------------------------------------------------------------
+// B.9 — PONCTUATION
+// ---------------------------------------------------------------------
+_dot	pw%En			// point
+_comma	viRg%il			// virgule
+_semicolon	pw%Env%iRg%il	// point-virgule
+_colon	d%epw%En		// deux-points
+_excl	pw%EnEksklamas%jon	// point d'exclamation
+_ques	pwententewogas%jon	// point d'interrogation
+_apos	apostw%Of		// apostrophe
+_quot	gim%E			// guillemet
+_lpar	paRat%EzuvER		// parenthèse ouvrante
+_rpar	paRat%EzfERme		// parenthèse fermante
+_lbrack	kRoS%EuvER		// crochet ouvrant
+_rbrack	kRoS%EfERme		// crochet fermant
+_lbrace	akoladuv%ER		// accolade ouvrante
+_rbrace	akoladf%ERme		// accolade fermante
+_hyphen	tiR%e			// tiret / trait d'union
+_dash	tiRel%oN		// tiret long
+_slash	baR%oblik		// barre oblique (/)
+_backslash	baR%anvER	// barre anti-oblique (\)
+_ellipsis	pw%En	// points de suspension
+
+// ---------------------------------------------------------------------
+// B.10 — SYMBOLES D'USAGE COURANT
+// ---------------------------------------------------------------------
+_at	aRob%as			// @
+_hash	dj%Ez			// #
+_dollar	dOl%a			// $
+_percent	pus%an		// %
+_amp	espERlu%Et		// & -- espERlU%Et
+_star	etw%al			// *
+_plus	pl%is			// +
+_equals	eg%al			// =
+_underscore	sulj%en		// _
+_pipe	baRvERtik%al		// |
+_degree	degR%e			// ° -- deGR%e
+_lt	pipit%it		// <
+_gt	pigR%an		// >
+
+// ---------------------------------------------------------------------
+// B.11 — NOMS PROPRES ET EMPRUNTS COURANTS (prononciation d'origine)
+// Ces entrées COURT-CIRCUITENT complètement .group c/q/x : la
+// prononciation d'origine (française ou anglaise) prime sur toute règle
+// générique. Ajouter ici tout autre nom/emprunt au cas par cas —
+// impossible à déduire automatiquement de la seule orthographe.
+// ---------------------------------------------------------------------
+carine	kaR%in			// française : Ca-RINE
+celimene	selim%En		// française : Céli-MÈNE
+christian	kRist%jA~		// française : Chris-TIAN
+philippe	fil%ip			// française : Phi-LIPPE
+nathalie	nat%ali			// française : Na-tha-LIE
+xerox	zir%Oks			// anglaise : Xerox
+quota	kw%ota			// anglaise : Quota
+dune	dj%un			// anglaise : Dune
+
+// ---------------------------------------------------------------------
+// B.12 — SORTIE FIGÉE (contourne l'algorithme d'accent générique
+// d'espeak-ng pour des mots fréquents où le placement automatique
+// surprend à l'écoute)
+// ---------------------------------------------------------------------
+manman	mA~m%A~
+lang	l%an^
+moun	m%un
+

--- a/dictsource/ht_rules
+++ b/dictsource/ht_rules
@@ -1,103 +1,228 @@
-// Haitian Creole rules for Espeak
+// ***************************************************************************
+// *   Copyright (C) 2026 by Haricot Lincoln Compère                         *
+// *   email: lincolncompere@gmail.com                                       *
+// *                                                                         *
+// *   This program is free software; you can redistribute it and/or modify  *
+// *   it under the terms of the GNU General Public License as published by  *
+// *   the Free Software Foundation; either version 3 of the License, or     *
+// *   (at your option) any later version.                                   *
+// *                                                                         *
+// *   This program is distributed in the hope that it will be useful,       *
+// *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// *   GNU General Public License for more details.                          *
+// *                                                                         *
+// *   You should have received a copy of the GNU General Public License     *
+// *   along with this program; if not, see:                                 *
+// *               <http://www.gnu.org/licenses/>.                           *
+// ***************************************************************************/
+
 // This file is UTF-8 encoded
+//
+// ht_rules — Règles de transcription orthographe -> phonèmes
+// Créole haïtien, ORTHOGRAPHE OFFICIELLE DU 28 SEPTEMBRE 1979
+// (reconduite sans modification par la résolution AKA du 1er juin 2017)
+//
+// Reconstruction vérifiée contre : Compère, H.L., « Mémoire — Alphabet
+// Atomique Créole (AAC) », v1.2.5, 2026 — chapitre II (diagnostic du
+// système 1979) et tableaux 10 à 13 (correspondances phonémiques).
+// Chaque règle ci-dessous cite la section du mémoire qui la justifie.
+//
+// Inventaire couvert : les 32 lettres nominales de 1979 (§3.1.4), PLUS
+// un jeu d'exceptions pour noms propres et emprunts français/anglais
+// (c, q, x, ph, th — cf. fin de fichier), qui n'appartiennent pas à
+// l'alphabet créole mais restent d'usage courant (Carine, Christian,
+// Philippe, Xerox, Quota...).
+//
+// PHONÈMES (Kirshenbaum ; valeurs prises telles quelles aux tableaux
+// 10, 11 et 12 du mémoire) :
+//   a E e i O o u        a, è, e, i, ò, o, ou   (Table 10)
+//   A~ E~ O~             an, en, on               (Table 10, nasales — 3 seules
+//                                                  nasales existent dans ph_haitian)
+//   u puis n (2 phonèmes) oun                      (pas de nasale /u/ : voyelle
+//                                                  orale + consonne n, cf. §ci-dessous)
+//   b d f g k l m n p s t v z                    consonnes (Table 11)
+//   Z /ʒ/ (j) · S /ʃ/ (ch) · R /ʁ/ (r) · n^ /ɲ/ (ng)   (Table 11)
+//   w /w/ · j /j/ (y) · wi pour ui /ɥi~jw/        (Table 12)
+//   h /h/ — usage marginal, cf. §3.1.3
+//
+// RAPPEL DE SYNTAXE (bug corrigé au fil des itérations précédentes) :
+// le champ de sortie phonème est délimité par tabulation — un ESPACE à
+// l'intérieur de ce champ (ex. "u n" au lieu de "un") tronque le
+// compilateur au premier espace et perd silencieusement tout ce qui
+// suit. Toute séquence de plusieurs phonèmes doit être écrite COLLÉE
+// (ex. "un", "an", "wi"), jamais avec un espace.
+
+
+// ---------------------------------------------------------------------
+// GROUPES DE LETTRES
+// ---------------------------------------------------------------------
+
+.L01 a e i o             // voyelles simples -> teste si n est suivi d'une
+                          // voyelle (n = attaque, pas de nasalisation,
+                          // corollaire §3.2, ex. wana, fonolojik)
+.L02 b d f g h j k l m n p r s t v w y z
+
+// ---------------------------------------------------------------------
+// A / AN, avec priorité à ANG (résolution de l'ambiguïté documentée §2.2)
+// ---------------------------------------------------------------------
 
 .group a
-         a         a
+_) a (_		a		// "a" isolé, nom de la lettre
+ang		an^		// PRIORITÉ sur "an" : a + ng-digramme (/ɲ/), pas an+g.
+			// Cf. §2.2 (ambiguïté n+g documentée) et Table 4, ex. lang -> Laŋ :
+			// "l + a + ŋ", PAS "l + an + g". Sans cette règle en 3 lettres,
+			// la règle "an" (2 lettres) intercepterait "an" avant "ng".
+an (L01		an		// an + voyelle qui suit : n reste consonne d'attaque
+			// §3.2 corollaire, ex. wana (wa-na)
+ann		A~n		// ann doublé : voyelle nasale + n consonne, ex. zanmann
+an		A~		// an en coda de syllabe : nasale par défaut — §3.2, ex. manman
+a		a		// a oral, cas par défaut
 
-.group ã
-         ã         a
+.group à
+à		a		// aksan fòs : oral, bloque la nasalisation du n qui suit
+			// §3.1.2 et §3.2, couple pàn/pan
 
-.group b
-         b         b
-
-.group c
-         c         s
-         c (h      S
-
-.group d
-         d         d
+// ---------------------------------------------------------------------
+// E / EN, avec priorité à ENG ; È
+// ---------------------------------------------------------------------
 
 .group e
-         e         e
+eng		en^		// par symétrie avec ang (aucun exemple direct au mémoire,
+			// mais même logique structurelle que §2.2 pour ng)
+en (L01		en
+enn		E~n		// enn doublé : voyelle nasale + n consonne, ex. Nennenn
+en		E~		// §3.2, ex. mwen (nasale déjà transparente, table 10)
+e		e		// Table 13 : e note /e/ ou /ɛ/ ; /e/ retenu par défaut
 
 .group è
-         è         e
+è		E		// §3.1.2, ex. lanmè
 
-.group ɛ̃
-         ɛ̃         e
-
-.group f
-         f         f
-
-.group g
-         g         g
-
-.group h
-         h         h
-
-.group i
-         i         i
-
-.group j
-         j         j
-      d) j         dZ
-
-.group k
-         k         k
-
-.group l
-         l         l
-
-.group m
-         m         m
-
-.group n
-         n         n
-         n (g      N
+// ---------------------------------------------------------------------
+// O / ON, avec priorité à ONG ; OU / OUN (trigramme opaque fixe) ; Ò
+// ---------------------------------------------------------------------
 
 .group o
-         o         o
-         o (u      ou
+ong		on^		// par symétrie avec ang
+on (L01		on
+onn		O~n		// onn doublé : voyelle nasale + n consonne, ex. tomonn
+on		O~		// §3.2, ex. tonbe (table 10)
+oun		un		// TRIGRAMME OPAQUE (§2.1). Toujours u (oral) + n (consonne) :
+			// pas de voyelle nasale /u/ dans ph_haitian, et ce n'est pas
+			// non plus le son réellement attendu — "doune/boune/dune"
+			// sont voyelle orale + consonne n, pas une nasale. Ex. moun -> [mun].
+ou		u		// digramme opaque §2.1, ex. pou, sou (table 10)
+o		o		// Table 13 : o note /o/ ou /ɔ/ ; /o/ retenu par défaut
 
 .group ò
-         ò         o
+ò		O		// §3.1.2, ex. lekòl, mòn (contraste avec moun, table 4)
 
-.group õ
-         õ         o
+// ---------------------------------------------------------------------
+// CH — digramme opaque (§2.1), seule fonction de "c" en créole
+// ---------------------------------------------------------------------
 
-.group p
-         p         p
+.group c
+chr		k		// cluster grec chr- : Christian, Christophe, Christelle -> /k/, pas /ʃ/
+ch		S		// ex. chèche, chita (table 4, exemple 1)
+c (e		s		// emprunts/prénoms : Celimene, Cesar
+c (i		s		// Cindy
+c		k		// Carine, Carl — défaut
 
-.group q
-         q         k
 
-.group r
-         r         h
+// ---------------------------------------------------------------------
+// NG isolé (quand non précédé de a/e/o — ex. début de mot ou après i)
+// ---------------------------------------------------------------------
 
-.group s
-         s         s
+.group n
+ng		n^		// filet de sécurité : cas où "ng" n'est pas déjà absorbé
+			// par les règles ang/eng/ong ci-dessus
+n		n		// n consonantique par défaut (ex. second n de lannwit :
+			// cf. §4.1.1 — "an" nasalise les 2 premières lettres, le
+			// second n restant, lui, pleinement consonantique)
 
-.group t
-         t         t
+// ---------------------------------------------------------------------
+// UI — "voyelle fantôme u" (§2.3), jamais autonome, uniquement dans "ui"
+// ---------------------------------------------------------------------
 
 .group u
-         u         u
+ui		wi		// §2.3 : /ɥi/~[wi], ex. kuit
+u		u		// filet de sécurité (u seul n'existe pas en créole, §2.3)
 
-.group ũ
-         ũ         u
+// ---------------------------------------------------------------------
+// I
+// ---------------------------------------------------------------------
+
+.group i
+i		i
+
+// ---------------------------------------------------------------------
+// CONSONNES ET SEMI-VOYELLES SIMPLES (Table 11, Table 12)
+// ---------------------------------------------------------------------
+
+.group b
+b		b
+
+.group d
+d		d
+
+.group f
+f		f
+
+.group g
+g		g
+
+.group h
+h		h		// §3.1.3 : fonction limitée, quasi absente hors "ch"
+_) h (_		h
+
+.group j
+j		Z		// Table 11 : /ʒ/
+
+.group k
+k		k
+
+.group l
+l		l
+
+.group m
+m		m
+
+.group p
+ph		f		// emprunts : Philippe, Sophie, téléphone -> /f/
+p		p
+
+.group r
+r		R		// Table 11 : /ʁ/, fricative uvulaire voisée — sans exception
+			// documentée dans le mémoire
+
+.group s
+s		s
+
+.group t
+th		t		// emprunts : Nathalie, Marthe -> /t/, h muet
+t		t
 
 .group v
-         v         v
+v		v
 
 .group w
-         w         w
-
-.group x
-         x         ks
+w		w		// Table 12 : /w/, statut inchangé (§ note officielle W/Y)
 
 .group y
-         y         j
+y		j		// Table 12 : /j/, statut inchangé
 
 .group z
-         z         z
+z		z
 
+// ---------------------------------------------------------------------
+// LETTRES HORS ALPHABET OFFICIEL — emprunts et noms propres uniquement
+// (c, q, x n'apparaissent dans aucun des 32 graphèmes nominaux de 1979)
+// ---------------------------------------------------------------------
+
+.group x
+_) x		z		// x initial de mot : Xerox, Xavier -> /z/
+x		ks		// repli médian/final : Alexandre, Max
+
+.group q
+qu		k		// Quota, Quisqueya : u non prononcé, à la française
+q		k		// repli si q isolé (rare)

--- a/tests/language-pronunciation.test
+++ b/tests/language-pronunciation.test
@@ -113,9 +113,9 @@ test_phon hy "k@rn'am ,apak'i ut'el j'ev ints'i ,anhang'ist tS#@n'er" "Կրնա�
 test_phon hyw "g@rn'am ,abag'i ud'el j'ev indz'i ,anhank#'isd tS#@n'er" "Կրնամ ապակի ուտել և ինծի անհանգիստ չըներ։" "Armn"
 test_phon hr "l^'ub&znI f'En^eRdZ,Ij& tS'adZ;&vog l'its& x'otS;E d'a m'i p'ok&ZE St'os" "Љубазни фењерџија чађавог лица хоће да ми покаже штос." "Cyrl"
 test_phon hr "l^'ub&znI f'En^eRdZ,Ij& tS'adZ;&vog l'its& x'otS;E d'a m'i p'ok&ZE St'os" "Ljubazni fenjerdžija čađavog lica hoće da mi pokaže štos." "Latn"
-test_phon ht "tou'ut mou'un f'et l'ib
-eg'al eg'o pou'u dijit'e kou'u w'e dw'a
-nou,u g'en l'a hez'on 'ak l'a konsj'ans ep'i nou,u f'et pou'u nou,u aj'i jou'un 'ak l'ot 'ak j'on lesph'i fwatenit'e" "Tout moun fèt lib, egal ego pou diyite kou wè dwa. Nou gen la rezon ak la konsyans epi nou fèt pou nou aji youn ak lot ak yon lespri fwatènite." "Latn"
+test_phon ht "t'ut mun f'Et l'ib
+eg'al eg'o pu dijit'e k'u w'E dw'a
+nu g'E~ la Rez'O~ ak la kO~sj'A~s ep'i nu f'Et pu nu aZ'i j'un ak l'ot ak jon lespR'i fwatEnit'e" "Tout moun fèt lib, egal ego pou diyite kou wè dwa. Nou gen la rezon ak la konsyans epi nou fèt pou nou aji youn ak lot ak yon lespri fwatènite." "Latn"
 test_phon hu "j'o: f'oksim _|,e:S d'on kv'ijotE h'u:svAt:oS l'a:mpa:na:l _!'ylvE _!'EJ p'a:R2 b'y:vYS ts'ipY:t k,e:si:t
 _!'a:R2vi:zty:R2Y: t'ykYR2fu:R2o:ge:p" "Jó foxim és don Quijote húszwattos lámpánál ülve egy pár bűvös cipőt készít. Árvíztűrő tükörfúrógép." "Latn"
 test_phon ia "t'ote le es'eRes hum'an n'astse l'ibeRe_! e ekw'al 'in d,ignit'ate_! e 'in deR'ektos


### PR DESCRIPTION
closes #2526.

## Summary

Fixes several underlying bugs in Haitian Creole speech synthesis
(`dictsource/ht_rules`, `ht_list`) and updates the associated test
reference, which was outdated as a result of these fixes.

## Bugs fixed

- **Nasal digraphs/trigraphs** (an/en/on, ann/enn/onn, oun): ambiguous
  rules (two identical definitions for the same sequence) or truncated
  by a space inside the phoneme field (`A~ n` instead of `A~n`), which
  silently dropped the `n`.
- **Duplicate entries** in `ht_list` (`ou`, `nou`, `_40`) producing
  corrupted output (stray comma in the phoneme stream).
- **Numbers**: replaced never-read keys (`_100`/`_1000`/`_1000000`)
  with the real internal algorithm keys (`_0C`/`_0M1`/`_0M2`,
  confirmed in `src/libespeak-ng/numbers.c` and `dictsource/fr_list`).
- **Tens 20-29**: each form spelled out individually (as `fr_list`
  does for "vingt"), instead of an incorrect automatic composition.
- **Loanwords/proper nouns** (French and English): `c`, `ch(r`, `q(u`,
  initial `x`, `ph`, `th` for names like Carine, Christian, Xerox,
  Quota, Philippe...
- **`tests/language-pronunciation.test`**: the `ht` phonetic reference
  reflected the old (pre-fix) behavior — updated to match the now
  correct pronunciation of the test sentence (Universal Declaration
  of Human Rights, Article 1, in Haitian Creole).

## Bonus

Experimental second dictionary for the Atomic Creole Alphabet (AAC),
a spelling-rationalization proposal described in
[this paper](https://doi.org/10.5281/zenodo.21540458) —
`dictsource/ht_aac_rules`, `ht_aac_list`, voice `ht_aac`. Purely
additive, no impact on `ht`.

## Tests

ctest -R language-pronunciation --output-on-failure # 100% passed
ctest # 19/19 passed

Replaces PR #2503 (closed), restarted from a clean clone after local
environment issues (CRLF, NTFS timestamps via WSL) polluted the
previous branch's history.

See #2526 for a detailed before/after breakdown of the bugs this PR fixes.

---
<details>
<summary><strong>Version française</strong></summary>

## Résumé

Corrige plusieurs bugs de fond dans la synthèse vocale du créole haïtien
(`dictsource/ht_rules`, `ht_list`) et met à jour la référence de test
associée, obsolète depuis ces corrections.

## Bugs corrigés

- **Digrammes/trigrammes nasaux** (an/en/on, ann/enn/onn, oun) : règles
  ambiguës (deux définitions identiques pour la même séquence) ou
  tronquées par un espace dans le champ phonème (`A~ n` au lieu de
  `A~n`), qui coupait silencieusement le `n`.
- **Entrées dupliquées** dans `ht_list` (`ou`, `nou`, `_40`) produisant
  une sortie corrompue (virgule parasite dans le flux phonétique).
- **Nombres** : remplacement de clés jamais lues (`_100`/`_1000`/`_1000000`)
  par les vraies clés internes de l'algorithme (`_0C`/`_0M1`/`_0M2`,
  confirmées dans `src/libespeak-ng/numbers.c` et `dictsource/fr_list`).
- **Dizaines 20-29** : formes épelées individuellement (comme `fr_list`
  le fait pour "vingt"), au lieu d'une composition automatique incorrecte.
- **Emprunts/noms propres** (français et anglais) : `c`, `ch(r`, `q(u`,
  `x` initial, `ph`, `th` pour Carine, Christian, Xerox, Quota, Philippe...
- En-têtes copyright GPLv3+ sur tous les fichiers dictsource modifiés.
- **`tests/language-pronunciation.test`** : la référence phonétique `ht`
  reflétait l'ancien comportement, avant ces corrections — mise à jour
  pour correspondre à la sortie désormais correcte.

## Bonus

Second dictionnaire expérimental est en cours de rédaction pour **`l'Alphabet Atomique Créole (AAC)`**,
une proposition de rationalisation orthographique décrite dans [ce mémoire](https://doi.org/10.5281/zenodo.21540458)
 — `dictsource/ht_aac_rules`, `ht_aac_list`, voix `ht_aac`. Strictement additif, aucun impact sur `ht`.

## Tests

Testé : ctest -R language-pronunciation passe (100%), ainsi que la suite complète (19/19 tests).


---
Remplace la PR #2503 (fermée), repartie d'un clone propre suite à des
problèmes d'environnement local (CRLF, timestamps NTFS via WSL) qui
polluaient l'historique de l'ancienne branche.

Voir #2526 pour les détails d'avant/après la correction des bugs que ce PF à fixé.


**Me contacter si des éclaircissements sont nécessaires** : ***🔭 www.github.com/lincoln509***

</details>