### PR TITLE
fix(cmn): preserve Mandarin tone contours in IPA output

### DIFF
--- a/phsource/ph_cmn
+++ b/phsource/ph_cmn
@@ -8,82 +8,97 @@
 //  tone: low level
 phoneme 11
   stress
+  ipa ˩˩
   Tone(12, 9, envelope/i_risefall, NULL)
 endphoneme
 
 phoneme 5
   stress
+  ipa ˩˩
   Tone(12, 9, envelope/i_risefall, NULL)
 endphoneme
 
 
 phoneme 21   //  tone: low fall
   stress
+  ipa ˨˩
   Tone(20, 10, envelope/p_fall, NULL)
 endphoneme
 
 //  tone: fall rise
 phoneme 214
   stress
+  ipa ˨˩˦
   Tone(18, 42, envelope/p_214, NULL)
 endphoneme
 
 phoneme 3
   stress
+  ipa ˨˩˦
   Tone(18, 42, envelope/p_214, NULL)
 endphoneme
 
 
 phoneme 22   //  tone: mid-low level
   stress
+  ipa ˨˨
   Tone(22, 20, envelope/p_fall, NULL)
 endphoneme
 
 phoneme 33   //  tone: mid level
   stress
+  ipa ˧˧
   Tone(32, 30, envelope/p_fall, NULL)
 endphoneme
 
 //  tone: mid rise
 phoneme 35   
   stress
+  ipa ˧˥
   Tone(30, 50, envelope/p_rise, NULL)
 endphoneme
 
 phoneme 2
   stress
+  ipa ˧˥
   Tone(30, 50, envelope/p_rise, NULL)
 endphoneme
 
 phoneme 44   //  tone: mid-high level
   stress
+  ipa ˦˦
   Tone(38, 41, envelope/p_rise, NULL)
 endphoneme
 
 //  tone: high fall
 phoneme 51
   stress
+  ipa ˥˩
   Tone(50, 10, envelope/p_fall, NULL)
 endphoneme
 
 phoneme 4
   stress
+  ipa ˥˩
   Tone(50, 10, envelope/p_fall, NULL)
 endphoneme
 
 phoneme 53   //  tone: high fall
   stress
+  ipa ˥˧
   Tone(50, 30, envelope/p_fall, NULL)
 endphoneme
 
 //  tone: high level
 phoneme 55   
   stress
+  ipa ˥˥
   Tone(55, 50, envelope/p_level, NULL)
 endphoneme
 
 phoneme 1
   stress
+  ipa ˥˥
   Tone(55, 50, envelope/p_level, NULL)
 endphoneme
 

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -467,8 +467,10 @@ char *WritePhMnemonic(char *phon_out, PHONEME_TAB *ph, PHONEME_LIST *plist, int 
 
 		if (plist == NULL)
 			InterpretPhoneme2(ph->code, &phdata);
-		else
+		else if (ph == plist->ph)
 			InterpretPhoneme(NULL, 0, plist, phoneme_list, &phdata, NULL);
+		else
+			InterpretPhoneme2WithData(ph->code, ph, &phdata);
 
 		p = phdata.ipa_string;
 		if (*p == 0x20) {


### PR DESCRIPTION
## Summary

Mandarin tone phonemes are internally represented with Chao tone-number mnemonics such as `55`, `35`, `214`, `51`, and `11`. The generic ASCII-to-IPA fallback loses information from those mnemonics, which makes different Mandarin tones appear identical or renders them as unrelated IPA vowel symbols.

This change gives every Mandarin tone contour an explicit IPA tone-letter spelling and makes `WritePhMnemonic` resolve the IPA spelling from the phoneme it was actually asked to append. The synthesized tone contours are unchanged; only phoneme/IPA reporting is corrected.

## Problem

The Mandarin dictionary rules map Pinyin tone numbers to Chao contours:

```text
1 -> 55
2 -> 35
3 -> 214
4 -> 51
5 -> 11
```

Before this change, `WritePhMnemonic` fell back to the Kirschenbaum conversion table for these tone phonemes. That fallback intentionally ignores digits after the first character to hide numeric phoneme-variant suffixes. Applied to numeric tone mnemonics, however, it causes:

- `55` and `51` to both become `5`, making tones 1 and 4 indistinguishable.
- The leading `3` in `35` to be interpreted as the Kirschenbaum symbol for `ɜ`.
- Multi-point contours such as `214` to be truncated to their first level.

The internal tone phonemes and synthesized pitch contours remain distinct, so the defect is limited to IPA output.

## Reproduction

The pairs `中`/`重` (`zhong1`/`zhong4`) and `妈`/`骂` (`ma1`/`ma4`) have the same segmental pronunciation within each pair but different tones. The mnemonic output preserves those distinctions:

```console
$ ESPEAK_DATA_PATH=build/espeak-ng-data build/src/espeak-ng -v cmn -q -x "中 重 妈 骂"
ts.'ong55_| ts.'ong51_| m'A55_| m'A51_|
```

Before this change, IPA output collapses tone 1 and tone 4 in both pairs:

```console
$ ESPEAK_DATA_PATH=build/espeak-ng-data build/src/espeak-ng -v cmn -q --ipa "中 重 妈 骂"
ts.ˈonɡ5 ts.ˈonɡ5 mˈɑ5 mˈɑ5
```

After this change, the same command reports the high-level and high-falling contours distinctly:

```console
$ ESPEAK_DATA_PATH=build/espeak-ng-data build/src/espeak-ng -v cmn -q --ipa "中 重 妈 骂"
ts.ˈonɡ˥˥ ts.ˈonɡ˥˩ mˈɑ˥˥ mˈɑ˥˩
```

## Changes

- Define IPA tone-letter spellings for all Mandarin tone phonemes, including normal tone aliases and contours produced by tone sandhi.
- Map the five dictionary contours as follows:
  - `55` -> `˥˥`
  - `35` -> `˧˥`
  - `214` -> `˨˩˦`
  - `51` -> `˥˩`
  - `11` -> `˩˩`
- Resolve an appended phoneme's IPA program independently when it differs from the syllable phoneme in the current phoneme-list entry. This allows explicit IPA names on tone phonemes to be used while preserving contextual interpretation for ordinary phonemes.
- Keep the generic numeric variant-suffix suppression unchanged for phonemes that rely on the ASCII-to-IPA fallback.

## Result

```console
$ ESPEAK_DATA_PATH=build/espeak-ng-data build/src/espeak-ng -v cmn -q --ipa "zhong1 zhong4"
ts.ˈonɡ˥˥ ts.ˈonɡ˥˩

$ ESPEAK_DATA_PATH=build/espeak-ng-data build/src/espeak-ng -v cmn -q --ipa "中國"
ts.ˈonɡ˥˥ kˈuo˧˥
```

Sandhi-generated contours are also preserved, for example:

```text
53 -> ˥˧
21 -> ˨˩
22 -> ˨˨
44 -> ˦˦
```

## Testing

- Configured a release build with `ENABLE_TESTS=OFF`.
- Built the CLI and compiled the phoneme data successfully with zero phoneme compilation errors.
- Manually verified tones 1 through 5 and the `21`, `22`, `35`, `44`, and `53` sandhi contours through `-x` and `--ipa` output.
- No testing-related code was added.

## Notes for Reviewers

The tone letters follow eSpeak-ng's documented five-level IPA convention and existing usage in the Hakka and Cherokee phoneme tables. This PR does not change Mandarin dictionary matching, tone sandhi selection, or synthesized audio.
