### PR TITLE
android: declare embedded synthesis in the TTS engine features

### DIFF
--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechServiceTest.java
@@ -290,7 +290,8 @@ public class TextToSpeechServiceTest
 
                 Set<String> features = mService.onGetFeaturesForLanguage(data.javaLanguage, data.javaCountry, data.variant);
                 assertThat(features, is(notNullValue()));
-                assertThat(features.size(), is(0));
+                assertThat(features, hasItem(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS));
+                assertThat(features.size(), is(1));
             }
         }
     }

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/TextToSpeechTest.java
@@ -137,7 +137,8 @@ public class TextToSpeechTest extends TextToSpeechTestCase
             assertThat(voice.getLocale().getCountry(), is(data.ianaCountry));
             assertThat(voice.getLocale().getVariant(), is(data.variant));
             assertThat(voice.getFeatures(), is(notNullValue()));
-            assertThat(voice.getFeatures().size(), is(0));
+            assertThat(voice.getFeatures(), hasItem(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS));
+            assertThat(voice.getFeatures().size(), is(1));
             assertThat(voice.getLatency(), is(android.speech.tts.Voice.LATENCY_VERY_LOW));
             assertThat(voice.getQuality(), is(android.speech.tts.Voice.QUALITY_NORMAL));
 
@@ -153,7 +154,8 @@ public class TextToSpeechTest extends TextToSpeechTestCase
             assertThat(voice2.getLocale().getCountry(), is(data.ianaCountry));
             assertThat(voice2.getLocale().getVariant(), is(data.variant));
             assertThat(voice2.getFeatures(), is(notNullValue()));
-            assertThat(voice2.getFeatures().size(), is(0));
+            assertThat(voice2.getFeatures(), hasItem(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS));
+            assertThat(voice2.getFeatures().size(), is(1));
             assertThat(voice2.getLatency(), is(android.speech.tts.Voice.LATENCY_VERY_LOW));
             assertThat(voice2.getQuality(), is(android.speech.tts.Voice.QUALITY_NORMAL));
         }

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -245,7 +245,14 @@ public class TtsService extends TextToSpeechService {
 
     @Override
     protected Set<String> onGetFeaturesForLanguage(String lang, String country, String variant) {
-        return new HashSet<String>();
+        // eSpeak synthesizes on the device for every language it offers, and never
+        // needs a network connection. Clients read this set -- directly, or through
+        // the features of the voices built in onGetVoices() -- to decide whether a
+        // language can be spoken offline; leaving it empty makes eSpeak look like an
+        // engine that cannot answer the question.
+        final Set<String> features = new HashSet<String>();
+        features.add(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS);
+        return features;
     }
 
     @Override


### PR DESCRIPTION
## Summary

`TtsService.onGetFeaturesForLanguage()` returned an empty `Set<String>` for every language, and `onGetVoices()` passes that same set into each `android.speech.tts.Voice` it builds. This declares `TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS` instead.

## Why

`TextToSpeech.getFeatures(Locale)` and `Voice.getFeatures()` are the only ways a client can ask an engine whether a language can be synthesized without a network connection. With an empty set, eSpeak answered "no information" to a question it can always answer affirmatively — it synthesizes entirely on the device, for every language it offers, and has no network path at all.

This came out of an audit of eSpeak against the engine-facing API surface that TalkBack uses. TalkBack performs exactly this check in `FailoverTextToSpeech.needsFallbackLocale()`:

```java
final Set<String> features = tts.getFeatures(mSystemLocale);
return !(((features != null) && features.contains(Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS))
    || !isNotAvailableStatus(tts.isLanguageAvailable(mSystemLocale)));
```

That particular call site is currently short-circuited for non-Google engines, so nothing was visibly broken. But the empty set is a genuine omission that propagates into every `Voice` object we hand out, and other clients read it.

## Behaviour

No change to synthesis. The key is advisory; requests already carrying it in their bundle were being satisfied regardless, since embedded synthesis is the only mode eSpeak has.

## Testing

Three assertions pinned the feature set to empty (`voice.getFeatures().size() == 0` in `TextToSpeechTest.testVoices()`, twice, and `features.size() == 0` in `TextToSpeechServiceTest.testLanguages()`). They now assert the set contains `KEY_FEATURE_EMBEDDED_SYNTHESIS` and has exactly one entry.

- `./gradlew assembleDebugAndroidTest` — passes; app and instrumentation test sources both compile.
- `./gradlew connectedDebugAndroidTest` for `TextToSpeechTest` and `TextToSpeechServiceTest` on an `espeak_phone34` AVD (API 34) — **14 tests, 0 failures, 0 skipped**. Details, plus a check that the new assertions are actually reached rather than skipped, are in the comment below.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
