### PR TITLE
Fix MBROLA support on macOS

### DIFF
--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -85,6 +85,12 @@ void unload_MBR()
 #include <sys/wait.h>
 #include <unistd.h>
 
+#if defined(__APPLE__)
+/* macOS has no procfs; process state comes from libproc instead. */
+#include <libproc.h>
+#include <sys/proc_info.h>
+#endif
+
 #include <espeak-ng/espeak_ng.h>
 
 /*
@@ -107,6 +113,9 @@ static pid_t mbr_pid;
 static int mbr_samplerate;
 static float mbr_volume = 1.0;
 static char mbr_errorbuf[160];
+#if defined(__APPLE__)
+static int mbr_seen_output; /* see mbrola_is_idle() */
+#endif
 
 struct datablock {
 	struct datablock *next;
@@ -219,6 +228,11 @@ static int start_mbrola(const char *voice_path)
 		_exit(1);
 	}
 
+#if defined(__APPLE__)
+	/* No procfs on macOS; mbrola_is_idle() queries libproc by pid. */
+	mbr_proc_stat = -1;
+	mbr_seen_output = 0;
+#else
 #if defined(__sun) && defined(__SVR4)
 	snprintf(charbuf, sizeof(charbuf), "/proc/%d/psinfo", mbr_pid);
 #else
@@ -233,6 +247,7 @@ static int start_mbrola(const char *voice_path)
 		err("/proc is unaccessible: %s", strerror(error));
 		return -1;
 	}
+#endif
 
 	signal(SIGPIPE, SIG_IGN);
 
@@ -262,7 +277,8 @@ static void stop_mbrola(void)
 {
 	if (mbr_state == MBR_INACTIVE)
 		return;
-	close(mbr_proc_stat);
+	if (mbr_proc_stat != -1)
+		close(mbr_proc_stat);
 	close(mbr_cmd_fd);
 	close(mbr_audio_fd);
 	close(mbr_error_fd);
@@ -417,7 +433,56 @@ static int send_to_mbrola(const char *cmd)
 	return result;
 }
 
-#if defined(__sun) && defined(__SVR4) /* Solaris */
+#if defined(__APPLE__) /* macOS */
+static int mbrola_is_idle(void)
+{
+	uint64_t tids[16];
+	int size, count, i;
+
+	/*
+	 * Until mbrola has produced its first byte we cannot distinguish
+	 * "blocked having finished" from "blocked while still starting up"
+	 * (dyld, faulting in the voice database). Both look like a thread in
+	 * a wait. Reporting idle in that window truncates the .wav header, so
+	 * treat a process that has not spoken yet as busy; the caller's own
+	 * escalating poll timeout still catches a genuinely stalled mbrola.
+	 */
+	if (!mbr_seen_output)
+		return 0;
+
+	/*
+	 * macOS has no procfs, so the process state has to come from libproc.
+	 * Two plausible-looking sources are wrong here:
+	 *
+	 *   - proc_bsdinfo.pbi_status stays at SRUN even while the process is
+	 *     blocked (XNU tracks run state per thread), so it never reports
+	 *     SSLEEP and this would always say "busy".
+	 *   - proc_taskinfo.pti_numrunning counts threads currently on a CPU,
+	 *     so it reads 0 for a process that is merely descheduled, or one
+	 *     blocked in disk I/O while loading its voice database. That says
+	 *     "idle" too early and truncates the stream.
+	 *
+	 * Match what the Linux path means by 'S' instead: every thread parked
+	 * in an interruptible wait. TH_STATE_UNINTERRUPTIBLE (Linux 'D', i.e.
+	 * mbrola blocked reading its database) is deliberately not idle.
+	 */
+	size = proc_pidinfo(mbr_pid, PROC_PIDLISTTHREADS, 0, tids, sizeof(tids));
+	if (size <= 0)
+		return 0;
+
+	count = size / sizeof(uint64_t);
+	for (i = 0; i < count; i++) {
+		struct proc_threadinfo th;
+		if (proc_pidinfo(mbr_pid, PROC_PIDTHREADINFO, tids[i],
+		                 &th, sizeof(th)) != sizeof(th))
+			return 0;
+		if (th.pth_run_state != TH_STATE_WAITING)
+			return 0;
+	}
+
+	return 1;
+}
+#elif defined(__sun) && defined(__SVR4) /* Solaris */
 #include <procfs.h>
 static int mbrola_is_idle(void)
 {
@@ -533,6 +598,10 @@ static ssize_t receive_from_mbrola(void *buffer, size_t bufsize)
 				return -1;
 			}
 			cursize += obtained;
+#if defined(__APPLE__)
+			if (obtained > 0)
+				mbr_seen_output = 1;
+#endif
 			mbr_state = MBR_AUDIO;
 		}
 	} while (cursize < bufsize);

--- a/tests/mbrola.test
+++ b/tests/mbrola.test
@@ -5,18 +5,41 @@
 is_hash
 is_mbrola
 
