### PR TITLE
voices: fix out-of-bounds read when a voice identifier is shorter than the name

### DIFF
--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -1026,6 +1026,7 @@ espeak_VOICE *SelectVoiceByName(espeak_VOICE **voices, const char *name2)
 	int match_fname2 = -1;
 	int match_name = -1;
 	const char *id; // this is the filename within espeak-ng-data/voices
+	int id_len;
 	int last_part_len;
 	char last_part[41];
 	char name[40];
@@ -1047,9 +1048,10 @@ espeak_VOICE *SelectVoiceByName(espeak_VOICE **voices, const char *name2)
 			break;
 		} else {
 			id = voices[ix]->identifier;
+			id_len = strlen(id);
 			if (strcasecmp(name, id) == 0)
 				match_fname = ix; // matching identifier, use this if no matching name
-			else if (strcasecmp(last_part, &id[strlen(id)-last_part_len]) == 0)
+			else if ((id_len >= last_part_len) && (strcasecmp(last_part, &id[id_len-last_part_len]) == 0))
 				match_fname2 = ix;
 		}
 	}


### PR DESCRIPTION
`SelectVoiceByName()` compares the tail of each voice identifier against `"<PATHSEP><name>"`:

```c
else if (strcasecmp(last_part, &id[strlen(id)-last_part_len]) == 0)
```

`strlen()` returns `size_t` and `last_part_len` is `int`, so the subtraction is evaluated as unsigned. Any identifier shorter than `last_part` wraps it to a huge value, and `&id[...]` then forms a pointer outside the string that `strcasecmp()` reads from.

### When it triggers

Three voices sit at the top level of `espeak-ng-data/voices` rather than in a language-family subdirectory, so their identifiers are two characters: `eu`, `ko` and `qu`. Selecting any two-character voice name makes `last_part` three characters (`/en`), and the loop reaches those three identifiers with `strlen(id) < last_part_len`. The offset computes to `(size_t)-1`, so `strcasecmp()` reads `id[-1]`, one byte before the allocation.

This is the ordinary voice-selection path reached from `espeak_ng_SetVoiceByName()`, so it happens on essentially every run, including `espeak-ng -v en "hello"`. UndefinedBehaviorSanitizer, clang 22.1.8:

```
voices.c:1052:36: runtime error: addition of unsigned offset to 0x7c0d50de14ed overflowed to 0x7c0d50de14ec
    #0 SelectVoiceByName voices.c:1052
    #1 espeak_ng_SetVoiceByName voices.c:1332
    #2 main espeak-ng.c:647
```

It also fires during `ctest`, in the `voices` test on the `ka` case.

### Why CI has not caught it

The `ubsan` jobs already run with `halt_on_error=1`, but the `pointer-overflow` check is not being applied there. Locally, with the same `-fsanitize=undefined`:

| compiler | reports it |
| --- | --- |
| clang 22.1.8 | yes |
| gcc 16.2.1 | no |

The CI clang does not, so `ubuntu amd64: clang + ubsan` currently passes the `voices` test with no diagnostic.

The `valgrind` legs do not catch it either, and that is worth spelling out because it is the more surprising half. Running the matrix's own valgrind invocation over an unpatched build:

```
$ valgrind --track-origins=yes --leak-check=full --error-exitcode=1 \
    espeak-ng -q -x -v en "hello"
ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Zero errors, on a run where UBSan reports the out-of-bounds read. The reason is that `id[-1]` lands inside the same heap block as the identifier rather than outside any allocation, so memcheck has nothing to flag. It is a language-level violation, not a memory-level one, which is precisely the class valgrind is not built to see.

So the two tools the matrix does run are both blind to this, for different reasons. Nothing needs changing in CI for this PR; it is just why the bug has gone unnoticed.

### Fix

Hoist the length into an `int` and skip the comparison when the identifier is too short to contain `last_part`.

### No behaviour change

A spurious match was not reachable. It would require `id[-1]` to be `PATHSEP` and the rest of the identifier to equal `name`, but that case is already taken by the `strcasecmp(name, id)` branch above, so the out-of-bounds comparison could only ever fail. The change removes the undefined behaviour without altering which voice is selected.

Verified:

- Phoneme output byte-identical across all 151 voices, before and after, for a fixed test sentence.
- `ctest` 19/19 under gcc and clang, plain and with `-fsanitize=undefined`.
- Under clang `-fsanitize=undefined` with `halt_on_error=1`, the suite goes from 15 failures to 19/19 with zero runtime errors.
- Zero build warnings under both compilers.

