### PR TITLE
synthdata: report a zero-length phoneme data file instead of crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ tests/*.check
 !tests/windows-data.test
 !tests/windows-installer.test
 !tests/voices.test
+!tests/truncated-data.test
 
 espeak-ng.pc
 

--- a/src/libespeak-ng/error.c
+++ b/src/libespeak-ng/error.c
@@ -136,6 +136,9 @@ espeak_ng_GetStatusCodeMessage(espeak_ng_STATUS status,
 	case ENS_UNKNOWN_TEXT_ENCODING:
 		strncpy0(buffer, "The text encoding is not supported", length);
 		break;
+	case ENS_UNEXPECTED_EOF:
+		strncpy0(buffer, "The file ended before all of the expected data was read", length);
+		break;
 	default:
 		if ((status & ENS_GROUP_MASK) == ENS_GROUP_ERRNO)
 			strerror_r(status, buffer, length);

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -85,8 +85,11 @@ static espeak_ng_STATUS ReadPhFile(void **ptr, const char *fname, int *size, esp
 	}
 	
 	if (length == 0) {
-		*ptr = NULL;
-		return 0;
+		// A zero-length file leaves *ptr NULL. Every caller dereferences it
+		// without a NULL check, so returning success here segfaults later
+		// rather than reporting the broken file.
+		fclose(f_in);
+		return create_file_error_context(context, ENS_UNEXPECTED_EOF, buf);
 	}
 
 	if ((*ptr = malloc(length)) == NULL) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ shell_test(bom)
 shell_test(non-executable-files-with-executable-bit)
 
 shell_test(cmd_options)
+shell_test(truncated-data)
 shell_test(dictionary)
 shell_test(language-numbers-cardinal)
 shell_test(language-numbers-ordinal)

--- a/tests/truncated-data.test
+++ b/tests/truncated-data.test
@@ -1,0 +1,51 @@
+#!/bin/sh
+# include common script
+. "`dirname $0`/common"
+
+# A zero-length phoneme data file left the destination pointer NULL while
+# ReadPhFile still reported success, so LoadPhData dereferenced NULL and the
+# process died with SIGSEGV instead of reporting the broken file.
+
+test_truncated_data() {
+	DATA_FILE=$1
+
+	echo "testing zero-length ${DATA_FILE}"
+
+	TMP_DIR=`mktemp -d` || exit 1
+	cp -r espeak-ng-data "${TMP_DIR}/espeak-ng-data" || exit 1
+	: > "${TMP_DIR}/espeak-ng-data/${DATA_FILE}" || exit 1
+
+	OUTPUT=$(
+		ESPEAK_DATA_PATH="${TMP_DIR}" LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
+			src/espeak-ng -q -v en "test" 2>&1
+	)
+	STATUS=$?
+
+	rm -rf "${TMP_DIR}"
+
+	# A status of 128+N means the process was killed by signal N, e.g. 139
+	# for SIGSEGV. Under a sanitizer build the crash is reported and the
+	# status is 1 instead, so the error message is checked as well.
+	if [ ${STATUS} -ge 128 ] ; then
+		echo "died with signal `expr ${STATUS} - 128` on a zero-length ${DATA_FILE}"
+		exit 1
+	fi
+
+	# It must report the failure rather than carry on without the data.
+	if [ ${STATUS} -eq 0 ] ; then
+		echo "reported success for a zero-length ${DATA_FILE}"
+		exit 1
+	fi
+
+	# The failure has to be espeak-ng's own diagnostic naming the file, not a
+	# crash report from a sanitizer or the shell.
+	echo "${OUTPUT}" | grep -q "${DATA_FILE}" || {
+		echo "did not report ${DATA_FILE}: ${OUTPUT}"
+		exit 1
+	}
+}
+
+test_truncated_data phontab
+test_truncated_data phonindex
+test_truncated_data phondata
+test_truncated_data intonations


### PR DESCRIPTION
`ReadPhFile()` treats a zero-length file as success:

```c
if (length == 0) {
    *ptr = NULL;
    return 0;
}
```

None of its four callers check the pointer. `LoadPhData()` goes straight to:

```c
p = phoneme_tab_data;
n_phoneme_tables = p[0];
```

so a zero-byte `phontab` dereferences NULL and the process dies. The `wavefile_data` read a few lines above it is NULL-guarded; this one is not.

```
$ : > espeak-ng-data/phontab
$ espeak-ng -q -v en "hi"
Segmentation fault (core dumped)        # exit 139
```

Under a sanitizer build:

```
synthdata.c:145:21: runtime error: load of null pointer of type 'unsigned char'
AddressSanitizer: SEGV on unknown address 0x000000000000
```

The same branch also returns without `fclose(f_in)`, leaking the handle. Every other path after the `fopen` closes it.

That half is confirmed independently by cppcheck 2.21.1, which flags it on master and goes quiet with this change applied:

```
$ cppcheck --enable=warning --inline-suppr --quiet src/libespeak-ng/synthdata.c
src/libespeak-ng/synthdata.c:89:3: error: Resource leak: f_in [resourceLeak]
```

### Reachability

`GetFileLength()` returns `st_size`, so this needs nothing more exotic than a zero-byte file: a truncated download, an interrupted install, a packaging mistake, a full disk during a write. All four files `ReadPhFile` loads reproduce it, `phontab`, `phonindex`, `phondata` and `intonations`.

### Fix

Close the file and return `ENS_UNEXPECTED_EOF` through `create_file_error_context` so the failing path is named:

```
Error processing file '.../phontab': The file ended before all of the expected data was read.
```

`ENS_UNEXPECTED_EOF` had no entry in `espeak_ng_GetStatusCodeMessage` and printed as `Unspecified error 0x100011ff`. It was already reachable from `spect.c`, so this adds the message rather than introducing a new status.

One judgement call worth surfacing: this turns a previously "successful" load into an error for all four files. `intonations` is the only one that might have limped along, since `n_tunes` would compute to 0 and the loops over it would not run. I took the view that a zero-length phoneme data file is a broken installation in every case and that reporting it beats continuing with no data, but I am happy to narrow it to the three that certainly crash if you would rather.

### Tests

`tests/truncated-data.test` covers all four files. For each it asserts the process is not killed by a signal, does not report success, and that the diagnostic names the file.

That last check is load-bearing. A sanitizer build converts the SIGSEGV into exit status 1, so a signal check on its own passes against the unfixed code. With the message check the test fails correctly either way:

```
testing zero-length phontab
did not report phontab: synthdata.c:145:21: runtime error: load of null pointer of type 'unsigned char'
```

Verified: `ctest` 20/20 on a plain build and on a clang ASan+UBSan build, zero build warnings on both. The one pre-existing failure in my tree, `non-executable-files-with-executable-bit`, fails identically on unmodified `master` here and is unrelated to this change. The new test file is mode 644 for that reason, and `.gitignore` needed the usual `!tests/...` negation since `tests/*.test` is ignored by default.