+# Mirror the voice lookup done by LoadMbrolaTable() in
+# src/libespeak-ng/synth_mbrola.c: the espeak-ng-data directory first, then
+# each XDG data directory. Keep the two in step, otherwise voices that
+# espeak-ng can load are reported here as untested.
 check_voice_folder() {
-        voice_file=${1#mb-} # remove mb- prefix
-        voice_file=${voice_file%+*} # remove variant suffix
-        if [ -f "/usr/share/mbrola/$voice_file" ]; then
-                voice_file="/usr/share/mbrola/$voice_file"
-        elif [ -f "/usr/share/mbrola/$voice_file/$voice_file" ]; then
-                voice_file="/usr/share/mbrola/$voice_file/$voice_file"
-        elif [ -f "/usr/share/mbrola/voices/$voice_file" ]; then
-                voice_file="/usr/share/mbrola/voices/$voice_file"
-        else
-                voice_file=""
-        fi
+        voice_name=${1#mb-} # remove mb- prefix
+        voice_name=${voice_name%+*} # remove variant suffix
+        voice_file=""
+
+        data_path="${ESPEAK_DATA_PATH:-`pwd`}"
+        for candidate in \
+                "$data_path/espeak-ng-data/mbrola/$voice_name" \
+                "$data_path/mbrola/$voice_name" ; do
+                if [ -f "$candidate" ] ; then
+                        voice_file="$candidate"
+                        return
+                fi
+        done
+
+        # Split the colon-separated dir list without losing paths with spaces.
+        old_ifs=$IFS
+        IFS=:
+        set -- ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+        IFS=$old_ifs
+        for dir in "$@" ; do
+                for candidate in \
+                        "$dir/mbrola/$voice_name" \
+                        "$dir/mbrola/$voice_name/$voice_name" \
+                        "$dir/mbrola/voices/$voice_name" ; do
+                        if [ -f "$candidate" ] ; then
+                                voice_file="$candidate"
+                                return
+                        fi
+                done
+        done
 }
 
 test_mb () {


### PR DESCRIPTION
## Problem

MBROLA voices cannot be used at all on macOS. `mbrowrap.c` opens `/proc/<pid>/stat` to poll whether the mbrola child process is still working or has gone idle. macOS has no procfs, so `start_mbrola()` fails immediately:

```
$ espeak-ng -v mb-en1 "Hello world"
mbrowrap error: /proc is unaccessible: No such file or directory
Error: Could not load the specified mbrola voice file.
```

The existing code has a Linux branch and a Solaris `psinfo` branch, and nothing else.

## Fix

`mbrola_is_idle()` gains a macOS implementation built on `libproc`. Two simpler-looking sources turned out not to work, and the reasons are recorded in a comment so they aren't "simplified" back later:

- **`proc_bsdinfo.pbi_status`** stays at `SRUN` even while the process is blocked, because XNU tracks run state per thread rather than per process. It never reports `SSLEEP`, so this would always answer "busy".
- **`proc_taskinfo.pti_numrunning`** counts threads *currently on a CPU*, so it reads zero for a process that is merely descheduled, or blocked in disk I/O while loading its voice database. That answers "idle" too early and truncates the stream.

What works is requiring every thread to be in `TH_STATE_WAITING` — the same thing the Linux path means by the `'S'` state character. `TH_STATE_UNINTERRUPTIBLE` (Linux `'D'`) is deliberately not idle.

One further guard is needed at startup. Until mbrola has produced its first byte, *"blocked having finished"* and *"blocked while still starting up"* (dyld, faulting in the voice database) are indistinguishable — both are a thread in a wait. Reporting idle there truncates the `.wav` header. A process that has not written anything yet is treated as busy; the caller's escalating poll timeout still catches a genuinely stalled mbrola.

That last part matters in practice: without it, synthesis failed for roughly 3% of runs under CPU load with `unable to get .wav header from mbrola`. The pre-existing `usleep(100)` WSL workaround just above the header read looks like the same race seen on another platform.

Linux and Solaris code paths are untouched — everything new is inside `#if defined(__APPLE__)`.

## Test lookup

`tests/mbrola.test` searched only `/usr/share/mbrola`, so it printed `was not tested` and passed vacuously anywhere else. It now mirrors the lookup `LoadMbrolaTable()` actually performs: the `espeak-ng-data` directory first, then each entry of `XDG_DATA_DIRS` (defaulting to `/usr/local/share:/usr/share`) across all three layouts.

This is not only a macOS fix — on Linux it also picks up voices installed under `/usr/local/share` or via a custom `XDG_DATA_DIRS`, which the old check missed.

## Testing

Verified on macOS 26.6.2 (arm64), Apple clang 21:

- `mb-fr4` and `mb-fr4+announcer` now produce output matching the SHA1 hashes `tests/mbrola.test` already expected — byte-identical to what the test was written against on Linux.
- Full suite green: `ctest --test-dir build --output-on-failure` → 20/20, repeated across parallel runs.
- 300 consecutive `mb-fr4` syntheses under full CPU saturation: zero mismatches. The same stress reproduced the failure reliably before the startup guard.
- Confirmed the test can still fail: with the voice removed it reports `was not tested`, and with a corrupted expected hash it exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)