### PR TITLE
Android: normalize Unicode (NFKC) before synthesis

### DIFF
--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -53,6 +53,7 @@ Android TTS Framework
 - **EspeakApp** — `Application` subclass; owns the device-protected storage context and the Wear launcher alias state (see below)
 - **TtsService** — Android TTS engine service; handles `onSynthesizeText()`, voice selection, parameter setup
 - **SpeechSynthesis** — JNI wrapper; loads `libttsespeak.so`, exposes native functions as Java API
+- **UnicodeNormalization** — NFKC normalization of synthesis input (stylized Unicode → plain text) with a normalized→original offset map for `rangeStart()` word boundaries
 - **VoiceSettings** — SharedPreferences wrapper for rate, pitch, volume, punctuation, variant
 - **LanguageSettings** — Filters available voices by user-selected languages
 - **CheckVoiceData** — Intent handler that verifies voice data files exist on device

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/UnicodeNormalizationTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/UnicodeNormalizationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Alexandr Epaneshnikov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak.test;
+
+import com.reecedunn.espeak.UnicodeNormalization;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Checks the NFKC normalization applied to synthesis input and the offset map
+ * used to keep {@code SynthesisCallback.rangeStart} anchored to the text the
+ * caller supplied.
+ */
+@RunWith(AndroidJUnit4.class)
+public class UnicodeNormalizationTest
+{
+    @Test
+    public void plainTextIsAlreadyNormalized()
+    {
+        assertThat(UnicodeNormalization.normalize(""), is(nullValue()));
+        assertThat(UnicodeNormalization.normalize("Hello, world!"), is(nullValue()));
+        assertThat(UnicodeNormalization.normalize("héllo wörld"), is(nullValue()));
+        // Composed text with an astral emoji is normalized too; the fast path
+        // must not be confused by surrogate pairs.
+        assertThat(UnicodeNormalization.normalize("ab 😀 cd"), is(nullValue()));
+    }
+
+    @Test
+    public void mathematicalAlphanumericSymbols()
+    {
+        // The examples from issue #2485.
+        assertThat(UnicodeNormalization.normalize("𝖁𝕰𝕹𝖀𝕾").text, is("VENUS"));
+        assertThat(UnicodeNormalization.normalize("𝘛𝘢𝘳𝘢").text, is("Tara"));
+        assertThat(UnicodeNormalization.normalize("𝐂𝐨𝐝𝐞").text, is("Code"));
+    }
+
+    @Test
+    public void fullwidthForms()
+    {
+        assertThat(UnicodeNormalization.normalize("Ｈｅｌｌｏ").text, is("Hello"));
+    }
+
+    @Test
+    public void negativeCircledLettersUseSupplementaryMapping()
+    {
+        // U+1F150.. has no compatibility decomposition, so plain NFKC would
+        // leave it alone; the supplementary mapping must kick in.
+        assertThat(UnicodeNormalization.normalize("🅐🅑🅒").text, is("ABC"));
+    }
+
+    @Test
+    public void negativeSquaredLettersPreserveEmoji()
+    {
+        // 🅾 has emoji semantics (blood type O) and must survive, while the
+        // surrounding squared letters normalize.
+        assertThat(UnicodeNormalization.normalize("🅲🅾🅳🅴").text, is("C🅾DE"));
+        // Text consisting only of the excluded emoji needs no normalization.
+        assertThat(UnicodeNormalization.normalize("🅰🅱🅾🅿"), is(nullValue()));
+    }
+
+    @Test
+    public void combiningMarksCompose()
+    {
+        // The input is decomposed ("e" + combining acute); NFKC composes it
+        // to a single "é", so the two literals differ despite looking alike.
+        assertThat(UnicodeNormalization.normalize("café").text, is("café"));
+    }
+
+    @Test
+    public void offsetsForStyledWord()
+    {
+        // "ab 𝖁𝕰𝕹𝖀𝕾 cd": each styled letter is one code point but two
+        // UTF-16 units, so the original is 16 units long and the normalized
+        // form ("ab VENUS cd") is 11.
+        final String text = "ab 𝖁𝕰𝕹𝖀𝕾 cd";
+        final UnicodeNormalization.Result result = UnicodeNormalization.normalize(text);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.text, is("ab VENUS cd"));
+
+        // "ab " is untouched.
+        assertThat(result.toOriginalOffset(0), is(0));
+        assertThat(result.toOriginalOffset(3), is(3));
+        // The word "VENUS" spans [3, 8) in the normalized text and must map
+        // back to the full styled span [3, 13) in the original.
+        assertThat(result.toOriginalOffset(8), is(13));
+        // "cd" after the styled word.
+        assertThat(result.toOriginalOffset(9), is(14));
+        assertThat(result.toOriginalOffset(11), is(16));
+    }
+
+    @Test
+    public void offsetsForExpandingLigature()
+    {
+        // "ĳ" normalizes to "ij": the text gets longer, and offsets inside
+        // the expansion must not run past the original character.
+        final UnicodeNormalization.Result result = UnicodeNormalization.normalize("ĳs");
+        assertThat(result, is(notNullValue()));
+        assertThat(result.text, is("ijs"));
+
+        assertThat(result.toOriginalOffset(0), is(0));
+        // Both the interior of the expansion and its end map to the end of
+        // the ligature, so a word ending there covers it exactly.
+        assertThat(result.toOriginalOffset(1), is(1));
+        assertThat(result.toOriginalOffset(2), is(1));
+        assertThat(result.toOriginalOffset(3), is(2));
+    }
+
+    @Test
+    public void offsetsAreMonotonic()
+    {
+        final String text = "a Ｗｉｄｅ ĳ 𝖁 b";
+        final UnicodeNormalization.Result result = UnicodeNormalization.normalize(text);
+        assertThat(result, is(notNullValue()));
+
+        int previous = 0;
+        for (int i = 0; i <= result.text.length(); ++i) {
+            final int offset = result.toOriginalOffset(i);
+            assertThat(offset, is(greaterThanOrEqualTo(previous)));
+            assertThat(offset, is(lessThanOrEqualTo(text.length())));
+            previous = offset;
+        }
+        assertThat(result.toOriginalOffset(result.text.length()), is(text.length()));
+    }
+
+    @Test
+    public void outOfRangeOffsetsAreClamped()
+    {
+        final UnicodeNormalization.Result result = UnicodeNormalization.normalize("𝖁");
+        assertThat(result, is(notNullValue()));
+        assertThat(result.text, is("V"));
+        assertThat(result.toOriginalOffset(-1), is(0));
+        assertThat(result.toOriginalOffset(100), is(2));
+    }
+}

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/VoiceSettingsTest.java
@@ -72,6 +72,7 @@ public class VoiceSettingsTest extends TextToSpeechTestCase
         assertThat(settings.getVolume(), is(synth.Volume.getDefaultValue()));
         assertThat(settings.getPunctuationLevel(), is(SpeechSynthesis.PUNCT_NONE));
         assertThat(settings.getPunctuationCharacters(), is(nullValue()));
