### PR TITLE
Android: finish the voice settings dialog label cleanup

### DIFF
--- a/android/res/layout/seekbar_preference_section.xml
+++ b/android/res/layout/seekbar_preference_section.xml
@@ -11,18 +11,9 @@
     android:paddingBottom="8dp" >
 
     <TextView
-        android:id="@+id/parameterTitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-    <TextView
         android:id="@+id/valueText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:gravity="center_horizontal"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <SeekBar

--- a/android/res/layout/seekbar_preference_section.xml
+++ b/android/res/layout/seekbar_preference_section.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- One voice parameter: its name, its current value, the slider and the
-     controls that go with it. Inflated once per parameter by
+<!-- One voice parameter: a label carrying its name and current value, the
+     slider and the controls that go with it. Inflated once per parameter by
      SeekBarPreference. Every height is wrap_content: the sections live in a
      ScrollView, so weights would collapse them to nothing. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -10,16 +10,25 @@
     android:paddingTop="8dp"
     android:paddingBottom="8dp" >
 
+    <!-- SeekBarPreference writes the same string here and into the slider's
+         content description, so leaving this label in the accessibility tree
+         would announce every parameter twice. The slider is the thing you
+         operate, so it keeps the announcement and this label is skipped. -->
     <TextView
         android:id="@+id/valueText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
+        android:layout_marginStart="@dimen/parameter_bezel_inset"
+        android:layout_marginEnd="@dimen/parameter_bezel_inset"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <SeekBar
         android:id="@+id/seekBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/parameter_bezel_inset"
+        android:layout_marginEnd="@dimen/parameter_bezel_inset" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/res/values-watch/dimens.xml
+++ b/android/res/values-watch/dimens.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- A watch dialog hands its content the full width of the display, and on
+         a round watch that width runs under the bezel: at 384x384 the visible
+         chord starts around 5px alongside the label, so text laid out from
+         x=0 loses its first character and the slider track its ends.
+
+         Only the label and the slider are inset. The row below them is
+         already tight enough on a watch that the checkbox wraps, and taking
+         another 32px from it breaks the wrap outright. -->
+    <dimen name="parameter_bezel_inset">16dp</dimen>
+
+</resources>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- How far a voice parameter's label and slider stay clear of the edge of
+         the display. Zero here: the dialog a phone puts them in already
+         indents its content. See values-watch. -->
+    <dimen name="parameter_bezel_inset">0dp</dimen>
+
+</resources>

--- a/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
@@ -158,8 +158,6 @@ public class SeekBarPreference extends DialogPreference
         parameter.mValueText = (TextView) section.findViewById(R.id.valueText);
         parameter.mRateBoost = (CheckBox) section.findViewById(R.id.rateBoost);
 
-        ((TextView) section.findViewById(R.id.parameterTitle)).setText(parameter.title);
-
         final Button reset = (Button) section.findViewById(R.id.resetToDefault);
         // Every section carries an identically labelled button, so name the
         // parameter for anyone who reaches it with a screen reader.
@@ -326,7 +324,7 @@ public class SeekBarPreference extends DialogPreference
     private void updateValueText(Parameter parameter)
     {
         String text = String.format(parameter.formatter, Integer.toString(getDisplayValue(parameter)));
-        parameter.mValueText.setText(text);
+        parameter.mValueText.setText(parameter.title + ", " + text);
         // A bare "50%" is ambiguous once pitch and pitch variation share a
         // dialog, so the announcement carries the parameter name too. This
         // replaces the percentage of the slider's range that a SeekBar would

--- a/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
@@ -324,12 +324,16 @@ public class SeekBarPreference extends DialogPreference
     private void updateValueText(Parameter parameter)
     {
         String text = String.format(parameter.formatter, Integer.toString(getDisplayValue(parameter)));
-        parameter.mValueText.setText(parameter.title + ", " + text);
         // A bare "50%" is ambiguous once pitch and pitch variation share a
-        // dialog, so the announcement carries the parameter name too. This
-        // replaces the percentage of the slider's range that a SeekBar would
-        // otherwise announce, which means nothing for these values.
-        parameter.mSeekBar.setContentDescription(parameter.title + ", " + text);
+        // dialog, so the parameter name goes in front of the value. On the
+        // SeekBar this replaces the percentage of the slider's range it would
+        // otherwise announce, which means nothing for these values; the label
+        // shows the same string so that what is on screen and what is spoken
+        // agree. The label itself is not important for accessibility -- see
+        // the layout -- so the pair is announced once, not twice.
+        String label = parameter.title + ", " + text;
+        parameter.mValueText.setText(label);
+        parameter.mSeekBar.setContentDescription(label);
     }
 
     /**


### PR DESCRIPTION
Builds on #2532 by @amirmahdifard, whose commit is included here unchanged
(maintainer edits were disabled on that branch, so this supersedes it rather
than pushing onto it).

## What #2532 does

It folds the parameter name into the value label, so each section carries one
line — `Speech rate, 175 WPM` — instead of a name line plus a centred value
line. That is the right call: it drops a redundant TalkBack stop per
parameter, makes the visible text agree with what the slider announces, and on
a watch it gives back ~70px of a 384px screen.

## What this adds

**The label is out of the accessibility tree.** #2532 left the same string in
two places, so TalkBack read `Speech rate, 175 WPM` off the label and then
again off the slider. The label is now `importantForAccessibility="no"` and
the slider — the thing you actually operate — keeps the announcement.

**The string is built once** rather than concatenated separately into the
label and the content description.

**The label and slider stay clear of the watch bezel.** This one is
pre-existing, from #2497 rather than from #2532: a watch dialog hands its
content the full width of the display, and at 384x384 the visible chord starts
around 5px, so text laid out from x=0 loses its first character. Before #2532
the clipped line was the title; after it, it is the merged label. Both are
fixed by a `parameter_bezel_inset` dimension — 16dp on a watch, 0dp everywhere
else, so the phone dialog is byte-identical.

The row beneath keeps the full width deliberately: it is tight enough on a
watch that the rate boost checkbox already wraps to three lines, and insetting
it as well breaks the wrap into one character per line. Making that row usable
on a watch is a separate change.

## Testing

Built and exercised on both AVDs (API 34 phone 1080x2400, round watch 384x384):

- Phone: all four parameters fit the dialog without scrolling; view bounds
  identical before and after the bezel inset.
- Watch: label bounds move from `[0,133][384,171]` to `[32,133][352,171]`, so
  the first character clears the bezel; the checkbox and reset button keep the
  bounds they have today.
- `uiautomator dump` confirms the content descriptions are unchanged:
  `Speech rate, 175 WPM` on the slider, `Speech rate, Set to default` on the
  button.

Closes #2532.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
