### PR TITLE
fix(ar): fallback Chinese characters to Mandarin (zh) pronunciation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,7 @@ updated languages:
 *  tlh (Klingon) -- fionnlagh
 
 bug fixes:
+*  fixed Han ideographs under the Arabic voice being spelled as "Chinese letter" instead of read with the Mandarin translator -- uyt3ar
 *  numerous buffer-overflow, out-of-bounds and memory-safety hardening fixes across number, clause, dictionary, letter-lookup, Roman-numeral, klatt and mbrola code (fuzzing-driven) -- Samuel Thibault, Rudi Heitbaum, Jiami Lin, Erik Chan
 *  fixed infinite loop in rule matching with UTF-8 input -- Samuel Thibault
 *  fixed loss of final input byte from stdin -- Samuel Thibault

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -659,8 +659,7 @@ const char *GetTranslatedPhonemeString(int phoneme_mode)
 				buf = WritePhMnemonic(buf, phoneme_tab[phonSYLLABIC], plist, use_ipa, NULL);
 			}
 			if (plist->tone_ph > 0) {
-				PHONEME_TAB *tone_ph = plist->tone_ph_data != NULL
-					? plist->tone_ph_data : phoneme_tab[plist->tone_ph];
+				PHONEME_TAB *tone_ph = TonePhoneme(plist);
 				if (tone_ph != NULL)
 					buf = WritePhMnemonic(buf, tone_ph, plist, use_ipa, NULL);
 			}

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -658,8 +658,12 @@ const char *GetTranslatedPhonemeString(int phoneme_mode)
 				// syllablic consonant
 				buf = WritePhMnemonic(buf, phoneme_tab[phonSYLLABIC], plist, use_ipa, NULL);
 			}
