### PR TITLE
Android: fix settings resetting on every screen reader restart

### DIFF
--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -50,7 +50,7 @@ Android TTS Framework
 
 ### Key Classes (`src/com/reecedunn/espeak/`)
 
-- **EspeakApp** — `Application` subclass; owns the device-protected storage context and the Wear launcher alias state (see below)
+- **EspeakApp** — `Application` subclass; owns the device-protected storage context, the one-time migration of pre-2022 preferences into it, and the Wear launcher alias state (see below)
 - **TtsService** — Android TTS engine service; handles `onSynthesizeText()`, voice selection, parameter setup
 - **SpeechSynthesis** — JNI wrapper; loads `libttsespeak.so`, exposes native functions as Java API
 - **UnicodeNormalization** — NFKC normalization of synthesis input (stylized Unicode → plain text) with a normalized→original offset map for `rangeStart()` word boundaries
@@ -122,3 +122,14 @@ Voice data comes from the parent project's `dictsource/` and `phsource/`. The Gr
 1. Add preference key constant in `VoiceSettings.java`
 2. Add preference XML in `res/xml/` or programmatically in `TtsSettingsActivity.java`
 3. Wire it through `TtsService.onSynthesizeText()` to the appropriate `SpeechSynthesis` parameter
+
+Settings live in device-protected storage so that `TtsService` can read them
+before the device is unlocked. Two things keep every writer on that one file:
+`PrefsEspeakFragment` switches its `PreferenceManager` to device-protected
+storage, so a `Preference` on the settings screen (and `getSharedPreferences()`
+or `getEditor()` inside one) is already right; code outside the Preference
+framework goes through `EspeakApp.getStorageContext()`. Never call
+`PreferenceManager.getDefaultSharedPreferences()` on a plain `Context`: the
+value lands in a credential-encrypted file that `EspeakApp` discards at the
+next process start, so the setting silently does nothing (#2536).
+`PreferenceStorageTest` fails if opening the settings screen creates that file.

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/PreferenceStorageTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/PreferenceStorageTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Alexandr Epaneshnikov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reecedunn.espeak.test;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.reecedunn.espeak.EspeakApp;
+import com.reecedunn.espeak.TtsSettingsActivity;
+import com.reecedunn.espeak.VoiceSettings;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Settings live in device-protected storage, where TtsService reads them
+ * before the device is unlocked. Regression tests for #2536: a Preference
+ * persisted through a plain Context created a credential-encrypted file, and
+ * the startup migration then copied it over the real settings every time a
+ * screen reader restarted the engine.
+ */
+@RunWith(AndroidJUnit4.class)
+public class PreferenceStorageTest extends TextToSpeechTestCase
+{
+    private Context mAppContext;
+    private Context mStorageContext;
+    private String mName;
+
+    @Before
+    public void setUpStorage()
+    {
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N);
+        mAppContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        mStorageContext = mAppContext.createDeviceProtectedStorageContext();
+        mName = PreferenceManager.getDefaultSharedPreferencesName(mAppContext);
+    }
+
+    @After
+    public void resetStorage()
+    {
+        if (mAppContext == null) {
+            return;
+        }
+        deviceProtected().edit().clear().commit();
+        mAppContext.deleteSharedPreferences(mName);
+    }
+
+    /** The file a plain Context writes to. It must stay empty. */
+    private SharedPreferences credentialEncrypted()
+    {
+        return mAppContext.getSharedPreferences(mName, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * The file TtsService reads. Fetched anew on every call, because a
+     * migration evicts the cached instance.
+     */
+    private SharedPreferences deviceProtected()
+    {
+        return mStorageContext.getSharedPreferences(mName, Context.MODE_PRIVATE);
+    }
+
+    @Test
+    public void settingsScreenWritesOnlyToDeviceProtectedStorage()
+    {
+        mAppContext.deleteSharedPreferences(mName);
+
+        // Attaching the preferences persists their defaults; that is how
+        // #2536 created the stray file without the user touching anything.
+        try (ActivityScenario<TtsSettingsActivity> ignored =
+                ActivityScenario.launch(TtsSettingsActivity.class)) {
+            assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
+            assertThat(deviceProtected().contains(VoiceSettings.PREF_UNICODE_NORMALIZATION), is(true));
+        }
+    }
+
+    @Test
+    public void legacyPreferencesMoveIntoDeviceProtectedStorage()
+    {
+        // An install from before device-protected storage: nothing there yet,
+        // the settings still sit in the credential-encrypted file.
+        deviceProtected().edit().clear().commit();
+        mAppContext.deleteSharedPreferences(mName);
+        credentialEncrypted().edit().putString(VoiceSettings.PREF_RATE, "123").commit();
+
+        EspeakApp.migrateLegacyPreferences(mAppContext, mStorageContext);
+
+        assertThat(deviceProtected().getString(VoiceSettings.PREF_RATE, null), is("123"));
+        assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
+    }
+
+    @Test
+    public void strayCredentialEncryptedFileNeverReplacesSettings()
+    {
+        deviceProtected().edit().clear().putString(VoiceSettings.PREF_RATE, "123").commit();
+        mAppContext.deleteSharedPreferences(mName);
+        // The exact file #2536 left behind: one default, persisted through a
+        // plain Context.
+        credentialEncrypted().edit().putBoolean(VoiceSettings.PREF_UNICODE_NORMALIZATION, true).commit();
+
+        EspeakApp.migrateLegacyPreferences(mAppContext, mStorageContext);
+
+        assertThat(deviceProtected().getString(VoiceSettings.PREF_RATE, null), is("123"));
+        assertThat(deviceProtected().contains(VoiceSettings.PREF_UNICODE_NORMALIZATION), is(false));
+        assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
+    }
+}

--- a/android/eSpeakTests/src/com/reecedunn/espeak/test/PreferenceStorageTest.java
+++ b/android/eSpeakTests/src/com/reecedunn/espeak/test/PreferenceStorageTest.java
@@ -19,6 +19,7 @@ package com.reecedunn.espeak.test;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
+import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 
 import androidx.test.core.app.ActivityScenario;
@@ -33,6 +34,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -86,15 +89,38 @@ public class PreferenceStorageTest extends TextToSpeechTestCase
         return mStorageContext.getSharedPreferences(mName, Context.MODE_PRIVATE);
     }
 
+    /**
+     * The settings screen loads the engine's voices on a worker thread and
+     * adds its preferences afterwards, so wait until the one under test is
+     * attached before looking at what it persisted.
+     */
+    private static void waitForPreference(ActivityScenario<TtsSettingsActivity> scenario,
+                                          final String key) throws InterruptedException
+    {
+        final AtomicBoolean attached = new AtomicBoolean();
+        for (int i = 0; i < 100 && !attached.get(); ++i) {
+            scenario.onActivity(activity -> {
+                final PreferenceFragment fragment = (PreferenceFragment)
+                        activity.getFragmentManager().findFragmentById(android.R.id.content);
+                attached.set(fragment != null && fragment.findPreference(key) != null);
+            });
+            if (!attached.get()) {
+                Thread.sleep(100);
+            }
+        }
+        assertThat("preference " + key + " attached within 10 s", attached.get(), is(true));
+    }
+
     @Test
-    public void settingsScreenWritesOnlyToDeviceProtectedStorage()
+    public void settingsScreenWritesOnlyToDeviceProtectedStorage() throws InterruptedException
     {
         mAppContext.deleteSharedPreferences(mName);
 
         // Attaching the preferences persists their defaults; that is how
         // #2536 created the stray file without the user touching anything.
-        try (ActivityScenario<TtsSettingsActivity> ignored =
+        try (ActivityScenario<TtsSettingsActivity> scenario =
                 ActivityScenario.launch(TtsSettingsActivity.class)) {
+            waitForPreference(scenario, VoiceSettings.PREF_UNICODE_NORMALIZATION);
             assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
             assertThat(deviceProtected().contains(VoiceSettings.PREF_UNICODE_NORMALIZATION), is(true));
         }
@@ -112,6 +138,26 @@ public class PreferenceStorageTest extends TextToSpeechTestCase
         EspeakApp.migrateLegacyPreferences(mAppContext, mStorageContext);
 
         assertThat(deviceProtected().getString(VoiceSettings.PREF_RATE, null), is("123"));
+        assertThat(deviceProtected().getBoolean(EspeakApp.PREF_PREFERENCES_MIGRATED, false), is(true));
+        assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
+    }
+
+    @Test
+    public void firstStartMarksDeviceProtectedStorageAsLive()
+    {
+        // A fresh install: neither file exists. The first unlocked start must
+        // still leave a mark, so that a credential-encrypted file appearing
+        // before the user ever opens the settings is discarded, not adopted.
+        deviceProtected().edit().clear().commit();
+        mAppContext.deleteSharedPreferences(mName);
+
+        EspeakApp.migrateLegacyPreferences(mAppContext, mStorageContext);
+        assertThat(deviceProtected().getBoolean(EspeakApp.PREF_PREFERENCES_MIGRATED, false), is(true));
+
+        credentialEncrypted().edit().putString(VoiceSettings.PREF_RATE, "123").commit();
+        EspeakApp.migrateLegacyPreferences(mAppContext, mStorageContext);
+
+        assertThat(deviceProtected().contains(VoiceSettings.PREF_RATE), is(false));
         assertThat(credentialEncrypted().getAll().keySet(), is(empty()));
     }
 

--- a/android/src/com/reecedunn/espeak/EspeakApp.java
+++ b/android/src/com/reecedunn/espeak/EspeakApp.java
@@ -18,11 +18,14 @@ package com.reecedunn.espeak;
 
 import android.annotation.TargetApi;
 import android.app.Application;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.SharedPreferences;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -30,14 +33,37 @@ public class EspeakApp extends Application {
 
     private static final String TAG = EspeakApp.class.getSimpleName();
 
+    /**
+     * Written to device-protected storage the first time
+     * {@link #migrateLegacyPreferences} runs with the credential-encrypted file
+     * readable, so that file is never empty again after the first unlocked
+     * start and a stray credential-encrypted file can never be adopted.
+     */
+    public static final String PREF_PREFERENCES_MIGRATED = "espeak_preferences_migrated";
+
     private static Context storageContext;
 
     public void onCreate() {
         super.onCreate();
-        Context appContext = getApplicationContext();
+        final Context appContext = getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             EspeakApp.storageContext = appContext.createDeviceProtectedStorageContext();
             migrateLegacyPreferences(appContext, EspeakApp.storageContext);
+            if (!appContext.getSystemService(UserManager.class).isUserUnlocked()) {
+                // Started at boot, for a direct-boot-aware screen reader. The
+                // credential-encrypted file cannot be read yet, so run the
+                // migration again when the user unlocks instead of leaving it
+                // to the next process restart, which may be days away.
+                // ACTION_USER_UNLOCKED is a protected system broadcast, exempt
+                // from the exported flag that targetSdk 34 requires otherwise.
+                appContext.registerReceiver(new BroadcastReceiver() {
+                    @Override
+                    public void onReceive(Context context, Intent intent) {
+                        appContext.unregisterReceiver(this);
+                        migrateLegacyPreferences(appContext, EspeakApp.storageContext);
+                    }
+                }, new IntentFilter(Intent.ACTION_USER_UNLOCKED));
+            }
         }
         else {
             EspeakApp.storageContext = appContext;
@@ -48,12 +74,15 @@ public class EspeakApp extends Application {
     /**
      * Adopts the preferences of an install that predates device-protected
      * storage (f7f66429, 2022) and still keeps them in the credential-encrypted
-     * file. Runs once per process, before any component reads the settings.
+     * file. Runs at process start, before any component reads the settings,
+     * and again on unlock when the process started before the user unlocked.
      *
-     * Everything in this app reads and writes the device-protected file, so
-     * once it holds anything it is the source of truth and there is nothing
-     * left to migrate. A credential-encrypted file that shows up after that
-     * point can only be a stray write through a plain Context, and
+     * Everything in this app reads and writes the device-protected file, and
+     * {@link #PREF_PREFERENCES_MIGRATED} lands there the first time the
+     * credential-encrypted file is readable, so once the device-protected file
+     * holds anything it is the source of truth and there is nothing left to
+     * migrate. A credential-encrypted file that shows up after that point can
+     * only be a stray write through a plain Context, and
      * moveSharedPreferencesFrom() would copy it over the user's settings: that
      * is how #2536 wiped every setting on each screen reader restart. Such a
      * file is discarded instead, which turns that class of bug into a setting
@@ -62,12 +91,19 @@ public class EspeakApp extends Application {
     @TargetApi(Build.VERSION_CODES.N)
     public static void migrateLegacyPreferences(Context appContext, Context storageContext) {
         final String name = PreferenceManager.getDefaultSharedPreferencesName(appContext);
-        final SharedPreferences settings = storageContext.getSharedPreferences(name, Context.MODE_PRIVATE);
-        if (settings.getAll().isEmpty()) {
-            storageContext.moveSharedPreferencesFrom(appContext, name);
-        } else {
+        if (!storageContext.getSharedPreferences(name, Context.MODE_PRIVATE).getAll().isEmpty()) {
             appContext.deleteSharedPreferences(name);
+            return;
         }
+        if (!appContext.getSystemService(UserManager.class).isUserUnlocked()) {
+            // Credential-encrypted storage is not readable before the first
+            // unlock; onCreate() retries this on ACTION_USER_UNLOCKED.
+            return;
+        }
+        storageContext.moveSharedPreferencesFrom(appContext, name);
+        // The move evicts the cached instance, so fetch the file anew.
+        storageContext.getSharedPreferences(name, Context.MODE_PRIVATE).edit()
+                .putBoolean(PREF_PREFERENCES_MIGRATED, true).apply();
     }
 
     /**

--- a/android/src/com/reecedunn/espeak/EspeakApp.java
+++ b/android/src/com/reecedunn/espeak/EspeakApp.java
@@ -16,11 +16,14 @@
 
 package com.reecedunn.espeak;
 
+import android.annotation.TargetApi;
 import android.app.Application;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 public class EspeakApp extends Application {
@@ -34,12 +37,37 @@ public class EspeakApp extends Application {
         Context appContext = getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             EspeakApp.storageContext = appContext.createDeviceProtectedStorageContext();
-            EspeakApp.storageContext.moveSharedPreferencesFrom(appContext, appContext.getPackageName() + "_preferences");
+            migrateLegacyPreferences(appContext, EspeakApp.storageContext);
         }
         else {
             EspeakApp.storageContext = appContext;
         }
         syncWearLauncherState();
+    }
+
+    /**
+     * Adopts the preferences of an install that predates device-protected
+     * storage (f7f66429, 2022) and still keeps them in the credential-encrypted
+     * file. Runs once per process, before any component reads the settings.
+     *
+     * Everything in this app reads and writes the device-protected file, so
+     * once it holds anything it is the source of truth and there is nothing
+     * left to migrate. A credential-encrypted file that shows up after that
+     * point can only be a stray write through a plain Context, and
+     * moveSharedPreferencesFrom() would copy it over the user's settings: that
+     * is how #2536 wiped every setting on each screen reader restart. Such a
+     * file is discarded instead, which turns that class of bug into a setting
+     * that does not take effect -- visible, and harmless.
+     */
+    @TargetApi(Build.VERSION_CODES.N)
+    public static void migrateLegacyPreferences(Context appContext, Context storageContext) {
+        final String name = PreferenceManager.getDefaultSharedPreferencesName(appContext);
+        final SharedPreferences settings = storageContext.getSharedPreferences(name, Context.MODE_PRIVATE);
+        if (settings.getAll().isEmpty()) {
+            storageContext.moveSharedPreferencesFrom(appContext, name);
+        } else {
+            appContext.deleteSharedPreferences(name);
+        }
     }
 
     /**

--- a/android/src/com/reecedunn/espeak/EspeakApp.java
+++ b/android/src/com/reecedunn/espeak/EspeakApp.java
@@ -34,6 +34,7 @@ public class EspeakApp extends Application {
         Context appContext = getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             EspeakApp.storageContext = appContext.createDeviceProtectedStorageContext();
+            EspeakApp.storageContext.moveSharedPreferencesFrom(appContext, appContext.getPackageName() + "_preferences");
         }
         else {
             EspeakApp.storageContext = appContext;

--- a/android/src/com/reecedunn/espeak/TtsService.java
+++ b/android/src/com/reecedunn/espeak/TtsService.java
@@ -97,8 +97,6 @@ public class TtsService extends TextToSpeechService {
     @Override
     public void onCreate() {
         storageContext = EspeakApp.getStorageContext();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-            storageContext.moveSharedPreferencesFrom(this, this.getPackageName() + "_preferences");
         mPreferences = PreferenceManager.getDefaultSharedPreferences(storageContext);
         mPreferences.registerOnSharedPreferenceChangeListener(mOnPreferencesChanged);
         if (!CheckVoiceData.hasBaseResources(storageContext)

--- a/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
+++ b/android/src/com/reecedunn/espeak/TtsSettingsActivity.java
@@ -77,11 +77,6 @@ public class TtsSettingsActivity extends PreferenceActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-        {
-            PreferenceManager preferenceManager = getPreferenceManager();
-            preferenceManager.setStorageDeviceProtected ();
-        }
         // Migrate old eyes-free settings to the new settings:
 
         storageContext = EspeakApp.getStorageContext();
@@ -122,17 +117,9 @@ public class TtsSettingsActivity extends PreferenceActivity {
 
         editor.commit();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-        {
-            getFragmentManager().beginTransaction().replace(
-                    android.R.id.content,
-                    new PrefsEspeakFragment()).commit();
-        }
-        else
-        {
-            addPreferencesFromResource(R.xml.preferences);
-            createPreferences(TtsSettingsActivity.this, getPreferenceScreen());
-        }
+        getFragmentManager().beginTransaction().replace(
+                android.R.id.content,
+                new PrefsEspeakFragment()).commit();
     }
 
     public static class PrefsEspeakFragment extends PreferenceFragment {
@@ -140,6 +127,15 @@ public class TtsSettingsActivity extends PreferenceActivity {
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
 
+            // The fragment has its own PreferenceManager, separate from the
+            // activity's. Everything on this screen persists through it, so it
+            // must use the device-protected file that TtsService reads. A
+            // Preference left on the default credential-encrypted storage has
+            // no effect on speech, and its stray file is what #2536 copied
+            // over the real settings on every screen reader restart.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                getPreferenceManager().setStorageDeviceProtected();
+            }
             addPreferencesFromResource(R.xml.preferences);
             createPreferences(getActivity(), getPreferenceScreen());
         }

--- a/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/SeekBarPreference.java
@@ -20,9 +20,7 @@ package com.reecedunn.espeak.preference;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.DialogPreference;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
@@ -350,7 +348,7 @@ public class SeekBarPreference extends DialogPreference
             return;
         }
 
-        SharedPreferences.Editor editor = getDeviceProtectedPreferences().edit();
+        SharedPreferences.Editor editor = getSharedPreferences().edit();
         editor.putString(parameter.key, Integer.toString(parameter.current));
         if (parameter.hasRateBoost) {
             editor.putBoolean(VoiceSettings.PREF_RATE_BOOST, parameter.boost);
@@ -417,14 +415,5 @@ public class SeekBarPreference extends DialogPreference
             summary.append(String.format(parameter.formatter, Integer.toString(getDisplayValue(parameter))));
         }
         return summary.toString();
-    }
-
-    private SharedPreferences getDeviceProtectedPreferences()
-    {
-        Context context = getContext();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            context = context.createDeviceProtectedStorageContext();
-        }
-        return PreferenceManager.getDefaultSharedPreferences(context);
     }
 }

--- a/android/src/com/reecedunn/espeak/preference/SpeakPunctuationPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/SpeakPunctuationPreference.java
@@ -20,9 +20,7 @@ package com.reecedunn.espeak.preference;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.DialogPreference;
-import android.preference.PreferenceManager;
 import android.text.Editable;
 import android.util.AttributeSet;
 import android.view.View;
@@ -131,11 +129,6 @@ public class SpeakPunctuationPreference extends DialogPreference {
                 onDataChanged(level, characters);
 
                 if (shouldCommit()) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-                    {
-                        PreferenceManager preferenceManager = getPreferenceManager();
-                        preferenceManager.setStorageDeviceProtected ();
-                    }
                     SharedPreferences.Editor editor = getEditor();
                     if (editor != null) {
                         editor.putString(VoiceSettings.PREF_PUNCTUATION_CHARACTERS, characters);

--- a/android/src/com/reecedunn/espeak/preference/SupportedLanguagesPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/SupportedLanguagesPreference.java
@@ -29,7 +29,6 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import com.reecedunn.espeak.EspeakApp;
 import com.reecedunn.espeak.LanguageSettings;
 import com.reecedunn.espeak.R;
 
@@ -156,16 +155,15 @@ public class SupportedLanguagesPreference extends MultiSelectListPreference {
         }
     }
 
-    // Persist using device-protected storage to stay in sync with TtsService.
+    // "All languages" is stored as the absence of the key, so that TtsService
+    // exposes every voice, including ones added by a later update.
     @Override
     public boolean persistStringSet(Set<String> values) {
         if (!shouldPersist()) return false;
         int total = mEntryCount > 0 ? mEntryCount :
                 (getEntryValues() != null ? getEntryValues().length : 0);
 
-        android.content.SharedPreferences.Editor editor = android.preference.PreferenceManager
-                .getDefaultSharedPreferences(EspeakApp.getStorageContext())
-                .edit();
+        android.content.SharedPreferences.Editor editor = getSharedPreferences().edit();
 
         if (values == null || (total > 0 && values.size() >= total)) {
             // Treat as "all": remove the preference key so TtsService exposes everything.
@@ -183,9 +181,7 @@ public class SupportedLanguagesPreference extends MultiSelectListPreference {
     @Override
     public Set<String> getPersistedStringSet(Set<String> defaultReturnValue) {
         if (!shouldPersist()) return defaultReturnValue;
-        Set<String> stored = android.preference.PreferenceManager
-                .getDefaultSharedPreferences(EspeakApp.getStorageContext())
-                .getStringSet(getKey(), defaultReturnValue);
+        Set<String> stored = getSharedPreferences().getStringSet(getKey(), defaultReturnValue);
         return (stored == null) ? defaultReturnValue : new HashSet<String>(stored);
     }
 }

--- a/android/src/com/reecedunn/espeak/preference/VoiceVariantPreference.java
+++ b/android/src/com/reecedunn/espeak/preference/VoiceVariantPreference.java
@@ -21,9 +21,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.DialogPreference;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -331,11 +329,6 @@ public class VoiceVariantPreference extends DialogPreference {
             case DialogInterface.BUTTON_POSITIVE:
                 onDataChanged();
                 if (shouldCommit()) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-                    {
-                        PreferenceManager preferenceManager = getPreferenceManager();
-                        preferenceManager.setStorageDeviceProtected ();
-                    }
                     SharedPreferences.Editor editor = getEditor();
                     if (editor != null) {
                         VoiceVariant variant = variants[mCategoryIndex][mVariantIndex].getVariant();


### PR DESCRIPTION
Closes #2536. Supersedes #2541, whose relocation of the migration is included here under @amirmahdifard's authorship.

Since #2523, opening the eSpeak settings screen and then restarting the screen reader reset every setting to its default.

## Root cause

The settings screen is a `PreferenceFragment`, and a fragment has its own `PreferenceManager`. `TtsSettingsActivity` switched the *activity's* manager to device-protected storage, but that one is only used by the pre-Honeycomb code path, dead since minSdk 21. The fragment's manager stayed on credential-encrypted storage, and every custom preference worked around it by hand: `SeekBarPreference` built its own device-protected context, `SupportedLanguagesPreference` went through `EspeakApp`, and the two dialog preferences flipped the manager at commit time.

The `CheckBoxPreference` from #2523 did none of that. Android persists a checkbox's default the moment it is attached, so merely opening the screen wrote `com.reecedunn.espeak_preferences.xml` into credential-encrypted storage, containing only `espeak_unicode_normalization`. On the next `TtsService.onCreate()`, which is every screen reader restart, `moveSharedPreferencesFrom()` copied that file over the device-protected one, and rate, pitch, variant and languages were gone.

#2541 moves the migration to `EspeakApp.onCreate()`. That helps only while the process stays alive: the stray file is still created every time the settings are opened, and the next process start (reboot after unlock, low-memory kill, app update) still wipes the settings.

## Changes

1. **The migration runs once per process, from `EspeakApp.onCreate()`** (from #2541).
2. **The fragment's `PreferenceManager` uses device-protected storage**, set before any preference is attached. The custom preferences now persist through `getSharedPreferences()`, so a single place decides where settings live. The per-preference workarounds and the dead pre-Honeycomb branch are gone.
3. **The migration can no longer replace existing settings.** It runs only while the device-protected file is empty, which is the actual upgrade-from-2022 case, and writes an `espeak_preferences_migrated` marker afterwards so the file is never empty again. A credential-encrypted file that appears after that is discarded instead of copied over the settings, so a regression of this kind shows up as "this setting has no effect" rather than "everything was wiped". Because `TtsService` is direct-boot aware, the process can start before the user unlocks, while the credential-encrypted file is unreadable; the move is skipped then and re-run from an `ACTION_USER_UNLOCKED` receiver, which keeps the retry that master got from running the move on every service creation.
4. **`PreferenceStorageTest`** opens the settings screen with the engine bound, waits for the preferences to attach, and asserts that no credential-encrypted file appears; three more cases cover the migration (legacy adoption, the marker on a fresh install, and a stray file being discarded). `android/CLAUDE.md` documents the storage rule next to the steps for adding a preference.

## Testing

Reproduced on an API 34 emulator with the engine bound, the settings opened and closed, the service stopped and restarted in the same process, then the process killed and the service bound again:

| Build | Opening settings creates a CE file | Same-process restart | Process restart |
|---|---|---|---|
| master | yes | settings wiped | wiped |
| #2541 | yes | intact | wiped |
| this PR | no | intact | intact |

`PreferenceStorageTest` 4/4 and `VoiceSettingsTest` 15/15 pass on the same emulator.

## AI Usage Disclosure

> This change was developed with assistance from Claude (Anthropic). All code
> was reviewed and tested by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
