### PR TITLE
android: target Android 16 (API level 36)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 36
     ndkVersion = "29.0.14206865"
     namespace = "com.reecedunn.espeak"
 
@@ -40,7 +40,7 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 36
         versionCode = 23
         versionName = "1.53.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Raise compileSdk from 34 to 36 and targetSdk from 33 to 36 to meet Google Play's target API level requirement for app updates (API 36 required since Aug 31, 2026). minSdk stays at 21.