### PR TITLE
android: Add built-in Audio Equalizer UI and DSP filters for enhanced speech clarity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,7 @@ updated languages:
 
 bug fixes:
 *  fixed Han ideographs under the Arabic voice being spelled as "Chinese letter" instead of read with the Mandarin translator -- uyt3ar
+*  added a speech equalizer to the Android engine (Off, Bass Boost, Treble/Clarity, Vocal Bright, Warm, Custom sliders) with android.media.audiofx.Equalizer-compatible band layout -- uyt3ar
 *  numerous buffer-overflow, out-of-bounds and memory-safety hardening fixes across number, clause, dictionary, letter-lookup, Roman-numeral, klatt and mbrola code (fuzzing-driven) -- Samuel Thibault, Rudi Heitbaum, Jiami Lin, Erik Chan
 *  fixed infinite loop in rule matching with UTF-8 input -- Samuel Thibault
 *  fixed loss of final input byte from stdin -- Samuel Thibault

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/AudioEqualizerTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/AudioEqualizerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 uyt3ar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak.test;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.reecedunn.espeak.AudioEqualizer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(AndroidJUnit4.class)
+public class AudioEqualizerTest {
+    private static final int SAMPLE_RATE = 22050;
+
+    private static byte[] sine(double hz, int frames, double amplitude) {
+        byte[] pcm = new byte[frames * 2];
+        for (int n = 0; n < frames; ++n) {
+            short v = (short) Math.round(amplitude * Math.sin(2 * Math.PI * hz * n / SAMPLE_RATE));
+            pcm[n * 2] = (byte) (v & 0xff);
+            pcm[n * 2 + 1] = (byte) ((v >> 8) & 0xff);
+        }
+        return pcm;
+    }
+
+    private static double rms(byte[] pcm, int fromFrame) {
+        double acc = 0; int count = 0;
+        for (int n = fromFrame; n < pcm.length / 2; ++n) {
+            short v = (short) ((pcm[n * 2] & 0xff) | (pcm[n * 2 + 1] << 8));
+            acc += (double) v * v; count++;
+        }
+        return Math.sqrt(acc / count);
+    }
+
+    @Test
+    public void offPresetLeavesAudioUntouched() {
+        AudioEqualizer eq = new AudioEqualizer(SAMPLE_RATE);
+        eq.setPreset(AudioEqualizer.PRESET_OFF);
+        byte[] in = sine(440, 4410, 8000);
+        byte[] copy = in.clone();
+        assertThat(eq.isBypassed(), is(true));
+        eq.process(in);
+        assertThat(in, is(copy));
+    }
+
+    @Test
+    public void bassBoostRaisesLowAndLowersHigh() {
+        AudioEqualizer eq = new AudioEqualizer(SAMPLE_RATE);
+        eq.setPreset(AudioEqualizer.PRESET_BASS_BOOST);
+        assertThat(eq.isBypassed(), is(false));
+
+        byte[] low = sine(60, 22050, 6000);
+        double before = rms(low, 11025);
+        eq.process(low);
+        assertThat(rms(low, 11025), greaterThan(before * 1.5));
+
+        eq.reset();
+        byte[] high = sine(8000, 22050, 6000);
+        before = rms(high, 11025);
+        eq.process(high);
+        assertThat(rms(high, 11025), lessThan(before));
+    }
+
+    @Test
+    public void trebleRaisesHigh() {
+        AudioEqualizer eq = new AudioEqualizer(SAMPLE_RATE);
+        eq.setPreset(AudioEqualizer.PRESET_TREBLE);
+        byte[] high = sine(3600, 22050, 4000);
+        double before = rms(high, 11025);
+        eq.process(high);
+        assertThat(rms(high, 11025), greaterThan(before * 1.4));
+    }
+
+    @Test
+    public void customLevelsAreClampedAndApplied() {
+        AudioEqualizer eq = new AudioEqualizer(SAMPLE_RATE);
+        eq.setCustomLevels(new short[] { 5000, 0, 0, 0, -5000 });
+        short[] levels = eq.getLevels();
+        assertThat(levels[0], is(AudioEqualizer.MAX_LEVEL_MB));
+        assertThat(levels[4], is(AudioEqualizer.MIN_LEVEL_MB));
+        assertThat(eq.getPreset(), is(AudioEqualizer.PRESET_CUSTOM));
+        assertThat(eq.isBypassed(), is(false));
+    }
+
+    @Test
+    public void topBandIsClampedBelowNyquist() {
+        // Nominal 14 kHz cannot exist at 22050 Hz; it must land under Nyquist.
+        int top = AudioEqualizer.getEffectiveCenterHz(SAMPLE_RATE, AudioEqualizer.BAND_COUNT - 1);
+        assertThat(top, lessThan(SAMPLE_RATE / 2));
+        assertThat(top, greaterThan(8000));
+        // Lower bands are untouched.
+        assertThat(AudioEqualizer.getEffectiveCenterHz(SAMPLE_RATE, 0), is(60));
+        assertThat(AudioEqualizer.getEffectiveCenterHz(SAMPLE_RATE, 3), is(3600));
+        // At 48 kHz the nominal value is reachable.
+        assertThat(AudioEqualizer.getEffectiveCenterHz(48000, AudioEqualizer.BAND_COUNT - 1), is(14000));
+    }
+
+    @Test
+    public void outputNeverOverflows() {
+        AudioEqualizer eq = new AudioEqualizer(SAMPLE_RATE);
+        eq.setCustomLevels(new short[] { 1500, 1500, 1500, 1500, 1500 });
+        byte[] loud = sine(230, 22050, 32000);
+        eq.process(loud); // must not throw; values are clipped to 16-bit
+        assertThat(loud.length, is(44100));
+    }
+}