+        assertThat(settings.isUnicodeNormalizationEnabled(), is(true));
 
         try {
             JSONObject json = settings.toJSON();

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -44,6 +44,17 @@
   <string name="espeak_deselect_all_languages">Deselect all languages</string>
   <string name="espeak_supported_languages_guard">Select at least one language.</string>
   <string name="espeak_speak_punctuation">Speak punctuation</string>
+  <!--
+        Source: Checkbox label.
+        Description: When enabled, stylized Unicode text is converted to plain
+        letters (Unicode NFKC normalization) before being spoken.
+    -->
+  <string name="setting_unicode_normalization">Unicode normalization</string>
+  <!--
+        Source: Checkbox summary.
+        Description: Explains the Unicode normalization setting.
+    -->
+  <string name="setting_unicode_normalization_summary">Read stylized Unicode text, such as fancy fonts used on social media, as normal words</string>
   <string name="punctuation_all">All</string>
   <string name="punctuation_custom">Custom</string>
   <string name="punctuation_custom_fmt">Custom: %s</string>

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -68,6 +68,11 @@ public class TtsService extends TextToSpeechService {
     private String mSynthText;
     /** Where {@link #mSynthText} starts within the text the caller supplied. */
     private int mSynthTextOffset;
+    /**
+     * Offset map back to the caller's text when {@link #mSynthText} is a
+     * normalized copy of it, or null when they are the same string.
+     */
+    private UnicodeNormalization.Result mSynthNormalization;
     /** Number of code points in {@link #mSynthText}. */
     private int mSynthTextCodePoints;
     /** Anchor for incremental code point to UTF-16 index conversion. */
@@ -443,8 +448,21 @@ public class TtsService extends TextToSpeechService {
             }
         }
 
+        final VoiceSettings settings = new VoiceSettings(PreferenceManager.getDefaultSharedPreferences(storageContext), mEngine);
+
+        UnicodeNormalization.Result normalization = null;
+        if (settings.isUnicodeNormalizationEnabled()) {
+            // NFKC leaves ASCII untouched, so SSML markup passes through
+            // unchanged and the "<speak" sniff below still works.
+            normalization = UnicodeNormalization.normalize(text);
+            if (normalization != null) {
+                text = normalization.text;
+            }
+        }
+
         mSynthText = text;
         mSynthTextOffset = textOffset;
+        mSynthNormalization = normalization;
         mSynthTextCodePoints = text.codePointCount(0, text.length());
         mAnchorCodePoint = 0;
         mAnchorOffset = 0;
@@ -452,7 +470,6 @@ public class TtsService extends TextToSpeechService {
         mCallback = callback;
         mCallback.start(mEngine.getSampleRate(), mEngine.getAudioFormat(), mEngine.getChannelCount());
 
-        final VoiceSettings settings = new VoiceSettings(PreferenceManager.getDefaultSharedPreferences(storageContext), mEngine);
         mEngine.setVoice(voice, settings.getVoiceVariant());
 
         int rate = settings.getRate();
@@ -538,8 +555,14 @@ public class TtsService extends TextToSpeechService {
             // eSpeak counts code points from 1, rangeStart() wants 0-based UTF-16
             // indices into the text the caller supplied.
             final int wordStart = textPosition - 1;
-            final int start = codePointToOffset(wordStart);
-            final int end = codePointToOffset(wordStart + Math.max(textLength, 0));
+            int start = codePointToOffset(wordStart);
+            int end = codePointToOffset(wordStart + Math.max(textLength, 0));
+            if (mSynthNormalization != null) {
+                // The engine spoke normalized text; report the range against
+                // the original so highlighting tracks the caller's string.
+                start = mSynthNormalization.toOriginalOffset(start);
+                end = mSynthNormalization.toOriginalOffset(end);
+            }
             if (end <= start) {
                 return;
             }

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -450,10 +450,14 @@ public class TtsService extends TextToSpeechService {
 
         final VoiceSettings settings = new VoiceSettings(PreferenceManager.getDefaultSharedPreferences(storageContext), mEngine);
 
+        // Detect SSML before normalizing. Real markup is ASCII, which NFKC
+        // leaves untouched, but normalization can turn lookalikes such as a
+        // fullwidth "＜ｓｐｅａｋ" into "<speak", and plain text must not
+        // switch into SSML parsing because of that.
+        final boolean isSsml = text.startsWith("<speak");
+
         UnicodeNormalization.Result normalization = null;
         if (settings.isUnicodeNormalizationEnabled()) {
-            // NFKC leaves ASCII untouched, so SSML markup passes through
-            // unchanged and the "<speak" sniff below still works.
             normalization = UnicodeNormalization.normalize(text);
             if (normalization != null) {
                 text = normalization.text;
@@ -484,7 +488,7 @@ public class TtsService extends TextToSpeechService {
         mEngine.Volume.setValue(settings.getVolume());
         mEngine.Punctuation.setValue(settings.getPunctuationLevel());
         mEngine.setPunctuationCharacters(settings.getPunctuationCharacters());
-        mEngine.synthesize(text, text.startsWith("<speak"));
+        mEngine.synthesize(text, isSsml);
     }
 
     protected void rebuildAvailableVoices() {

--- a/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
+++ b/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
@@ -27,6 +27,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
@@ -176,6 +177,16 @@ public class TtsSettingsActivity extends PreferenceActivity {
         pref.setOnPreferenceChangeListener(mOnPreferenceChanged);
         pref.setPersistent(true);
         pref.setVoiceSettings(settings);
+        return pref;
+    }
+
+    private static Preference createUnicodeNormalizationPreference(Context context) {
+        final CheckBoxPreference pref = new CheckBoxPreference(context);
+        pref.setTitle(R.string.setting_unicode_normalization);
+        pref.setSummary(R.string.setting_unicode_normalization_summary);
+        pref.setKey(VoiceSettings.PREF_UNICODE_NORMALIZATION);
+        pref.setDefaultValue(true);
+        pref.setPersistent(true);
         return pref;
     }
 
@@ -477,6 +488,7 @@ public class TtsSettingsActivity extends PreferenceActivity {
         }
         group.addPreference(createVoiceVariantPreference(context, settings, R.string.espeak_variant));
         group.addPreference(createSpeakPunctuationPreference(context, settings, R.string.espeak_speak_punctuation));
+        group.addPreference(createUnicodeNormalizationPreference(context));
 
         if (isWatch) {
             // One parameter per dialog on Wear. The rotating crown only

--- a/android/src/com/reecedunn/espeak/UnicodeNormalization.java
+++ b/android/src/com/reecedunn/espeak/UnicodeNormalization.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Alexandr Epaneshnikov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak;
+
+import java.text.BreakIterator;
+import java.text.Normalizer;
+
+/**
+ * NFKC normalization of synthesis input, so that stylized Unicode text (such
+ * as the Mathematical Alphanumeric Symbols popular on social media, fullwidth
+ * forms, and enclosed letters) is spoken as the words it spells rather than
+ * one codepoint at a time.
+ *
+ * <p>This mirrors what NVDA and speech-dispatcher do before text reaches a
+ * synthesizer. Like NVDA, a supplementary mapping handles the negative
+ * circled and negative squared Latin letters, which are decorative but have
+ * no compatibility decomposition in Unicode.
+ *
+ * <p>NFKC can change the length of the text, but word boundary events must be
+ * reported against the text the caller supplied, so normalization also builds
+ * an offset map from the normalized string back to the original one.
+ */
+public final class UnicodeNormalization {
+    private UnicodeNormalization() {
+    }
+
+    /** A normalized string together with its offset map into the original. */
+    public static final class Result {
+        /** The normalized text, to be handed to the synthesizer. */
+        public final String text;
+
+        /**
+         * Boundary map of size {@code text.length() + 1}: entry {@code i} is
+         * the UTF-16 offset in the original string corresponding to UTF-16
+         * offset {@code i} in the normalized string. Within a run the
+         * normalization changed, interior positions map to the end of the
+         * original run, so a word ending inside it covers the whole run and
+         * mapped ranges never invert.
+         */
+        private final int[] mOffsets;
+
+        Result(String text, int[] offsets) {
+            this.text = text;
+            mOffsets = offsets;
+        }
+
+        /** Maps a UTF-16 offset in {@link #text} to one in the original string. */
+        public int toOriginalOffset(int offset) {
+            if (offset <= 0) {
+                return 0;
+            }
+            if (offset >= mOffsets.length) {
+                return mOffsets[mOffsets.length - 1];
+            }
+            return mOffsets[offset];
+        }
+    }
+
+    /**
+     * Normalizes {@code text} to NFKC, including the supplementary mapping.
+     *
+     * @return the normalized text with its offset map, or {@code null} when
+     * the text is already normalized and can be used as-is (the common case,
+     * where exact identity of offsets is guaranteed).
+     */
+    public static Result normalize(String text) {
+        if (!hasSupplementaryMappings(text)
+                && Normalizer.isNormalized(text, Normalizer.Form.NFKC)) {
+            return null;
+        }
+
+        // Normalize one grapheme cluster at a time. Canonical composition
+        // never crosses a cluster boundary (combining marks belong to their
+        // base's cluster), so this matches whole-string NFKC for real text
+        // while keeping an unambiguous offset for every cluster.
+        final BreakIterator graphemes = BreakIterator.getCharacterInstance();
+        graphemes.setText(text);
+
+        final StringBuilder normalized = new StringBuilder(text.length());
+        int[] offsets = new int[text.length() + 1];
+        int offsetCount = 0;
+
+        int start = graphemes.first();
+        for (int end = graphemes.next(); end != BreakIterator.DONE;
+                start = end, end = graphemes.next()) {
+            final String part = text.substring(start, end);
+            final String norm = Normalizer.normalize(
+                    applySupplementaryMappings(part), Normalizer.Form.NFKC);
+            normalized.append(norm);
+
+            if (offsetCount + norm.length() >= offsets.length) {
+                offsets = grow(offsets, offsetCount + norm.length() + 1);
+            }
+            if (norm.equals(part)) {
+                for (int i = 0; i < norm.length(); ++i) {
+                    offsets[offsetCount++] = start + i;
+                }
+            } else if (!norm.isEmpty()) {
+                offsets[offsetCount++] = start;
+                for (int i = 1; i < norm.length(); ++i) {
+                    offsets[offsetCount++] = end;
+                }
+            }
+        }
+        offsets[offsetCount++] = text.length();
+
+        if (offsetCount != offsets.length) {
+            final int[] trimmed = new int[offsetCount];
+            System.arraycopy(offsets, 0, trimmed, 0, offsetCount);
+            offsets = trimmed;
+        }
+        return new Result(normalized.toString(), offsets);
+    }
+
+    private static int[] grow(int[] array, int minCapacity) {
+        final int[] grown = new int[Math.max(array.length * 2, minCapacity)];
+        System.arraycopy(array, 0, grown, 0, array.length);
+        return grown;
+    }
+
+    /**
+     * Maps one decorative code point that NFKC leaves alone, or returns it
+     * unchanged. Same ranges and emoji exclusions as NVDA's supplementary
+     * normalization table.
+     */
+    private static int mapSupplementaryCodePoint(int codePoint) {
+        // Negative Circled Latin Capital Letters.
+        if (codePoint >= 0x1F150 && codePoint <= 0x1F169) {
+            return 'A' + (codePoint - 0x1F150);
+        }
+        // Negative Squared Latin Capital Letters, except the four that carry
+        // emoji semantics: 🅰 🅱 🅾 🅿 (blood types and the parking sign).
+        if (codePoint >= 0x1F170 && codePoint <= 0x1F189) {
+            switch (codePoint) {
+                case 0x1F170:
+                case 0x1F171:
+                case 0x1F17E:
+                case 0x1F17F:
+                    return codePoint;
+            }
+            return 'A' + (codePoint - 0x1F170);
+        }
+        return codePoint;
+    }
+
+    private static boolean hasSupplementaryMappings(String text) {
+        for (int i = 0; i < text.length(); ) {
+            final int codePoint = text.codePointAt(i);
+            if (mapSupplementaryCodePoint(codePoint) != codePoint) {
+                return true;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return false;
+    }
+
+    private static String applySupplementaryMappings(String part) {
+        StringBuilder mapped = null;
+        for (int i = 0; i < part.length(); ) {
+            final int codePoint = part.codePointAt(i);
+            final int replacement = mapSupplementaryCodePoint(codePoint);
+            if (replacement != codePoint && mapped == null) {
+                mapped = new StringBuilder(part.length());
+                mapped.append(part, 0, i);
+            }
+            if (mapped != null) {
+                mapped.appendCodePoint(replacement);
+            }
+            i += Character.charCount(codePoint);
+        }
+        return (mapped == null) ? part : mapped.toString();
+    }
+}

--- a/android/src/com/reecedunn/espeak/VoiceSettings.java
+++ b/android/src/com/reecedunn/espeak/VoiceSettings.java
@@ -36,6 +36,7 @@ public class VoiceSettings {
     public static final String PREF_PUNCTUATION_LEVEL = "espeak_punctuation_level";
     public static final String PREF_PUNCTUATION_CHARACTERS = "espeak_punctuation_characters";
     public static final String PREF_RATE_BOOST = "espeak_rate_boost";
+    public static final String PREF_UNICODE_NORMALIZATION = "espeak_unicode_normalization";
     public static final int RATE_BOOST_MULTIPLIER = 3;
 
     public static final String PRESET_VARIANT = "variant";
@@ -170,5 +171,15 @@ public class VoiceSettings {
 
     public boolean isRateBoostEnabled() {
         return mPreferences.getBoolean(PREF_RATE_BOOST, false);
+    }
+
+    /**
+     * Whether to NFKC-normalize text before synthesis, so stylized Unicode
+     * (e.g. 𝖇𝖔𝖑𝖉 social media "fonts") is read as words instead of being
+     * spelled out codepoint by codepoint. On by default, matching NVDA's
+     * speech setting and speech-dispatcher's always-on server behaviour.
+     */
+    public boolean isUnicodeNormalizationEnabled() {
+        return mPreferences.getBoolean(PREF_UNICODE_NORMALIZATION, true);
     }
 }


### PR DESCRIPTION
Fixes #2485.

Stylized Unicode text — the Mathematical Alphanumeric Symbols popular on social media (`𝖁𝕰𝕹𝖀𝕾`, `𝐂𝐨𝐝𝐞`), fullwidth forms, enclosed letters — was spelled out codepoint by codepoint, which makes such text unintelligible and painfully slow under TalkBack.

## Approach

NVDA and speech-dispatcher both solved this outside the synthesizer, in the layer that feeds it text: NVDA normalizes to NFKC in its speech pipeline (`unicodedata.normalize` plus a supplementary table, enabled by default), and speech-dispatcher unconditionally applies `g_utf8_normalize(..., G_NORMALIZE_ALL_COMPOSE)` server-side (brailcom/speechd#289). On Android, the equivalent layer is this app, so the same is done in `TtsService` before text reaches the native engine.

- **`UnicodeNormalization`** (new): NFKC via `java.text.Normalizer`, applied per grapheme cluster, plus NVDA's supplementary mapping for the negative circled (U+1F150–U+1F169) and negative squared (U+1F170–U+1F189) Latin letters, which are decorative but have no compatibility decomposition — excluding 🅰🅱🅾🅿, which carry emoji semantics. A fast path returns the input untouched when it is already normalized (the common case).
- **Word-boundary offsets**: normalization changes text length, so the class also builds an offset map from the normalized string back to the original, and `TtsService` maps word events through it. `rangeStart()` highlighting therefore still tracks the string the caller supplied — a word spoken as "VENUS" highlights the full `𝖁𝕰𝕹𝖀𝕾` span.
- **Setting**: a "Unicode normalization" checkbox in the TTS settings, on by default (matching NVDA's default and speech-dispatcher's always-on behaviour).

SSML is unaffected: ASCII is NFKC-invariant, so markup passes through unchanged.

## Testing

- New `UnicodeNormalizationTest` instrumentation suite: the issue's own examples, fullwidth forms, the supplementary ranges with their emoji exclusions, combining-mark composition, offset maps for shrinking (styled letters) and expanding (`ĳ` → `ij`) normalizations, monotonicity, and clamping.
- Ran on an API 34 emulator: `UnicodeNormalizationTest` 10/10, `VoiceSettingsTest` 15/15, `WordBoundaryTest` 5/5 passed.
- `assembleDebug` and `assembleDebugAndroidTest` build clean.

## Known trade-off

NFKC is lossy in ways NVDA and speech-dispatcher also accepted: e.g. `½` now reaches the engine as `1⁄2` (U+2044) and is read as "one fraction slash two" instead of "half". A follow-up could add fraction-slash entries to the dictionaries; the setting also allows opting out entirely.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)