### PR TITLE
tests: skip exact WAV hash checks where floating point keeps excess precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ message(STATUS "  libpcaudio: ${USE_LIBPCAUDIO} (${PCAUDIO_LIB} ${PCAUDIO_INC})"
 message(STATUS "  klatt: ${USE_KLATT}")
 message(STATUS "  speech-player: ${USE_SPEECHPLAYER}")
 message(STATUS "  async: ${USE_ASYNC}")
+message(STATUS "  excess floating point precision: ${ESPEAK_EXCESS_FP_PRECISION} (1 skips the WAV hash tests)")
 
 install(
   DIRECTORY vim/ftdetect vim/syntax DESTINATION share/vim/vimfiles

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,11 +1,30 @@
 include(CheckSymbolExists)
 include(CheckIncludeFile)
+include(CheckCSourceCompiles)
 
 check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
 check_include_file("nbtool_config.h" HAVE_NBTOOL_CONFIG_H)
 check_symbol_exists(optreset "getopt.h;unistd.h" HAVE_DECL_OPTRESET)
 check_include_file("sys/endian.h" HAVE_SYS_ENDIAN_H)
 check_symbol_exists(iswblank "wctype.h" HAVE_ISWBLANK)
+
+# The WAV tests compare an exact sha1 of the synthesized audio against hashes
+# that were generated on targets which evaluate float and double at the
+# precision of the type. A target that keeps excess intermediate precision --
+# in practice the x87 FPU without SSE math, where FLT_EVAL_METHOD is 2 --
+# rounds differently, so every one of those hashes differs. See #1270.
+check_c_source_compiles("
+#if !defined(__FLT_EVAL_METHOD__) || __FLT_EVAL_METHOD__ != 2
+#error floating point is evaluated at the precision of the type
+#endif
+int main(void) { return 0; }
+" HAVE_EXCESS_FP_PRECISION)
+
+if (HAVE_EXCESS_FP_PRECISION)
+  set(ESPEAK_EXCESS_FP_PRECISION 1)
+else()
+  set(ESPEAK_EXCESS_FP_PRECISION 0)
+endif()
 
 option(USE_MBROLA "Use mbrola for speech synthesis" ${HAVE_MBROLA})
 option(USE_LIBSONIC "Use libsonic for faster speech rates" ${HAVE_LIBSONIC})

--- a/docs/building.md
+++ b/docs/building.md
@@ -221,6 +221,16 @@ You can run the test suite with:
 
     ctest --test-dir build -j$(nproc) --output-on-failure
 
+Some of the tests compare an exact sha1 of the synthesized audio against a
+hash recorded in the test file. Those hashes were generated on targets that
+evaluate `float` and `double` at the precision of the type, so they only hold
+where `FLT_EVAL_METHOD` is 0. A build that keeps excess intermediate precision
+-- in practice the x87 FPU without SSE math, as on 32-bit x86 built with
+`-mfpmath=387` -- rounds differently and produces a different hash for correct
+audio. The build detects this and those checks report as skipped rather than
+failed; configuring such a build with `-mfpmath=sse -msse2` makes them run
+again.
+
 ### Installing
 
 You can install eSpeak NG by running the following command:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,9 +35,11 @@ find_program(SHELL bash)
 macro(shell_test _test_name)
   add_test(
     NAME ${_test_name}
-    COMMAND ${ESPEAK_RUN_ENV} ESPEAK_BIN=$<TARGET_FILE:espeak-ng-bin> ${SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/${_test_name}.test
+    COMMAND ${ESPEAK_RUN_ENV} ESPEAK_BIN=$<TARGET_FILE:espeak-ng-bin> ESPEAK_EXCESS_FP_PRECISION=${ESPEAK_EXCESS_FP_PRECISION} ${SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/${_test_name}.test
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
   )
+  # tests/common exits with 77 when a check cannot run on this target.
+  set_tests_properties(${_test_name} PROPERTIES SKIP_RETURN_CODE 77)
 endmacro(shell_test)
 
 compiled_test(api)

--- a/tests/common
+++ b/tests/common
@@ -20,6 +20,27 @@ check_hash() {
     # Test some common commands to find the correct one for the system being tested on.
 }
 
+# The WAV checks below compare an exact sha1 of the synthesized audio against
+# hashes generated on targets that evaluate float and double at the precision of
+# the type. A target that keeps excess intermediate precision -- in practice the
+# x87 FPU without SSE math, where FLT_EVAL_METHOD is 2 -- rounds differently, so
+# every one of those hashes differs even though synthesis is correct (#1270).
+# ESPEAK_EXCESS_FP_PRECISION is set by the build, see cmake/config.cmake.
+wav_hash_is_reproducible() {
+    [ "$ESPEAK_EXCESS_FP_PRECISION" != "1" ]
+}
+
+# Skip the whole test file, for files that contain nothing but WAV hash checks
+is_wav_hash() {
+    echo -n "checking if exact WAV hashes are reproducible on this target ... "
+    if wav_hash_is_reproducible; then
+        echo "yes"
+    else
+        echo "no (excess floating point precision, FLT_EVAL_METHOD is 2)"
+        exit 77
+    fi
+}
+
 # test if MBROLA synthesizer is installed
 is_mbrola() {
     echo -n "checking if MBROLA is installed ... "
@@ -65,6 +86,11 @@ test_wav () {
     TEST_TEXT=$3
     MESSAGE=$4
 
+    if ! wav_hash_is_reproducible ; then
+        echo "skipping ${VOICE} ${MESSAGE} (WAV hashes are not reproducible on this target)"
+        return 0
+    fi
+
     echo "testing ${VOICE} ${MESSAGE}"
     RESULT=$(
         ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
@@ -86,6 +112,12 @@ test_wav_grep () {
     EXPECTED=$2
     TEST_TEXT=$3
     MESSAGE=$4
+
+    if ! wav_hash_is_reproducible ; then
+        echo "skipping ${VOICE} ${MESSAGE} (WAV hashes are not reproducible on this target)"
+        return 0
+    fi
+
     echo "testing ${VOICE} ${MESSAGE}"
     $()
     ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \

--- a/tests/klatt.test
+++ b/tests/klatt.test
@@ -3,6 +3,7 @@
 . "`dirname $0`/common"
 # and run needed checks before
 is_hash
+is_wav_hash
 # call actual test functions
 test_wav en+klatt  "696213dbbceecf20c3f80d771aab5757e05181c0" "The quick brown fox jumps over the lazy dog"
 test_wav en+klatt2 "e55bf0a5cd96d648177f743557c67a791da03f7b" "The quick brown fox jumps over the lazy dog"

--- a/tests/mbrola.test
+++ b/tests/mbrola.test
@@ -3,6 +3,7 @@
 . "`dirname $0`/common"
 # and run needed checks before
 is_hash
+is_wav_hash
 is_mbrola
 
 check_voice_folder() {

--- a/tests/ssml.test
+++ b/tests/ssml.test
@@ -10,6 +10,11 @@ test_ssml_audio() {
 	TEST_TEXT=$3
 	OPTS=$4
 
+	if ! wav_hash_is_reproducible ; then
+		echo "skipping ${TEST_NAME} (WAV hashes are not reproducible on this target)"
+		return 0
+	fi
+
 	echo "testing ${TEST_NAME}"
 	RESULT=$(
 		ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \

--- a/tests/variants.test
+++ b/tests/variants.test
@@ -3,6 +3,7 @@
 . "`dirname $0`/common"
 # and run needed checks before
 is_hash
+is_wav_hash
 
 test_wav "en" 029983e9084e04384af8a0816fb667e5c5e06389 "Testing variants"
 # variant doesn't exist, should be equal to en:


### PR DESCRIPTION
The i686 failures are not about the audio, they are about `FLT_EVAL_METHOD`, so the right thing to key the skip on is that property rather than the architecture.

I measured `__FLT_EVAL_METHOD__` across 25 target/flag combinations with clang. It is 2 for `i386`, `i686` and `x86_64` under `-mno-sse` or `-march=i486`, and 0 for those same targets under `-msse2` or `-march=pentium3`, and 0 on aarch64 and armv7. So keying on `== 2` keeps the hash checks running on i386 builds configured with SSE math, where they pass, and still catches an `x86_64 -mno-sse` build that a `uname` check would miss. `__SSE2_MATH__` was probed in the same matrix and adds no case gcc or clang would miss, so it is not in the check. Worth noting that CI's own `arch: i386` job already sets `-m32 -msse2 -mfpmath=sse`, which is why it has never seen this — and why the detection reads 0 there and those jobs keep running the hash checks unchanged.

The guard sits in the `test_wav` / `test_wav_grep` / `test_ssml_audio` helpers rather than at the top of the files: skipping whole files costs the `language-phonemes` meta test and the 9 non-audio SSML markup checks. Files that are only hash comparisons (`variants`, `klatt`, `mbrola`) do skip whole, with `SKIP_RETURN_CODE 77` so ctest says Skipped instead of quietly passing.

Matched pair, same tree and command, on arm64 where `__FLT_EVAL_METHOD__` is 0:

- auto-detected: 19/19, 181 hash assertions executed, 0 skipped — same as clean master.
- detection forced on: 19/19, `variants` and `klatt` Skipped, 159 hash checks skipped, the 9 markup checks and the meta test still run.
- guard reverted, detection still forced on: all 181 run, nothing skips.
- naive whole-file variant: 4 tests Skipped, losing the meta test and the markup checks.

CI on this PR confirms the no-over-skip half on real i386: the `ubuntu i386: gcc + debug` job logs `HAVE_EXCESS_FP_PRECISION - Failed`, zero skipping lines, and `variants` / `klatt` / `ssml` / `language-phonemes` all Passed.

Honest limit: I have no x87 host, so the hash mismatch itself is your reproduction, not mine — what I verified is the classifier and the skip behaviour. My 25 probes are clang, and CI covers gcc only on the SSE side; gcc's `__FLT_EVAL_METHOD__` under `-mfpmath=387` is documented rather than measured here. If the macro is undefined the check fails and the tests run exactly as they do today. This covers excess precision only; other divergence sources such as FMA contraction would each need their own look.

Closes #1270

---
The code, the tests and this description were drafted by Claude Opus 5 working as a coding agent in this repository.