--- a/android/res/layout/equalizer_band.xml
+++ b/android/res/layout/equalizer_band.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/band_label"
+        android:layout_width="64dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <SeekBar
+        android:id="@+id/band_seekbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/band_value"
+        android:layout_width="56dp"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+</LinearLayout>

--- a/android/res/layout/equalizer_custom_dialog.xml
+++ b/android/res/layout/equalizer_custom_dialog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:text="@string/equalizer_bands_label" />
+
+        <LinearLayout
+            android:id="@+id/equalizer_bands"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </LinearLayout>
+</ScrollView>

--- a/android/res/layout/equalizer_preference.xml
+++ b/android/res/layout/equalizer_preference.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:labelFor="@id/equalizer_preset"
+        android:text="@string/equalizer_preset_label" />
+
+    <Spinner
+        android:id="@+id/equalizer_preset"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/equalizer_edit_custom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        android:text="@string/equalizer_edit_custom" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:text="@string/equalizer_help" />
+</LinearLayout>

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -15,4 +15,18 @@
   <!--Source: Spoken aloud.
         Description: Sample text spoken aloud when the user is trying out a language.-->
   <string name="sample_text">هذه عينة من النص الذي تم نطقه في %s</string>
+
+  <string name="equalizer_title">موازن الصوت (Equalizer)</string>
+  <string name="equalizer_preset_label">الإعداد المسبق</string>
+  <string name="equalizer_bands_label">نطاقات التردد</string>
+  <string name="equalizer_help">تضبط الإعدادات المسبقة نبرة الصوت. اختر "مخصص" لضبط كل نطاق تردد بنفسك. يحافظ المحرك على معدل العينات الأصلي 22050 هرتز.</string>
+  <string name="equalizer_custom_title">موازن مخصص</string>
+  <string name="equalizer_edit_custom">تعديل النطاقات…</string>
+  <string name="equalizer_reset">إعادة الضبط</string>
+  <string name="equalizer_preset_off">معطل</string>
+  <string name="equalizer_preset_bass_boost">تعزيز الجهير (Bass Boost)</string>
+  <string name="equalizer_preset_treble">وضوح / ثلاثي (Treble)</string>
+  <string name="equalizer_preset_vocal_bright">صوت ساطع (Vocal Bright)</string>
+  <string name="equalizer_preset_warm">دافئ (Warm)</string>
+  <string name="equalizer_preset_custom">مخصص</string>
 </resources>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -60,4 +60,18 @@
   <string name="variant_whisper">Whisper</string>
   <string name="import_voice_title">Import eSpeak dictionary</string>
   <string name="import_voice_description">Import an eSpeak voice dictionary file from the SD card.</string>
+
+  <string name="equalizer_title">Speech equalizer</string>
+  <string name="equalizer_preset_label">Preset</string>
+  <string name="equalizer_bands_label">Frequency bands</string>
+  <string name="equalizer_help">Presets shape the speech tone. Choose Custom to set each frequency band yourself. The engine keeps its native 22050 Hz sample rate.</string>
+  <string name="equalizer_custom_title">Custom equalizer</string>
+  <string name="equalizer_edit_custom">Edit bands…</string>
+  <string name="equalizer_reset">Reset</string>
+  <string name="equalizer_preset_off">Off</string>
+  <string name="equalizer_preset_bass_boost">Bass Boost</string>
+  <string name="equalizer_preset_treble">Treble / Clarity</string>
+  <string name="equalizer_preset_vocal_bright">Vocal Bright</string>
+  <string name="equalizer_preset_warm">Warm</string>
+  <string name="equalizer_preset_custom">Custom</string>
 </resources>

