### PR TITLE
build: enable -Wimplicit-fallthrough for libespeak-ng

### DIFF
--- a/src/libespeak-ng/CMakeLists.txt
+++ b/src/libespeak-ng/CMakeLists.txt
@@ -64,6 +64,13 @@ if (NOT MSVC)
     "-Wimplicit"
     "-Wmisleading-indentation"
 
+    # SelectTranslator() in tr_languages.c is a ~1000-line switch, one case
+    # per language. A missing break silently gives one language another's
+    # langopts, and the language tests assert a hash of synthesised audio, so
+    # the failure reads as "wrong hash" rather than as a fall-through.
+    # Intentional fall-throughs are marked with ESPEAKNG_FALLTHROUGH.
+    "-Wimplicit-fallthrough"
+
     # All path buffers are sized to the platform path limit (PATH_MAX /
     # MAX_PATH) and written with snprintf. Truncation on a near-limit path
     # is therefore safe and deliberate. -Wformat-truncation fires whenever

--- a/src/libespeak-ng/common.h
+++ b/src/libespeak-ng/common.h
@@ -23,6 +23,18 @@
 #include "espeak-ng/espeak_ng.h"
 #include "translate.h"
 
+// Marks an intentional fall-through between switch cases. gcc also accepts a
+// "// fallthrough" comment, but clang honours only the attribute, so the
+// attribute is the form that works across both CI compilers.
+#if defined(__has_attribute)
+#if __has_attribute(fallthrough)
+#define ESPEAKNG_FALLTHROUGH __attribute__((fallthrough))
+#endif
+#endif
+#ifndef ESPEAKNG_FALLTHROUGH
+#define ESPEAKNG_FALLTHROUGH ((void)0)
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -2033,7 +2033,7 @@ static int CompilePhoneme(CompileContext *ctx, int compile_phoneme)
 				break;
 			case kWAV:
 				ctx->if_stack[ctx->if_level].returned = true;
-				// fallthrough:
+				ESPEAKNG_FALLTHROUGH;
 			case kVOWELSTART:
 			case kVOWELENDING:
 			case kANDWAV:
@@ -2063,7 +2063,7 @@ static int CompilePhoneme(CompileContext *ctx, int compile_phoneme)
 			case kINCLUDE:
 			case kPHONEMETABLE:
 				error(ctx, "Missing 'endphoneme' before '%s'", ctx->item_string);  // drop through to endphoneme
-				// fallthrough:
+				ESPEAKNG_FALLTHROUGH;
 			case kENDPHONEME:
 			case kENDPROCEDURE:
 				endphoneme = 1;

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -283,7 +283,7 @@ char *DecodeRule(const char *group_chars, int group_length, char *rule, int cont
 				break;
 			case RULE_PRE_ATSTART:
 				at_start = true;
-				// fallthrough:
+				ESPEAKNG_FALLTHROUGH;
 			case RULE_PRE:
 				match_type = RULE_PRE;
 				*p = 0;
@@ -879,7 +879,7 @@ static void copy_rule_string(CompileContext *ctx, char *string, int *state_out)
 
 				case 'Y':
 					c = 'I';
-					// fallthrough:
+					ESPEAKNG_FALLTHROUGH;
 				case 'A': // vowel
 				case 'B':
 				case 'C':
@@ -994,7 +994,7 @@ static void copy_rule_string(CompileContext *ctx, char *string, int *state_out)
 					break;
 				case 'P': // Prefix
 					sxflags |= SUFX_P;
-					// fallthrough
+					ESPEAKNG_FALLTHROUGH;
 				case 'S': // Suffix
 					output[ix++] = RULE_ENDING;
 					value = 0;

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -326,6 +326,7 @@ const char *EncodePhonemes(const char *p, char *outptr, int *bad_phoneme)
 				p++;
 				break;
 			}
+			ESPEAKNG_FALLTHROUGH;
 		default:
 			// lookup the phoneme mnemonic, find the phoneme with the highest number of
 			// matching characters
