### PR TITLE
Android. Fix the reset settings bug up on talkback startup by garding the move migration

### DIFF
--- a/android/src/com/reecedunn/espeak/EspeakApp.java
+++ b/android/src/com/reecedunn/espeak/EspeakApp.java
@@ -34,6 +34,7 @@ public class EspeakApp extends Application {
         Context appContext = getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             EspeakApp.storageContext = appContext.createDeviceProtectedStorageContext();
+            EspeakApp.storageContext.moveSharedPreferencesFrom(appContext, appContext.getPackageName() + "_preferences");
         }
         else {
             EspeakApp.storageContext = appContext;

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -59,7 +59,6 @@ import java.util.Set;
 public class TtsService extends TextToSpeechService {
     private static final String TAG = TtsService.class.getSimpleName();
     private static Context storageContext;
-    private static boolean sMigratedPreferences = false;
     private static final boolean DEBUG = BuildConfig.DEBUG;
 
     private SpeechSynthesis mEngine;
@@ -98,10 +97,6 @@ public class TtsService extends TextToSpeechService {
     @Override
     public void onCreate() {
         storageContext = EspeakApp.getStorageContext();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && !sMigratedPreferences) {
-            storageContext.moveSharedPreferencesFrom(this, this.getPackageName() + "_preferences");
-            sMigratedPreferences = true;
-        }
         mPreferences = PreferenceManager.getDefaultSharedPreferences(storageContext);
         mPreferences.registerOnSharedPreferenceChangeListener(mOnPreferencesChanged);
         if (!CheckVoiceData.hasBaseResources(storageContext)

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -59,6 +59,7 @@ import java.util.Set;
 public class TtsService extends TextToSpeechService {
     private static final String TAG = TtsService.class.getSimpleName();
     private static Context storageContext;
+    private static boolean sMigratedPreferences = false;
     private static final boolean DEBUG = BuildConfig.DEBUG;
 
     private SpeechSynthesis mEngine;
@@ -97,8 +98,10 @@ public class TtsService extends TextToSpeechService {
     @Override
     public void onCreate() {
         storageContext = EspeakApp.getStorageContext();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && !sMigratedPreferences) {
             storageContext.moveSharedPreferencesFrom(this, this.getPackageName() + "_preferences");
+            sMigratedPreferences = true;
+        }
         mPreferences = PreferenceManager.getDefaultSharedPreferences(storageContext);
         mPreferences.registerOnSharedPreferenceChangeListener(mOnPreferencesChanged);
         if (!CheckVoiceData.hasBaseResources(storageContext)


### PR DESCRIPTION
@alex19EP The bug was fixed by this, I don't know how you want to go forward with this, but I've opened to show you and conferm what is fixing the issue. May be we can just remove the migration thing entirely. But it's up to you how to go forward with this.
Edit. I've already applyed the correct and standard fix for this. And tested with all phones, It's battle tested