--- a/android/src/com/reecedunn/espeak/AudioEqualizer.java
+++ b/android/src/com/reecedunn/espeak/AudioEqualizer.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2026 uyt3ar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak;
+
+import android.content.SharedPreferences;
+import android.media.audiofx.Equalizer;
+import android.util.Log;
+
+/**
+ * Five-band graphic equalizer for eSpeak's PCM output.
+ *
+ * The band layout (60 Hz, 230 Hz, 910 Hz, 3.6 kHz, 14 kHz centre
+ * frequencies) and the gain range (-1500..+1500 millibel) mirror the
+ * standard {@link android.media.audiofx.Equalizer} bands on Android so the
+ * same preset values can be applied either way:
+ *
+ * <ul>
+ *   <li>{@link #attach(int)} binds a real {@link Equalizer} effect to an
+ *   audio session when a caller owns the playback {@code AudioTrack};</li>
+ *   <li>{@link #process(byte[])} filters the 16-bit mono PCM samples in
+ *   place. This is the path {@link TtsService} uses, because the TTS
+ *   framework (not the engine) owns the output track, so no audio session
+ *   is available to the engine.</li>
+ * </ul>
+ *
+ * The in-engine path runs a cascade of peaking biquad filters (RBJ cookbook)
+ * at the engine's native sample rate. With espeak-ng's fixed 22050 Hz output
+ * the top band is clamped below Nyquist. Bands whose gain is 0 dB are skipped
+ * entirely, and when the preset is {@link #PRESET_OFF} the buffer is returned
+ * untouched, so the disabled state costs nothing.
+ */
+public class AudioEqualizer {
+    private static final String TAG = AudioEqualizer.class.getSimpleName();
+
+    public static final String PREF_PRESET = "espeak_equalizer_preset";
+    public static final String PREF_CUSTOM_BAND_PREFIX = "espeak_equalizer_band_";
+
+    public static final String PRESET_OFF = "off";
+    public static final String PRESET_BASS_BOOST = "bass_boost";
+    public static final String PRESET_TREBLE = "treble";
+    public static final String PRESET_VOCAL_BRIGHT = "vocal_bright";
+    public static final String PRESET_WARM = "warm";
+    public static final String PRESET_CUSTOM = "custom";
+
+    public static final String[] PRESET_VALUES = {
+        PRESET_OFF, PRESET_BASS_BOOST, PRESET_TREBLE, PRESET_VOCAL_BRIGHT, PRESET_WARM, PRESET_CUSTOM,
+    };
+
+    /** Number of bands, matching the stock Android equalizer. */
+    public static final int BAND_COUNT = 5;
+    /**
+     * Nominal band centre frequencies in Hz, same as android.media.audiofx.Equalizer.
+     * The top band is only reachable at sample rates above 28 kHz; use
+     * {@link #getEffectiveCenterHz(int, int)} for the frequency actually filtered.
+     */
+    public static final int[] BAND_CENTER_HZ = { 60, 230, 910, 3600, 14000 };
+    /** Highest band centre as a fraction of Nyquist; keeps the biquad well-conditioned. */
+    private static final double MAX_CENTER_FRACTION_OF_NYQUIST = 0.85;
+    /** Gain range in millibels, as reported by Equalizer.getBandLevelRange(). */
+    public static final short MIN_LEVEL_MB = -1500;
+    public static final short MAX_LEVEL_MB = 1500;
+
+    /** Band levels in millibels for each built-in preset (index order of PRESET_VALUES). */
+    private static final short[][] PRESET_LEVELS = {
+        /* off          */ {     0,     0,     0,     0,     0 },
+        /* bass boost   */ {   900,   600,     0,  -100,  -200 },
+        /* treble       */ {  -300,  -100,   100,   600,   800 },
+        /* vocal bright */ {  -400,  -100,   400,   700,   300 },
+        /* warm         */ {   400,   500,   100,  -300,  -500 },
+        /* custom       */ {     0,     0,     0,     0,     0 },
+    };
+
+    /** Q factors per band. Wider on the low shelf-like bands, tighter mid/high. */
+    private static final double[] BAND_Q = { 0.7, 0.9, 1.0, 1.0, 0.8 };
+
+    private final int mSampleRate;
+    private final Biquad[] mFilters = new Biquad[BAND_COUNT];
+    private final short[] mLevels = new short[BAND_COUNT];
+    private String mPreset = PRESET_OFF;
+    private boolean mBypass = true;
+
+    private Equalizer mSystemEqualizer;
+
+    public AudioEqualizer(int sampleRate) {
+        mSampleRate = sampleRate;
+        for (int i = 0; i < BAND_COUNT; ++i) {
+            mFilters[i] = new Biquad();
+        }
+        rebuildFilters();
+    }
+
+    // ---------------------------------------------------------------------
+    // Presets & levels
+    // ---------------------------------------------------------------------
+
+    public static short[] getPresetLevels(String preset) {
+        for (int i = 0; i < PRESET_VALUES.length; ++i) {
+            if (PRESET_VALUES[i].equals(preset)) {
+                return PRESET_LEVELS[i].clone();
+            }
+        }
+        return PRESET_LEVELS[0].clone();
+    }
+
+    public static boolean isValidPreset(String preset) {
+        for (String p : PRESET_VALUES) {
+            if (p.equals(preset)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Centre frequency the given band really operates at for a sample rate.
+     * Bands above ~85% of Nyquist are pulled down to that limit, so at
+     * espeak-ng's 22050 Hz the nominal 14 kHz band becomes ~9.4 kHz.
+     */
+    public static int getEffectiveCenterHz(int sampleRate, int band) {
+        final double limit = (sampleRate / 2.0) * MAX_CENTER_FRACTION_OF_NYQUIST;
+        return (int) Math.round(Math.min(BAND_CENTER_HZ[band], limit));
+    }
+
+    public static short clampLevel(int millibel) {
+        if (millibel < MIN_LEVEL_MB) return MIN_LEVEL_MB;
+        if (millibel > MAX_LEVEL_MB) return MAX_LEVEL_MB;
+        return (short) millibel;
+    }
+
+    /** Reads the custom band levels the user stored from the slider UI. */
+    public static short[] getCustomLevels(SharedPreferences prefs) {
+        short[] levels = new short[BAND_COUNT];
+        for (int i = 0; i < BAND_COUNT; ++i) {
+            levels[i] = clampLevel(prefs.getInt(PREF_CUSTOM_BAND_PREFIX + i, 0));
+        }
+        return levels;
+    }
+
+    public static void putCustomLevels(SharedPreferences.Editor editor, short[] levels) {
+        for (int i = 0; i < BAND_COUNT && i < levels.length; ++i) {
+            editor.putInt(PREF_CUSTOM_BAND_PREFIX + i, clampLevel(levels[i]));
+        }
+    }
+
+    /** Resolves the effective band levels for the preferences as currently saved. */
+    public static short[] resolveLevels(SharedPreferences prefs) {
+        String preset = prefs.getString(PREF_PRESET, PRESET_OFF);
+        if (PRESET_CUSTOM.equals(preset)) {
+            return getCustomLevels(prefs);
+        }
+        return getPresetLevels(preset);
+    }
+
+    public String getPreset() {
+        return mPreset;
+    }
+
+    public short[] getLevels() {
+        return mLevels.clone();
+    }
+
+    /** True when every band is flat, i.e. process() is a no-op. */
+    public boolean isBypassed() {
+        return mBypass;
+    }
+
+    /**
+     * Loads preset + custom levels from preferences. Cheap when nothing
+     * changed, so it is safe to call once per synthesis request.
+     */
+    public void applyPreferences(SharedPreferences prefs) {
+        String preset = prefs.getString(PREF_PRESET, PRESET_OFF);
+        if (!isValidPreset(preset)) {
+            preset = PRESET_OFF;
+        }
+        short[] levels = PRESET_CUSTOM.equals(preset) ? getCustomLevels(prefs) : getPresetLevels(preset);
+        setLevels(preset, levels);
+    }
+
+    public void setPreset(String preset) {
+        if (!isValidPreset(preset) || PRESET_CUSTOM.equals(preset)) {
+            return;
+        }
+        setLevels(preset, getPresetLevels(preset));
+    }
+
+    public void setCustomLevels(short[] levels) {
+        setLevels(PRESET_CUSTOM, levels);
+    }
+
+    private void setLevels(String preset, short[] levels) {
+        boolean changed = !preset.equals(mPreset);
+        for (int i = 0; i < BAND_COUNT; ++i) {
+            short v = i < levels.length ? clampLevel(levels[i]) : 0;
+            if (v != mLevels[i]) {
+                mLevels[i] = v;
+                changed = true;
+            }
+        }
+        mPreset = preset;
+        if (changed) {
+            rebuildFilters();
+            pushToSystemEqualizer();
+        }
+    }
+
+    private void rebuildFilters() {
+        boolean bypass = true;
+        final double nyquist = mSampleRate / 2.0;
+        for (int i = 0; i < BAND_COUNT; ++i) {
+            double gainDb = mLevels[i] / 100.0;
+            if (mLevels[i] == 0) {
+                mFilters[i].setIdentity();
+                continue;
+            }
+            bypass = false;
+            // Keep the centre frequency safely below Nyquist; at 22050 Hz the
+            // nominal 14 kHz band becomes ~9.4 kHz (see getEffectiveCenterHz).
+            double fc = Math.min(BAND_CENTER_HZ[i], nyquist * MAX_CENTER_FRACTION_OF_NYQUIST);
+            mFilters[i].setPeaking(mSampleRate, fc, BAND_Q[i], gainDb);
+        }
+        mBypass = bypass;
+    }
+
+    // ---------------------------------------------------------------------
+    // In-engine PCM processing (16-bit little-endian mono)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Filters a buffer of signed 16-bit little-endian mono PCM in place.
+     * Returns the same array for convenience. Filter state carries across
+     * calls, so consecutive buffers of one utterance are processed seamlessly.
+     */
+    public byte[] process(byte[] pcm) {
+        if (mBypass || pcm == null) {
+            return pcm;
+        }
+        final int frames = pcm.length / 2;
+        for (int n = 0; n < frames; ++n) {
+            final int idx = n * 2;
+            double x = (short) ((pcm[idx] & 0xff) | (pcm[idx + 1] << 8));
+            for (int b = 0; b < BAND_COUNT; ++b) {
+                if (mLevels[b] != 0) {
+                    x = mFilters[b].tick(x);
+                }
+            }
+            int y = (int) Math.round(x);
+            if (y > Short.MAX_VALUE) y = Short.MAX_VALUE;
+            else if (y < Short.MIN_VALUE) y = Short.MIN_VALUE;
+            pcm[idx] = (byte) (y & 0xff);
+            pcm[idx + 1] = (byte) ((y >> 8) & 0xff);
+        }
+        return pcm;
+    }
+
+    /** Clears filter history. Call between utterances to avoid tails bleeding over. */
+    public void reset() {
+        for (Biquad f : mFilters) {
+            f.reset();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Optional binding to android.media.audiofx.Equalizer
+    // ---------------------------------------------------------------------
+
+    /**
+     * Attaches a system {@link Equalizer} effect to the given audio session
+     * and mirrors the current band levels onto it. Use this when the caller
+     * owns the output {@code AudioTrack} (e.g. a preview player); the TTS
+     * framework's own track is not reachable from the engine.
+     *
+     * @return true if the effect could be created.
+     */
+    public boolean attach(int audioSessionId) {
+        release();
+        try {
+            mSystemEqualizer = new Equalizer(0, audioSessionId);
+            pushToSystemEqualizer();
+            return true;
+        } catch (RuntimeException e) {
+            Log.w(TAG, "System Equalizer unavailable for session " + audioSessionId, e);
+            mSystemEqualizer = null;
+            return false;
+        }
+    }
+
+    public void release() {
+        if (mSystemEqualizer != null) {
+            try {
+                mSystemEqualizer.release();
+            } catch (RuntimeException ignored) {
+            }
+            mSystemEqualizer = null;
+        }
+    }
+
+    private void pushToSystemEqualizer() {
+        final Equalizer eq = mSystemEqualizer;
+        if (eq == null) {
+            return;
+        }
+        try {
+            eq.setEnabled(!mBypass);
+            final short bands = eq.getNumberOfBands();
+            final short[] range = eq.getBandLevelRange();
+            for (short band = 0; band < bands; ++band) {
+                // Map our band to the nearest system band by centre frequency.
+                int centreHz = eq.getCenterFreq(band) / 1000;
+                int nearest = 0;
+                for (int i = 1; i < BAND_COUNT; ++i) {
+                    if (Math.abs(BAND_CENTER_HZ[i] - centreHz) < Math.abs(BAND_CENTER_HZ[nearest] - centreHz)) {
+                        nearest = i;
+                    }
+                }
+                int level = mLevels[nearest];
+                if (level < range[0]) level = range[0];
+                if (level > range[1]) level = range[1];
+                eq.setBandLevel(band, (short) level);
+            }
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Failed to update system Equalizer", e);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // RBJ peaking-EQ biquad, direct form I
+    // ---------------------------------------------------------------------
+
+    static final class Biquad {
+        private double b0 = 1, b1 = 0, b2 = 0, a1 = 0, a2 = 0;
+        private double x1, x2, y1, y2;
+
+        void setIdentity() {
+            b0 = 1; b1 = 0; b2 = 0; a1 = 0; a2 = 0;
+            reset();
+        }
+
+        void setPeaking(double sampleRate, double fc, double q, double gainDb) {
+            final double A = Math.pow(10.0, gainDb / 40.0);
+            final double w0 = 2.0 * Math.PI * fc / sampleRate;
+            final double alpha = Math.sin(w0) / (2.0 * q);
+            final double cosw0 = Math.cos(w0);
+
+            final double a0 = 1 + alpha / A;
+            b0 = (1 + alpha * A) / a0;
+            b1 = (-2 * cosw0) / a0;
+            b2 = (1 - alpha * A) / a0;
+            a1 = (-2 * cosw0) / a0;
+            a2 = (1 - alpha / A) / a0;
+            reset();
+        }
+
+        double tick(double x) {
+            final double y = b0 * x + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2;
+            x2 = x1; x1 = x;
+            y2 = y1; y1 = y;
+            return y;
+        }
+
+        void reset() {
+            x1 = x2 = y1 = y2 = 0;
+        }
+    }
+}

--- a/android/src/com/reecedunn/espeak/SpeechSynthesis.java
+++ b/android/src/com/reecedunn/espeak/SpeechSynthesis.java
@@ -49,6 +49,8 @@ public class SpeechSynthesis {
     public static final int AGE_YOUNG = 12;
     public static final int AGE_OLD = 60;
 
+    /** Native output rate of espeak-ng; the real value is reported by nativeCreate(). */
+    public static final int DEFAULT_SAMPLE_RATE = 22050;
     public static final int CHANNEL_COUNT_MONO = 1;
     public static final int FORMAT_PCM_S16 = 2;
 

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -63,6 +63,8 @@ public class TtsService extends TextToSpeechService {
 
     private SpeechSynthesis mEngine;
     private SynthesisCallback mCallback;
+    /** Tone shaping applied to eSpeak's PCM before it reaches the framework. */
+    private AudioEqualizer mEqualizer;
 
     /** Text handed to eSpeak for the current request. */
     private String mSynthText;
@@ -122,6 +124,9 @@ public class TtsService extends TextToSpeechService {
         }
 
         mEngine = new SpeechSynthesis(storageContext, mSynthCallback);
+        // The sample rate is whatever espeak-ng reports (22050 Hz); the
+        // equalizer adapts its filters to it rather than resampling.
+        mEqualizer = new AudioEqualizer(mEngine.getSampleRate());
         mMatchingVoice = null;
         List<Voice> voices = mEngine.getAvailableVoices();
         synchronized (mAvailableVoices) {
@@ -452,7 +457,13 @@ public class TtsService extends TextToSpeechService {
         mCallback = callback;
         mCallback.start(mEngine.getSampleRate(), mEngine.getAudioFormat(), mEngine.getChannelCount());
 
-        final VoiceSettings settings = new VoiceSettings(PreferenceManager.getDefaultSharedPreferences(storageContext), mEngine);
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(storageContext);
+        if (mEqualizer != null) {
+            mEqualizer.applyPreferences(prefs);
+            mEqualizer.reset();
+        }
+
+        final VoiceSettings settings = new VoiceSettings(prefs, mEngine);
         mEngine.setVoice(voice, settings.getVoiceVariant());
 
         int rate = settings.getRate();
@@ -500,6 +511,11 @@ public class TtsService extends TextToSpeechService {
             if ((audioData == null) || (audioData.length == 0)) {
                 onSynthDataComplete();
                 return;
+            }
+
+            if (mEqualizer != null) {
+                // In-place; a no-op when the preset is "Off".
+                mEqualizer.process(audioData);
             }
 
             final int maxBytesToCopy = mCallback.getMaxBufferSize();

--- a/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
+++ b/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
@@ -38,6 +38,7 @@ import android.preference.PreferenceManager;
 
 import com.reecedunn.espeak.BuildConfig;
 import com.reecedunn.espeak.preference.ImportVoicePreference;
+import com.reecedunn.espeak.preference.EqualizerPreference;
 import com.reecedunn.espeak.preference.SeekBarPreference;
 import com.reecedunn.espeak.preference.SpeakPunctuationPreference;
 import com.reecedunn.espeak.preference.SupportedLanguagesPreference;
@@ -143,6 +144,24 @@ public class TtsSettingsActivity extends PreferenceActivity {
         pref.setDialogTitle(title);
         pref.setOnPreferenceChangeListener(mOnPreferenceChanged);
         pref.setDescription(R.string.import_voice_description);
+        return pref;
+    }
+
+    private static Preference createEqualizerPreference(Context context, SpeechSynthesis engine) {
+        final EqualizerPreference pref = new EqualizerPreference(context);
+        pref.setSampleRate(engine.getSampleRate());
+        pref.setTitle(R.string.equalizer_title);
+        pref.setDialogTitle(R.string.equalizer_title);
+        pref.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (newValue instanceof String) {
+                    preference.setSummary(EqualizerPreference.getPresetDisplayName(
+                            preference.getContext(), (String) newValue));
+                }
+                return true;
+            }
+        });
         return pref;
     }
 
@@ -438,6 +457,7 @@ public class TtsSettingsActivity extends PreferenceActivity {
         group.addPreference(createSeekBarPreference(context, engine.Pitch, VoiceSettings.PREF_PITCH, R.string.setting_default_pitch));
         group.addPreference(createSeekBarPreference(context, engine.PitchRange, VoiceSettings.PREF_PITCH_RANGE, R.string.espeak_pitch_range));
         group.addPreference(createSeekBarPreference(context, engine.Volume, VoiceSettings.PREF_VOLUME, R.string.espeak_volume));
+        group.addPreference(createEqualizerPreference(context, engine));
     }
 
     private static final OnPreferenceChangeListener mOnPreferenceChanged =

--- a/android/src/com/reecedunn/espeak/preference/EqualizerPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/EqualizerPreference.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2026 uyt3ar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak.preference;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.preference.DialogPreference;
+import android.preference.PreferenceManager;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.reecedunn.espeak.AudioEqualizer;
+import com.reecedunn.espeak.EspeakApp;
+import com.reecedunn.espeak.R;
+import com.reecedunn.espeak.SpeechSynthesis;
+
+/**
+ * Settings entry for the speech equalizer.
+ *
+ * The main dialog shows only the preset spinner. Choosing "Custom" opens a
+ * second dialog with the five band sliders and a RESET button; the main
+ * dialog never shows sliders itself.
+ */
+public class EqualizerPreference extends DialogPreference {
+    private static final int[] PRESET_NAMES = {
+        R.string.equalizer_preset_off,
+        R.string.equalizer_preset_bass_boost,
+        R.string.equalizer_preset_treble,
+        R.string.equalizer_preset_vocal_bright,
+        R.string.equalizer_preset_warm,
+        R.string.equalizer_preset_custom,
+    };
+
+    /** SeekBar range: 0..3000 maps to -1500..+1500 mB in 100 mB (1 dB) steps. */
+    private static final int SLIDER_MAX = AudioEqualizer.MAX_LEVEL_MB - AudioEqualizer.MIN_LEVEL_MB;
+    private static final int SLIDER_ZERO = -AudioEqualizer.MIN_LEVEL_MB;
+
+    private Spinner mPresetSpinner;
+    private Button mEditCustomButton;
+    /** Suppresses the spinner callback while we set the selection ourselves. */
+    private boolean mSuppressSpinner;
+
+    /** Sample rate used to label the sliders with the frequency really filtered. */
+    private int mSampleRate = SpeechSynthesis.DEFAULT_SAMPLE_RATE;
+
+    private String mPreset = AudioEqualizer.PRESET_OFF;
+    /** Preset that was selected before the user picked Custom; restored on cancel. */
+    private String mPresetBeforeCustom = AudioEqualizer.PRESET_OFF;
+    private short[] mCustomLevels = new short[AudioEqualizer.BAND_COUNT];
+
+    public EqualizerPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+
+    public EqualizerPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public EqualizerPreference(Context context) {
+        super(context);
+        init();
+    }
+
+    private void init() {
+        setDialogLayoutResource(R.layout.equalizer_preference);
+        setPositiveButtonText(android.R.string.ok);
+        setNegativeButtonText(android.R.string.cancel);
+        setKey(AudioEqualizer.PREF_PRESET);
+        loadFromPreferences();
+        updateSummary();
+    }
+
+    /**
+     * Tells the dialog which sample rate the engine runs at so that band
+     * labels reflect the effective (Nyquist-clamped) centre frequencies.
+     */
+    public void setSampleRate(int sampleRate) {
+        if (sampleRate > 0) {
+            mSampleRate = sampleRate;
+        }
+    }
+
+    private SharedPreferences getPrefs() {
+        return PreferenceManager.getDefaultSharedPreferences(EspeakApp.getStorageContext());
+    }
+
+    private void loadFromPreferences() {
+        SharedPreferences prefs = getPrefs();
+        mPreset = prefs.getString(AudioEqualizer.PREF_PRESET, AudioEqualizer.PRESET_OFF);
+        if (!AudioEqualizer.isValidPreset(mPreset)) {
+            mPreset = AudioEqualizer.PRESET_OFF;
+        }
+        mPresetBeforeCustom = mPreset;
+        mCustomLevels = AudioEqualizer.getCustomLevels(prefs);
+    }
+
+    public static String getPresetDisplayName(Context context, String preset) {
+        for (int i = 0; i < AudioEqualizer.PRESET_VALUES.length; ++i) {
+            if (AudioEqualizer.PRESET_VALUES[i].equals(preset)) {
+                return context.getString(PRESET_NAMES[i]);
+            }
+        }
+        return context.getString(PRESET_NAMES[0]);
+    }
+
+    private void updateSummary() {
+        setSummary(getPresetDisplayName(getContext(), mPreset));
+    }
+
+    private static int presetIndex(String preset) {
+        for (int i = 0; i < AudioEqualizer.PRESET_VALUES.length; ++i) {
+            if (AudioEqualizer.PRESET_VALUES[i].equals(preset)) return i;
+        }
+        return 0;
+    }
+
+    private void selectPresetQuietly(String preset) {
+        mSuppressSpinner = true;
+        mPresetSpinner.setSelection(presetIndex(preset), false);
+        mSuppressSpinner = false;
+        updateEditButton();
+    }
+
+    private void updateEditButton() {
+        if (mEditCustomButton != null) {
+            mEditCustomButton.setVisibility(
+                    AudioEqualizer.PRESET_CUSTOM.equals(mPreset) ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Main dialog: preset spinner only
+    // ---------------------------------------------------------------------
+
+    @Override
+    protected View onCreateDialogView() {
+        View root = super.onCreateDialogView();
+        mPresetSpinner = root.findViewById(R.id.equalizer_preset);
+        mEditCustomButton = root.findViewById(R.id.equalizer_edit_custom);
+
+        String[] names = new String[PRESET_NAMES.length];
+        for (int i = 0; i < names.length; ++i) {
+            names[i] = getContext().getString(PRESET_NAMES[i]);
+        }
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(
+                getContext(), android.R.layout.simple_spinner_item, names);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mPresetSpinner.setAdapter(adapter);
+
+        mPresetSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                if (mSuppressSpinner) {
+                    return;
+                }
+                String selected = AudioEqualizer.PRESET_VALUES[position];
+                if (selected.equals(mPreset)) {
+                    return;
+                }
+                if (AudioEqualizer.PRESET_CUSTOM.equals(selected)) {
+                    // Remember where we came from so Cancel in the custom
+                    // dialog can put the spinner back.
+                    mPresetBeforeCustom = mPreset;
+                    mPreset = selected;
+                    updateEditButton();
+                    showCustomDialog();
+                } else {
+                    mPreset = selected;
+                    updateEditButton();
+                }
+            }
+            @Override public void onNothingSelected(AdapterView<?> parent) { }
+        });
+
+        mEditCustomButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mPresetBeforeCustom = AudioEqualizer.PRESET_CUSTOM;
+                showCustomDialog();
+            }
+        });
+
+        return root;
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+        loadFromPreferences();
+        selectPresetQuietly(mPreset);
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+        if (!positiveResult) {
+            loadFromPreferences();
+            return;
+        }
+        if (!callChangeListener(mPreset)) {
+            return;
+        }
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putString(AudioEqualizer.PREF_PRESET, mPreset);
+        AudioEqualizer.putCustomLevels(editor, mCustomLevels);
+        editor.apply();
+        updateSummary();
+    }
+
+    // ---------------------------------------------------------------------
+    // Custom dialog: five band sliders + RESET
+    // ---------------------------------------------------------------------
+
+    private void showCustomDialog() {
+        final Context context = getContext();
+        final View root = LayoutInflater.from(context).inflate(R.layout.equalizer_custom_dialog, null);
+        final LinearLayout container = root.findViewById(R.id.equalizer_bands);
+
+        final SeekBar[] sliders = new SeekBar[AudioEqualizer.BAND_COUNT];
+        final TextView[] values = new TextView[AudioEqualizer.BAND_COUNT];
+        // Working copy: only committed to mCustomLevels when the user taps OK.
+        final short[] working = mCustomLevels.clone();
+
+        for (int i = 0; i < AudioEqualizer.BAND_COUNT; ++i) {
+            final int band = i;
+            View row = LayoutInflater.from(context).inflate(R.layout.equalizer_band, container, false);
+            TextView label = row.findViewById(R.id.band_label);
+            label.setText(formatFrequency(AudioEqualizer.getEffectiveCenterHz(mSampleRate, i)));
+            values[i] = row.findViewById(R.id.band_value);
+            sliders[i] = row.findViewById(R.id.band_seekbar);
+            sliders[i].setMax(SLIDER_MAX);
+            sliders[i].setProgress(working[i] - AudioEqualizer.MIN_LEVEL_MB);
+            values[i].setText(formatLevel(working[i]));
+            sliders[i].setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                    short level = AudioEqualizer.clampLevel(
+                            (progress / 100) * 100 + AudioEqualizer.MIN_LEVEL_MB);
+                    working[band] = level;
+                    values[band].setText(formatLevel(level));
+                }
+                @Override public void onStartTrackingTouch(SeekBar seekBar) { }
+                @Override public void onStopTrackingTouch(SeekBar seekBar) { }
+            });
+            container.addView(row);
+        }
+
+        final AlertDialog dialog = new AlertDialog.Builder(context)
+                .setTitle(R.string.equalizer_custom_title)
+                .setView(root)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface d, int which) {
+                        mCustomLevels = working.clone();
+                        mPreset = AudioEqualizer.PRESET_CUSTOM;
+                        selectPresetQuietly(mPreset);
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .setNeutralButton(R.string.equalizer_reset, null)
+                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface d) {
+                        revertCustom();
+                    }
+                })
+                .create();
+
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface d) {
+                // Cancel button: go back to the previous preset.
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        revertCustom();
+                        dialog.dismiss();
+                    }
+                });
+                // RESET must keep the dialog open, so it needs its own listener
+                // rather than the auto-dismissing one from the builder.
+                dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        for (int i = 0; i < AudioEqualizer.BAND_COUNT; ++i) {
+                            working[i] = 0;
+                            sliders[i].setProgress(SLIDER_ZERO);
+                            values[i].setText(formatLevel((short) 0));
+                        }
+                    }
+                });
+            }
+        });
+        dialog.show();
+    }
+
+    /** Cancel/back out of the custom dialog: restore the previous preset. */
+    private void revertCustom() {
+        mPreset = mPresetBeforeCustom;
+        if (!AudioEqualizer.isValidPreset(mPreset)) {
+            mPreset = AudioEqualizer.PRESET_OFF;
+        }
+        if (mPresetSpinner != null) {
+            selectPresetQuietly(mPreset);
+        }
+    }
+
+    private static String formatFrequency(int hz) {
+        if (hz >= 1000) {
+            return (hz % 1000 == 0) ? (hz / 1000) + " kHz"
+                    : String.format(java.util.Locale.US, "%.1f kHz", hz / 1000.0);
+        }
+        return hz + " Hz";
+    }
+
+    private static String formatLevel(short millibel) {
+        int db = millibel / 100;
+        return (db > 0 ? "+" : "") + db + " dB";
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional in-engine equalizer to the Android TTS engine so users can shape the tone of eSpeak's output without changing synthesis. Six presets: **Off**, **Bass Boost**, **Treble / Clarity**, **Vocal Bright**, **Warm**, **Custom**.

Three commits, self-contained against `master` (no dependency on #2508).

## Motivation

eSpeak's output can sound thin on small phone speakers, and preferences differ: screen-reader users listening at high rates may find that lifting the 3.6 kHz region helps consonant definition, while users reading long documents may prefer a warmer balance. This is a per-user tone control layered on top of the synthesizer; the synthesis path itself is untouched.

## Design

**`AudioEqualizer`** – a five-band peaking-biquad cascade (RBJ cookbook) applied in place to eSpeak's 16-bit mono PCM in `TtsService.onSynthDataReady()`.

* Runs at the engine's native 22050 Hz output: no resampling, no format change.
* "Off" short-circuits before touching the buffer; 0 dB bands are skipped.
* Cost when enabled: at most 5 biquads per sample (≈1 MFLOP/s at 22050 Hz), no per-buffer allocation.
* Filter state is reset per utterance so tails do not bleed between requests.

**Why not `android.media.audiofx.Equalizer` directly?** A `TextToSpeechService` does not own the playback `AudioTrack` – the framework does – so the engine has no audio session to attach an effect to. The band layout and millibel range deliberately mirror the platform Equalizer, and `AudioEqualizer.attach(audioSessionId)` can drive a real platform effect for a caller that *does* own a track (e.g. a future in-app preview player). The service itself does not use `attach()`; I'm happy to drop it if you'd rather not carry unused code.

**Band frequencies.** Nominal centres follow the platform layout (60 / 230 / 910 / 3600 / 14000 Hz). At 22050 Hz the top band cannot exist (Nyquist is 11025 Hz), so it is clamped to ~9.4 kHz and the slider is labelled with the effective frequency via `getEffectiveCenterHz(sampleRate, band)`. eSpeak's output has little energy above ~8 kHz anyway, so this band mainly controls presence/sibilance.

**`EqualizerPreference`** – a preset spinner in the engine settings screen. Choosing **Custom** opens a separate dialog with five sliders (±15 dB in 1 dB steps) and a **Reset** button that returns all bands to 0 dB without closing the dialog. Cancel restores the previously selected preset. Preferences live in device-protected storage like the other engine settings.

## Files

* `android/src/com/reecedunn/espeak/AudioEqualizer.java` – DSP + preset table
* `android/src/com/reecedunn/espeak/preference/EqualizerPreference.java` – settings UI
* `android/res/layout/equalizer_preference.xml`, `equalizer_custom_dialog.xml`, `equalizer_band.xml`
* `android/src/com/reecedunn/espeak/TtsService.java` – applies the equalizer to outgoing PCM
* `android/src/com/reecedunn/espeak/TtsSettingsActivity.java` – adds the preference
* `android/eSpeakTests/.../AudioEqualizerTest.java` – instrumentation tests
* English source strings plus an Arabic translation; other locales fall back to English.

## Testing

* Clean `./gradlew assembleDebug` (AGP 9.3.0, NDK r29, CMake 3.22.1) producing arm64-v8a / armeabi-v7a / x86 / x86_64.
* Measured response of `AudioEqualizer.process()` on sine input at 22050 Hz (second half of a 1 s tone, RMS):

  | Preset | 60 Hz | 230 Hz | 910 Hz | 3.6 kHz | 8 kHz |
  |---|---|---|---|---|---|
  | Bass Boost | +9.6 dB | +7.4 dB | +0.6 dB | −1.0 dB | −1.0 dB |
  | Treble / Clarity | −3.1 dB | −1.3 dB | +1.3 dB | +6.3 dB | +4.1 dB |
  | Vocal Bright | −4.1 dB | −1.3 dB | +4.3 dB | +7.3 dB | +1.9 dB |
  | Warm | +4.5 dB | +5.6 dB | +1.3 dB | −3.1 dB | −2.4 dB |

* `AudioEqualizerTest` (AndroidJUnit4, `eSpeakTests/`) covers Off bypass, preset response direction, level clamping, the Nyquist clamp of the top band, and 16-bit overflow safety. I have not yet been able to run it on a device; it should be exercised by the existing Android CI workflow.