-			if (plist->tone_ph > 0)
-				buf = WritePhMnemonic(buf, phoneme_tab[plist->tone_ph], plist, use_ipa, NULL);
+			if (plist->tone_ph > 0) {
+				PHONEME_TAB *tone_ph = plist->tone_ph_data != NULL
+					? plist->tone_ph_data : phoneme_tab[plist->tone_ph];
+				if (tone_ph != NULL)
+					buf = WritePhMnemonic(buf, tone_ph, plist, use_ipa, NULL);
+			}
 		}
 
 		len = buf - phon_buf;

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -1079,10 +1079,13 @@ void CalcPitches(Translator *tr, int clause_type)
 			}
 
 			if (p->tone_ph) {
-				ph = phoneme_tab[p->tone_ph];
-				x = (p->pitch1 + p->pitch2)/2;
-				p->pitch2 = x + ph->end_type;
-				p->pitch1 = x + ph->start_type;
+				ph = p->tone_ph_data != NULL
+					? p->tone_ph_data : phoneme_tab[p->tone_ph];
+				if (ph != NULL) {
+					x = (p->pitch1 + p->pitch2)/2;
+					p->pitch2 = x + ph->end_type;
+					p->pitch1 = x + ph->start_type;
+				}
 			}
 
 			if (syl->flags & SYL_EMPHASIS)

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -1079,8 +1079,7 @@ void CalcPitches(Translator *tr, int clause_type)
 			}
 
 			if (p->tone_ph) {
-				ph = p->tone_ph_data != NULL
-					? p->tone_ph_data : phoneme_tab[p->tone_ph];
+				ph = TonePhoneme(p);
 				if (ph != NULL) {
 					x = (p->pitch1 + p->pitch2)/2;
 					p->pitch2 = x + ph->end_type;

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -448,6 +448,9 @@ void MakePhonemeList(Translator *tr, int post_pause, bool start_sentence)
 			phlist[ix].stresslevel = plist3->stresslevel & 0xf;
 			phlist[ix].wordstress = plist3->wordstress;
 			phlist[ix].tone_ph = plist3->tone_ph;
+			phlist[ix].tone_ph_data = (plist3->tone_ph != 0
+					&& (plist3->synthflags & SFLAG_SWITCHED_LANG))
+				? phoneme_tab[plist3->tone_ph] : NULL;
 			phlist[ix].sourceix = 0;
 			phlist[ix].phcode = ph->code;
 

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -640,7 +640,9 @@ void CalcLengths(Translator *tr)
 			length_mod = length_mod * len;
 
 			if (p->tone_ph != 0) {
-				if ((tone_mod = phoneme_tab[p->tone_ph]->std_length) > 0) {
+				PHONEME_TAB *tone_ph = p->tone_ph_data != NULL
+					? p->tone_ph_data : phoneme_tab[p->tone_ph];
+				if ((tone_ph != NULL) && ((tone_mod = tone_ph->std_length) > 0)) {
 					// a tone phoneme specifies a percentage change to the length
 					length_mod = (length_mod * tone_mod) / 100;
 				}
@@ -677,7 +679,9 @@ void CalcLengths(Translator *tr)
 			env2 = p->env + 1; // version for use with preceding semi-vowel
 
 			if (p->tone_ph != 0) {
-				InterpretPhoneme2(p->tone_ph, &phdata_tone);
+				InterpretPhoneme2WithData(p->tone_ph,
+					p->tone_ph_data != NULL ? p->tone_ph_data : phoneme_tab[p->tone_ph],
+					&phdata_tone);
 				pitch_env = GetEnvelope(phdata_tone.pitch_env);
 			} else
 				pitch_env = envelope_data[env2];

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -640,8 +640,7 @@ void CalcLengths(Translator *tr)
 			length_mod = length_mod * len;
 
 			if (p->tone_ph != 0) {
-				PHONEME_TAB *tone_ph = p->tone_ph_data != NULL
-					? p->tone_ph_data : phoneme_tab[p->tone_ph];
+				PHONEME_TAB *tone_ph = TonePhoneme(p);
 				if ((tone_ph != NULL) && ((tone_mod = tone_ph->std_length) > 0)) {
 					// a tone phoneme specifies a percentage change to the length
 					length_mod = (length_mod * tone_mod) / 100;
@@ -679,9 +678,7 @@ void CalcLengths(Translator *tr)
 			env2 = p->env + 1; // version for use with preceding semi-vowel
 
 			if (p->tone_ph != 0) {
-				InterpretPhoneme2WithData(p->tone_ph,
-					p->tone_ph_data != NULL ? p->tone_ph_data : phoneme_tab[p->tone_ph],
-					&phdata_tone);
+				InterpretPhoneme2WithData(p->tone_ph, TonePhoneme(p), &phdata_tone);
 				pitch_env = GetEnvelope(phdata_tone.pitch_env);
 			} else
 				pitch_env = envelope_data[env2];

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -1040,3 +1040,13 @@ void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata)
 {
 	InterpretPhoneme2WithData(phcode, phoneme_tab[phcode], phdata);
 }
+
+PHONEME_TAB *TonePhoneme(const PHONEME_LIST *plist)
+{
+	// Prefer the phoneme resolved while the word's own table was current.
+	// tone_ph on its own is table-local, so looking it up in phoneme_tab is
+	// only correct for words which did not switch language.
+	if (plist->tone_ph_data != NULL)
+		return plist->tone_ph_data;
+	return phoneme_tab[plist->tone_ph];
+}

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -1011,12 +1011,18 @@ void InterpretPhoneme(Translator *tr, int control, PHONEME_LIST *plist, PHONEME_
 	}
 }
 
-void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata)
+void InterpretPhoneme2WithData(int phcode, PHONEME_TAB *ph, PHONEME_DATA *phdata)
 {
-	// Examine the program of a single isolated phoneme
+	// Examine the program of a single isolated phoneme. The caller may pass
+	// a resolved phoneme from an alternate table; the numeric code alone is
+	// table-local and is unsafe after the base table has been restored.
 	int ix;
 	PHONEME_LIST plist[4];
 	memset(plist, 0, sizeof(plist));
+	if (ph == NULL) {
+		memset(phdata, 0, sizeof(*phdata));
+		return;
+	}
 
 	for (ix = 0; ix < 4; ix++) {
 		plist[ix].phcode = phonPAUSE;
@@ -1024,8 +1030,13 @@ void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata)
 	}
 
 	plist[1].phcode = phcode;
-	plist[1].ph = phoneme_tab[phcode];
+	plist[1].ph = ph;
 	plist[2].sourceix = 1;
 
 	InterpretPhoneme(NULL, 0, &plist[1], plist, phdata, NULL);
+}
+
+void InterpretPhoneme2(int phcode, PHONEME_DATA *phdata)
+{
+	InterpretPhoneme2WithData(phcode, phoneme_tab[phcode], phdata);
 }

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -44,6 +44,8 @@ void InterpretPhoneme2WithData(int phcode,
 		PHONEME_TAB *ph,
 		PHONEME_DATA *phdata);
 
+PHONEME_TAB *TonePhoneme(const PHONEME_LIST *plist);
+
 void FreePhData(void);
 const unsigned char *GetEnvelope(int index);
 espeak_ng_STATUS LoadPhData(int *srate, espeak_ng_ERROR_CONTEXT *context);

--- a/src/libespeak-ng/synthdata.h
+++ b/src/libespeak-ng/synthdata.h
@@ -40,6 +40,9 @@ void InterpretPhoneme(Translator *tr,
 
 void InterpretPhoneme2(int phcode,
 		PHONEME_DATA *phdata);
+void InterpretPhoneme2WithData(int phcode,
+		PHONEME_TAB *ph,
+		PHONEME_DATA *phdata);
 
 void FreePhData(void);
 const unsigned char *GetEnvelope(int index);

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -1456,7 +1456,9 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 			pitch_env = envelope_data[p->env];
 			amp_env = NULL;
 			if (p->tone_ph != 0) {
-				InterpretPhoneme2(p->tone_ph, &phdata_tone);
+				InterpretPhoneme2WithData(p->tone_ph,
+					p->tone_ph_data != NULL ? p->tone_ph_data : phoneme_tab[p->tone_ph],
+					&phdata_tone);
 				pitch_env = GetEnvelope(phdata_tone.pitch_env);
 				if (phdata_tone.amp_env > 0)
 					amp_env = GetEnvelope(phdata_tone.amp_env);

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -1456,9 +1456,7 @@ int Generate(PHONEME_LIST *phoneme_list, int *n_ph, bool resume)
 			pitch_env = envelope_data[p->env];
 			amp_env = NULL;
 			if (p->tone_ph != 0) {
-				InterpretPhoneme2WithData(p->tone_ph,
-					p->tone_ph_data != NULL ? p->tone_ph_data : phoneme_tab[p->tone_ph],
-					&phdata_tone);
+				InterpretPhoneme2WithData(p->tone_ph, TonePhoneme(p), &phdata_tone);
 				pitch_env = GetEnvelope(phdata_tone.pitch_env);
 				if (phdata_tone.amp_env > 0)
 					amp_env = GetEnvelope(phdata_tone.amp_env);

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -195,6 +195,10 @@ typedef struct {
 	unsigned char tone_ph;    // tone phoneme to use with this vowel
 
 	PHONEME_TAB *ph;
+	// Resolved while the word's phoneme table is active. tone_ph is only a
+	// table-local code and cannot safely be looked up after switching back to
+	// the base language later in the clause.
+	PHONEME_TAB *tone_ph_data;
 	unsigned int length;  // length_mod
 	unsigned char env;    // pitch envelope number
 	unsigned char type;

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -59,7 +59,8 @@
 #define OFFSET_GEORGIAN 0x10a0
 #define OFFSET_KOREAN   0x1100
 #define OFFSET_ETHIOPIC 0x1200
-#define OFFSET_SHAVIAN  0x10450
+#define OFFSET_CJK      0x3100
+#define OFFSET_SHAVIAN 0x10450
 
 // character ranges must be listed in ascending unicode order
 static const ALPHABET alphabets[] = {
@@ -88,7 +89,7 @@ static const ALPHABET alphabets[] = {
 	{ "_eth",   OFFSET_ETHIOPIC, 0x1200, 0x139f, 0, 0 },
 	{ "_braille", 0x2800,        0x2800, 0x28ff, 0, AL_NO_SYMBOL },
 	{ "_ja",    0x3040,          0x3040, 0x30ff, 0, AL_NOT_CODE },
-	{ "_zh",    0x3100,          0x3100, 0x9fff, 0, AL_NOT_CODE },
+	{ "_zh",    OFFSET_CJK,     0x3100, 0x9fff, 0, AL_NOT_CODE | AL_IDEOGRAPHS },
 	{ "_ko",    0xa700,          0xa700, 0xd7ff, L('k', 'o'), AL_NOT_CODE | AL_WORDS },
 	{ "_shaw",  OFFSET_SHAVIAN,  0x10450, 0x1047F, L('e', 'n'), 0 },
 	{ NULL, 0, 0, 0, 0, 0 }
@@ -537,6 +538,10 @@ Translator *SelectTranslator(const char *name)
 		tr->letter_bits_offset = OFFSET_ARABIC;
 		tr->langopts.numbers = NUM_SWAP_TENS | NUM_AND_UNITS | NUM_HUNDRED_AND | NUM_OMIT_1_HUNDRED | NUM_AND_HUNDRED | NUM_THOUSAND_AND | NUM_OMIT_1_THOUSAND;
 		tr->langopts.param[LOPT_UNPRONOUNCABLE] = 1; // disable check for unpronouncable words
+		// Read Han ideographs with the Mandarin translator instead of spelling
+		// every codepoint as "Chinese letter" through the English fallback.
+		tr->langopts.alt_alphabet = OFFSET_CJK;
+		tr->langopts.alt_alphabet_lang = L3('c', 'm', 'n');
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_6;
 		SetArabicLetters(tr);
 		break;

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -60,7 +60,7 @@
 #define OFFSET_KOREAN   0x1100
 #define OFFSET_ETHIOPIC 0x1200
 #define OFFSET_CJK      0x3100
-#define OFFSET_SHAVIAN 0x10450
+#define OFFSET_SHAVIAN  0x10450
 
 // character ranges must be listed in ascending unicode order
 static const ALPHABET alphabets[] = {
@@ -89,7 +89,7 @@ static const ALPHABET alphabets[] = {
 	{ "_eth",   OFFSET_ETHIOPIC, 0x1200, 0x139f, 0, 0 },
 	{ "_braille", 0x2800,        0x2800, 0x28ff, 0, AL_NO_SYMBOL },
 	{ "_ja",    0x3040,          0x3040, 0x30ff, 0, AL_NOT_CODE },
-	{ "_zh",    OFFSET_CJK,     0x3100, 0x9fff, 0, AL_NOT_CODE | AL_IDEOGRAPHS },
+	{ "_zh",    OFFSET_CJK,      0x3100, 0x9fff, 0, AL_NOT_CODE | AL_IDEOGRAPHS },
 	{ "_ko",    0xa700,          0xa700, 0xd7ff, L('k', 'o'), AL_NOT_CODE | AL_WORDS },
 	{ "_shaw",  OFFSET_SHAVIAN,  0x10450, 0x1047F, L('e', 'n'), 0 },
 	{ NULL, 0, 0, 0, 0, 0 }

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -142,6 +142,27 @@ char *strchr_w(const char *s, int c)
 	return strchr((char *)s, c); // (char *) is needed for Borland compiler
 }
 
+static bool ShouldSplitIdeographs(Translator *tr, int c, int prev)
+{
+	if (tr->langopts.ideographs && ((c > 0x3040) || (prev > 0x3040)))
+		return true;
+
+	// A non-ideographic base language may nominate an ideographic alternate
+	// translator (Arabic uses Mandarin for Han characters). Split that run in
+	// the same way as the alternate translator would, so every Han character
+	// reaches its dictionary entry instead of one long foreign-script token.
+	if (tr->langopts.alt_alphabet != 0) {
+		const ALPHABET *alpha_c = AlphabetFromChar(c);
+		const ALPHABET *alpha_prev = AlphabetFromChar(prev);
+		if (((alpha_c != NULL) && (alpha_c->offset == tr->langopts.alt_alphabet)
+				&& (alpha_c->flags & AL_IDEOGRAPHS))
+				|| ((alpha_prev != NULL) && (alpha_prev->offset == tr->langopts.alt_alphabet)
+				&& (alpha_prev->flags & AL_IDEOGRAPHS)))
+			return true;
+	}
+	return false;
+}
+
 static void SegmentReplacement(Translator *tr, const char *text, char *out, int out_size)
 {
 	// Apply the word-splitting rules of the clause tokenizer (TranslateClause)
@@ -166,7 +187,7 @@ static void SegmentReplacement(Translator *tr, const char *text, char *out, int 
 
 		if (IsAlpha(prev)) {
 			if (IsAlpha(c)) {
-				if (tr->langopts.ideographs && ((c > 0x3040) || (prev > 0x3040)))
+				if (ShouldSplitIdeographs(tr, c, prev))
 					insert_space = true; // each ideograph is a separate word
 			} else if (c == '-') {
 				int next;
@@ -1369,7 +1390,7 @@ void TranslateClauseWithTerminator(Translator *tr, int *tone_out, char **voice_c
 				bool prev_foreign = (alpha_prev != NULL) && (alpha_prev->offset != tr->letter_bits_offset);
 				if (emoji_join) {
 					// continuation of a ZWJ emoji sequence: not a word boundary
-				} else if (emoji_break || !IsAlpha(prev_out) || (tr->langopts.ideographs && ((c > 0x3040) || (prev_out > 0x3040))) || (IsEmoji(c) != IsEmoji(prev_out)) || (c_foreign != prev_foreign)) {
+				} else if (emoji_break || !IsAlpha(prev_out) || ShouldSplitIdeographs(tr, c, prev_out) || (IsEmoji(c) != IsEmoji(prev_out)) || (c_foreign != prev_foreign)) {
 					if (wcschr(tr->punct_within_word, prev_out) == 0)
 						letter_count = 0; // don't reset count for an apostrophy within a word
 

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -282,6 +282,7 @@ typedef struct {
 #define AL_WORDS        0x04 // use the language to speak words
 #define AL_NOT_CODE     0x08 // don't speak the character code
 #define AL_NO_SYMBOL    0x10 // don't repeat "symbol" or "character"
+#define AL_IDEOGRAPHS   0x20 // split this alphabet into individual dictionary words
 
 #define N_LOPTS       18
 #define LOPT_DIERESES  0

--- a/tests/language-pronunciation.test
+++ b/tests/language-pronunciation.test
@@ -14,6 +14,7 @@ test_phon an "t'oT os 'omb**es n'aksen l'iB**es i; iQw'als_! en d,iniD'at# i_! e
 d'eBen ,apatS'as'en 'unos kon 'at**os D'una man'e**a f**,etern'al" "Toz os ombres naxen libres y iguals en dinidat y en dreitos. Adotatos de razón y de conzenzia, deben apachar-sen unos con atros d'una manera freternal." "Latn"
 test_phon ar "?'us[buR A'ala: H'ifZi. X'udHa.R,in wa:'istaS,iR fat[,u.nna:
 w'azudZ: h'ammka fi: baQd'a:d mnTml'a:" "اُصْبُرْ عَلَى حِفْظِ خُضَرٍ وَاِسْتَشِرْ فَطُنًّا، وَزُجَّ هَمِّكَ فِي بغداد منثملَا" "Arab"
+test_phon ar "?'iDa: (cmn)z.u35k'uo214 n'i35n j'i55n w'ei51 f'a55n j'i51(ar) ?ann'as[s[" "إذا 如果您因为翻译 النص" "Arabic switches Han ideographs to Mandarin"
 test_phon as "X'@kOl,o m'anuh,e S'ad#in,Ob#aw,Oe X'@man m'O*&d,a 'a*u 'od#ik,a*e J'OnmOgr,OhOn k'O*e
 X'ihO~t,Or b'ibek 'a*u b'udd#i 'atS#e 'a*u X'ihO~t,e p'OrOXp,Or b#atr'itbO*,e 'atSOr,On k'o*ib l'age" "সকলো মানুহে স্বাধীনভাৱে সমান মৰ্যদা আৰু অধিকাৰে জন্মগ্ৰহণ কৰে । সিহঁতৰ বিবেক আৰু বুদ্ধি আছে আৰু সিহঁতে পৰস্পৰ ভাতৃত্বৰে আচৰণ কৰিব লাগে ।" "Beng"
 test_phon az "byts'yn insanL'aR l&jag'&t v& hygugLa*@n'a J'W*& az'ad b&*ab'&R do:uLuRL'aR


### PR DESCRIPTION
### Summary of Changes
When using the Arabic voice (`ar`), Chinese characters (Hanzi) were previously spoken by reading their descriptive character names (e.g., "Chinese letter") instead of pronouncing them properly.

This PR fixes the issue by setting up a fallback mechanism for Chinese characters (CJK Unified Ideographs) to be pronounced using the Mandarin (`zh`) voice/pronunciation rules when encountering them within Arabic text.

### Testing
- Tested reading mixed Arabic and Chinese text (`如果您因为翻译...`).
- Verified that Chinese characters are now pronounced correctly via Mandarin rules without spoken labels.