@@ -1039,7 +1040,7 @@ void SetWordStress(Translator *tr, char *output, unsigned int *dictionary_flags,
 		// stress on first syllable, unless it is a light syllable followed by a heavy syllable
 		if ((syllable_weight[1] > 0) || (syllable_weight[2] == 0))
 			break;
-		// fallthrough:
+		ESPEAKNG_FALLTHROUGH;
 	case STRESSPOSN_2L:
 		// stress on second syllable
 		if ((stressed_syllable == 0) && (vowel_count > 2)) {

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -1734,7 +1734,7 @@ static int TranslateNumber_1(Translator *tr, char *word, char *ph_out, char *ph_
 		{
 		case NUM_DFRACTION_4:
 			max_decimal_count = 5;
-			// fallthrough:
+			ESPEAKNG_FALLTHROUGH;
 		case NUM_DFRACTION_2:
 			// French/Polish decimal fraction
 			while (word[n_digits] == '0') {

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -846,7 +846,7 @@ Translator *SelectTranslator(const char *name)
 		break;
 	case L('e', 't'): // Estonian
 		tr->encoding = ESPEAKNG_ENCODING_ISO_8859_4;
-		// fallthrough:
+		ESPEAKNG_FALLTHROUGH;
 	case L('f', 'i'): // Finnish
 	{
 		tr->langopts.long_stop = 130;

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -1050,7 +1050,8 @@ void SetEmbedded(int control, int value)
 	switch (command)
 	{
 	case EMBED_T:
-		WavegenSetEcho(); // and drop through to case P
+		WavegenSetEcho();
+		ESPEAKNG_FALLTHROUGH; // and drop through to case P
 	case EMBED_P:
 		SetPitchFormants();
 		break;
@@ -1328,14 +1329,16 @@ static int WavegenFill2(void)
 			wdata.mix_wavefile = (unsigned char *)q[2];
 			break;
 		case WCMD_SPECT2: // as WCMD_SPECT but stop any concurrent wave file
-			wdata.n_mix_wavefile = 0; // ... and drop through to WCMD_SPECT case
+			wdata.n_mix_wavefile = 0;
+			ESPEAKNG_FALLTHROUGH; // ... and drop through to WCMD_SPECT case
 		case WCMD_SPECT:
 			echo_complete = echo_length;
 			result = Wavegen(length & 0xffff, q[1] >> 16, resume, (frame_t *)q[2], (frame_t *)q[3], wvoice);
 			break;
 #if USE_KLATT
 		case WCMD_KLATT2: // as WCMD_SPECT but stop any concurrent wave file
-			wdata.n_mix_wavefile = 0; // ... and drop through to WCMD_SPECT case
+			wdata.n_mix_wavefile = 0;
+			ESPEAKNG_FALLTHROUGH; // ... and drop through to WCMD_KLATT case
 		case WCMD_KLATT:
 			echo_complete = echo_length;
 			result = Wavegen_Klatt(length & 0xffff, resume, (frame_t *)q[2], (frame_t *)q[3], &wdata, wvoice);


### PR DESCRIPTION
Closes #2476.

`SelectTranslator()` in `tr_languages.c` is a ~1000-line switch with one case per language. A missing `break` silently hands one language another language's `langopts`, and nothing in the build catches it. Because `tests/language-phonemes.test` asserts a sha1 of synthesised audio, the failure reads as `wrong hash:`, and the natural next step of pasting in the new hash converts the regression into a passing test.

This enables `-Wimplicit-fallthrough` on the `espeak-ng` target and annotates the existing intentional fall-throughs.

### Verification

Reintroducing the exact bug from the issue, deleting the `break;` that closes `case L('o','m')` so Oromo falls into the next language, is caught by both CI compilers:

```
gcc 16.2.1:
  tr_languages.c:1346:39: warning: this statement may fall through [-Wimplicit-fallthrough=]
  tr_languages.c:1348:9: note: here

clang 22.1.8:
  tr_languages.c:1348:2: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
```

With the bug removed, both compilers build the tree with zero warnings and `ctest` passes 19/19, including with `-DUSE_LIBPCAUDIO=ON`.

### Two corrections to the issue

The issue reports that clang catches this shape and gcc does not, and estimates the cost at one annotation. Neither held up on current toolchains, which is worth recording since the issue argues the flag is worth having *because* CI runs clang:

**gcc does catch it.** The braced-compound-body case is caught by gcc 16 as shown above, so the gcc jobs get the check too, not just the clang ones. Detection has presumably improved since the issue was filed.

**The cost is twelve annotations, not one.** All twelve are pre-existing and intentional. Measured against pristine master with `-Wimplicit-fallthrough` added:

| | sites flagged in `libespeak-ng` |
| --- | --- |
| gcc 16.2.1 | 10 |
| clang 22.1.8 | 12 |

The twelve here are the union. The two gcc misses are worth noting because they cut in opposite directions:

- `numbers.c:1737` is a real fall-through that gcc does not detect at all. It stays silent there even with the comment deleted entirely, so this is a detection gap rather than anything to do with the marker.
- `compiledict.c:997` carries a bare `// fallthrough` comment, which gcc accepts and clang ignores.

The remaining ten split into seven `// fallthrough:` comments and four prose markers such as `// and drop through to case P` that neither compiler recognises.

### Why a macro rather than comments

Dropping the colons from the existing comments is the smaller diff and would satisfy gcc, but clang does not honour comment markers in any form. Verified directly:

| marker | gcc | clang |
| --- | --- | --- |
| `// fallthrough:` | warns | warns |
| `// fallthrough` | accepted | warns |
| `__attribute__((fallthrough))` | accepted | accepted |

Since CI runs a `[gcc, clang]` matrix, comments would leave half of it failing. The sites now use an `ESPEAKNG_FALLTHROUGH` macro in `common.h` that expands to `__attribute__((fallthrough))` where `__has_attribute` reports it and to `((void)0)` otherwise, so MSVC and other compilers are unaffected. It is also more robust than a comment, which silently stops working if someone rewords it.

### Scope

The flag is set on the `espeak-ng` target rather than globally, so the vendored `src/ucd-tools` subtree is untouched. That subtree has warnings of its own, two under gcc and one under clang.

Two corrections to what this section said originally, since both turned out to be wrong on a closer look.

The shared warning site (`proplist.c:1745`) is **not** a bug. `case 0x2600:` falls into `case 0x2700:`, whose body is `return UCD_PROPERTY_PATTERN_SYNTAX;`, and that is exactly what the sibling cases return explicitly. It is one line of code-golf, unannotated but correct.

The reason given for leaving the subtree alone, that it tracks a separate upstream, is also weaker than it looked. `rhdunn/ucd-tools` has had no push since 2021-05-09 and is not archived; the last upstream tag merged here was 2021-05-04; and the subtree has carried local commits ever since, including cmake support in 2022 and a PIC change in 2024. Whether a resync is still expected is the open question in the comment below, and if the subtree is effectively espeak-ng's code now I would rather widen the flag to cover it and annotate that site here than leave a known warning outside the check.

Also corrects a copy-paste error in the `WCMD_KLATT2` comment, which referred to the `WCMD_SPECT` case.

To be clear about what this does and does not do: no live fall-through bug exists in the tree today. Every site annotated here is deliberate. The value is preventing the next one, which the issue shows had already reached a PR in reviewable state with all 79 checks green.

The secondary point in the issue, that 26 `test_phwav` lines share the English phoneme string for languages whose tables cannot contain those phonemes, is untouched here and probably wants its own change.

